### PR TITLE
feat(reputation): add applyTemporalDecay() — sigma grows during agent inactivity

### DIFF
--- a/src/core/reputation-authority.ts
+++ b/src/core/reputation-authority.ts
@@ -37,6 +37,20 @@ export const INITIAL_SIGMA = MAX_SIGMA
 /** Points added to promotion threshold per demotion (cryptographic scarring) */
 export const SCARRING_PENALTY = 5
 
+// ── Temporal Decay ──
+
+/**
+ * Half-life for sigma recovery when an agent is inactive.
+ * After this many days without activity, sigma increases by half the remaining
+ * gap to MAX_SIGMA.  Concretely:
+ *
+ *   sigma_new = sigma + (MAX_SIGMA - sigma) * (1 - 0.5^(days / SIGMA_HALF_LIFE_DAYS))
+ *
+ * Default: 30 days half-life — a highly-active agent who goes quiet for
+ * a month should carry meaningfully more uncertainty.
+ */
+export const SIGMA_HALF_LIFE_DAYS = 30
+
 /** Default tier definitions with hysteresis */
 export const DEFAULT_TIERS: TierDefinition[] = [
   { tier: 0, name: 'recruit',    promoteAt: 0,  demoteAt: -1,  autonomyLevel: 1 as AutonomyLevel, maxDelegationDepth: 0, maxSpendPerAction: 0 },
@@ -585,5 +599,63 @@ export function updateReputationFromResult(
     sigma: Math.round(newSigma * 100) / 100,
     receiptCount: rep.receiptCount + 1,
     lastUpdatedAt: new Date().toISOString(),
+  }
+}
+
+// ── Temporal Sigma Decay ──
+
+/**
+ * Apply time-based uncertainty growth to a reputation state.
+ *
+ * Agents earn low sigma (high confidence) through a track record of
+ * successful actions.  But old evidence is less informative than recent
+ * evidence: a highly-trusted agent who has been inactive for months may
+ * have changed models, policies, or behaviour in ways the historical
+ * receipts cannot capture.
+ *
+ * This function implements exponential sigma recovery toward MAX_SIGMA:
+ *
+ *   gap   = MAX_SIGMA - sigma
+ *   decay = gap * (1 - 0.5^(inactiveDays / halfLifeDays))
+ *   sigma_new = sigma + decay
+ *
+ * Properties:
+ * - Idempotent: zero days of inactivity → no change.
+ * - Bounded: sigma never exceeds MAX_SIGMA.
+ * - Preserves mu: capability estimate is unchanged — only confidence drops.
+ * - Composable: call at query time by passing `now` minus `lastUpdatedAt`.
+ *
+ * Example (halfLife = 30 days):
+ *   sigma=5, inactive 30 days → sigma ≈ 15.0  (halfway to MAX_SIGMA=25)
+ *   sigma=5, inactive 60 days → sigma ≈ 20.0  (¾ of the way)
+ *   sigma=5, inactive 90 days → sigma ≈ 22.5  (⅞ of the way)
+ *
+ * @param rep          Current reputation state (read `lastUpdatedAt` from here).
+ * @param now          Current wall-clock time used to compute inactivity.
+ * @param halfLifeDays Days until sigma closes half the gap to MAX_SIGMA.
+ *                     Defaults to SIGMA_HALF_LIFE_DAYS (30 days).
+ * @returns            New reputation state with decayed sigma and updated
+ *                     `lastUpdatedAt` set to `now`.
+ */
+export function applyTemporalDecay(
+  rep: ScopedReputation,
+  now: Date = new Date(),
+  halfLifeDays: number = SIGMA_HALF_LIFE_DAYS
+): ScopedReputation {
+  const lastActive = new Date(rep.lastUpdatedAt)
+  const inactiveMs = now.getTime() - lastActive.getTime()
+
+  // Negative or zero gap → no change (clock skew / same-instant call)
+  if (inactiveMs <= 0) return rep
+
+  const inactiveDays = inactiveMs / (1000 * 60 * 60 * 24)
+  const gap = MAX_SIGMA - rep.sigma
+  const decay = gap * (1 - Math.pow(0.5, inactiveDays / halfLifeDays))
+  const newSigma = Math.min(MAX_SIGMA, rep.sigma + decay)
+
+  return {
+    ...rep,
+    sigma: Math.round(newSigma * 100) / 100,
+    lastUpdatedAt: now.toISOString(),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,9 @@ export {
   meetsPromotionRequirements,
   createPromotionReview, validatePromotionReview,
   triggerDemotion, checkTierForIntent, advisoryTierPrecheck,
-  updateReputationFromResult
+  updateReputationFromResult,
+  applyTemporalDecay,
+  SIGMA_HALF_LIFE_DAYS
 } from './core/reputation-authority.js'
 
 export type {

--- a/tests/reputation-authority.test.ts
+++ b/tests/reputation-authority.test.ts
@@ -6,7 +6,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  DEFAULT_K, MAX_SIGMA, INITIAL_MU, INITIAL_SIGMA, SCARRING_PENALTY,
+  DEFAULT_K, MAX_SIGMA, INITIAL_MU, INITIAL_SIGMA, SCARRING_PENALTY, SIGMA_HALF_LIFE_DAYS,
   DEFAULT_TIERS, DEFAULT_PROMOTION_REQUIREMENTS,
   computeEffectiveScore, createScopedReputation,
   classifyEvidence, resolveAuthorityTier, shouldDemote,
@@ -15,7 +15,7 @@ import {
   meetsPromotionRequirements,
   createPromotionReview, validatePromotionReview,
   triggerDemotion, checkTierForIntent, advisoryTierPrecheck,
-  updateReputationFromResult, generateKeyPair
+  updateReputationFromResult, applyTemporalDecay, generateKeyPair
 } from '../src/index.js'
 
 import type {
@@ -711,5 +711,122 @@ describe('updateReputationFromResult', () => {
     const score = computeEffectiveScore(rep.mu, rep.sigma)
     assert.ok(score > 0, `Effective score should be positive: ${score}`)
     assert.equal(rep.receiptCount, 20)
+  })
+})
+
+// ══════════════════════════════════════
+// 10. Temporal Sigma Decay
+// ══════════════════════════════════════
+
+describe('applyTemporalDecay', () => {
+  // Helper: create a rep with low sigma (agent has track record)
+  function lowSigmaRep(sigma: number = 5): ReturnType<typeof createScopedReputation> {
+    const rep = createScopedReputation('p', 'a', 's')
+    return { ...rep, sigma }
+  }
+
+  // Helper: date N days in the future
+  function daysLater(rep: ReturnType<typeof createScopedReputation>, days: number): Date {
+    return new Date(new Date(rep.lastUpdatedAt).getTime() + days * 24 * 60 * 60 * 1000)
+  }
+
+  it('no change when now === lastUpdatedAt', () => {
+    const rep = lowSigmaRep(5)
+    const result = applyTemporalDecay(rep, new Date(rep.lastUpdatedAt))
+    assert.equal(result.sigma, 5)
+  })
+
+  it('no change for zero or negative elapsed time (clock skew guard)', () => {
+    const rep = lowSigmaRep(5)
+    const past = new Date(new Date(rep.lastUpdatedAt).getTime() - 1000)
+    const result = applyTemporalDecay(rep, past)
+    assert.equal(result.sigma, 5)
+  })
+
+  it('sigma increases after inactivity', () => {
+    const rep = lowSigmaRep(5)
+    const result = applyTemporalDecay(rep, daysLater(rep, 30))
+    assert.ok(result.sigma > 5, `sigma should grow: ${result.sigma}`)
+  })
+
+  it('one half-life: sigma closes half the gap to MAX_SIGMA', () => {
+    const rep = lowSigmaRep(5) // gap = MAX_SIGMA(25) - 5 = 20
+    const result = applyTemporalDecay(rep, daysLater(rep, SIGMA_HALF_LIFE_DAYS))
+    // expected: 5 + 20 * (1 - 0.5^1) = 5 + 10 = 15
+    assert.ok(Math.abs(result.sigma - 15) < 0.05, `expected ≈15, got ${result.sigma}`)
+  })
+
+  it('two half-lives: sigma closes ¾ of the gap', () => {
+    const rep = lowSigmaRep(5) // gap = 20
+    const result = applyTemporalDecay(rep, daysLater(rep, SIGMA_HALF_LIFE_DAYS * 2))
+    // expected: 5 + 20 * (1 - 0.5^2) = 5 + 15 = 20
+    assert.ok(Math.abs(result.sigma - 20) < 0.05, `expected ≈20, got ${result.sigma}`)
+  })
+
+  it('sigma never exceeds MAX_SIGMA regardless of elapsed time', () => {
+    const rep = lowSigmaRep(5)
+    const result = applyTemporalDecay(rep, daysLater(rep, 3650)) // 10 years
+    assert.ok(result.sigma <= MAX_SIGMA, `sigma must not exceed MAX_SIGMA: ${result.sigma}`)
+  })
+
+  it('does not change mu (capability estimate preserved)', () => {
+    const rep = { ...lowSigmaRep(5), mu: 72 }
+    const result = applyTemporalDecay(rep, daysLater(rep, 60))
+    assert.equal(result.mu, 72)
+  })
+
+  it('does not change receiptCount', () => {
+    const rep = { ...lowSigmaRep(5), receiptCount: 42 }
+    const result = applyTemporalDecay(rep, daysLater(rep, 30))
+    assert.equal(result.receiptCount, 42)
+  })
+
+  it('updates lastUpdatedAt to now', () => {
+    const rep = lowSigmaRep(5)
+    const now = daysLater(rep, 30)
+    const result = applyTemporalDecay(rep, now)
+    assert.equal(result.lastUpdatedAt, now.toISOString())
+  })
+
+  it('idempotent at MAX_SIGMA (already maximally uncertain)', () => {
+    const rep = lowSigmaRep(MAX_SIGMA) // gap = 0
+    const result = applyTemporalDecay(rep, daysLater(rep, 30))
+    assert.equal(result.sigma, MAX_SIGMA)
+  })
+
+  it('custom half-life shortens decay period', () => {
+    const rep = lowSigmaRep(5)
+    const halfDaysCustom = 7
+    const result = applyTemporalDecay(rep, daysLater(rep, halfDaysCustom), halfDaysCustom)
+    // One half-life → should be ≈ 15 (halfway to 25)
+    assert.ok(Math.abs(result.sigma - 15) < 0.05, `expected ≈15 with 7d half-life, got ${result.sigma}`)
+  })
+
+  it('effective score decreases after inactivity (decay reduces confidence)', () => {
+    const rep = lowSigmaRep(5)
+    const before = computeEffectiveScore(rep.mu, rep.sigma)
+    const decayed = applyTemporalDecay(rep, daysLater(rep, 30))
+    const after = computeEffectiveScore(decayed.mu, decayed.sigma)
+    assert.ok(after < before, `effective score should drop: before=${before}, after=${after}`)
+  })
+
+  it('scenario: active agent retains tier, then goes quiet and sigma climbs', () => {
+    let rep = createScopedReputation('p', 'agent', 'code')
+
+    // Build track record: 40 standard successes
+    for (let i = 0; i < 40; i++) {
+      rep = updateReputationFromResult(rep, true, 'standard')
+    }
+    const afterActive = computeEffectiveScore(rep.mu, rep.sigma)
+    assert.ok(afterActive >= 30, `Should reach operator tier: score=${afterActive}`)
+
+    // Agent goes silent for 60 days
+    const future = new Date(new Date(rep.lastUpdatedAt).getTime() + 60 * 24 * 60 * 60 * 1000)
+    const decayed = applyTemporalDecay(rep, future)
+
+    // Sigma should have grown; effective score should be lower
+    assert.ok(decayed.sigma > rep.sigma, `Sigma should increase after 60d silence`)
+    const afterDecay = computeEffectiveScore(decayed.mu, decayed.sigma)
+    assert.ok(afterDecay < afterActive, `Score should drop after decay: ${afterDecay} vs ${afterActive}`)
   })
 })


### PR DESCRIPTION
## Summary

The Bayesian reputation model stores `(mu, sigma)` per `(principal, agent, scope)`. Agents earn low sigma through a track record of successful actions. But old evidence is less informative than recent evidence: an agent who has been inactive for weeks or months may have changed models, policies, or behaviour in ways the historical receipts cannot capture.

This PR adds **temporal sigma decay** — a function that increases sigma (uncertainty) as inactivity grows, using an exponential recovery formula toward `MAX_SIGMA`.

## API

```typescript
// New constant (exported)
SIGMA_HALF_LIFE_DAYS = 30  // days until sigma closes half the gap to MAX_SIGMA

// New function (exported)
applyTemporalDecay(
  rep: ScopedReputation,
  now?: Date,              // defaults to new Date()
  halfLifeDays?: number    // defaults to SIGMA_HALF_LIFE_DAYS
): ScopedReputation
```

## Formula

```
gap       = MAX_SIGMA - sigma
decay     = gap * (1 - 0.5^(inactiveDays / halfLifeDays))
sigma_new = sigma + decay
```

### Examples (half-life = 30 days, sigma=5, MAX_SIGMA=25)

| Inactive days | sigma_new | Interpretation |
|---|---|---|
| 0 | 5.0 | no change |
| 30 | 15.0 | half the gap closed |
| 60 | 20.0 | ¾ of the gap closed |
| 90 | 22.5 | ⅞ of the gap closed |
| ∞ | 25.0 | fully uncertain (never exceeds MAX_SIGMA) |

## Properties

- **Idempotent**: zero or negative elapsed time → no change (clock-skew guard)
- **Bounded**: sigma never exceeds `MAX_SIGMA`
- **Preserves mu**: capability estimate unchanged — only confidence drops
- **Composable**: designed to be called at query time, not stored automatically
- **Configurable**: custom `halfLifeDays` for tighter/looser decay

## Usage pattern

Call `applyTemporalDecay` when you evaluate a reputation state for tier resolution or promotion eligibility, passing the current wall-clock time:

```typescript
// Before computing effective score / resolving tier:
const repNow = applyTemporalDecay(storedRep)
const score  = computeEffectiveScore(repNow.mu, repNow.sigma)
const tier   = resolveAuthorityTier(score, agent.demotionCount)
```

The `lastUpdatedAt` on the returned value is set to `now` so you can store the decayed state if desired.

## Tests

13 new tests in `tests/reputation-authority.test.ts`:
- Zero / negative elapsed time → no change
- One half-life → sigma closes exactly halfway to MAX_SIGMA
- Two half-lives → sigma closes ¾ of the gap
- Extreme inactivity (10 years) → bounded at MAX_SIGMA
- mu and receiptCount unchanged
- lastUpdatedAt updated to `now`
- Custom half-life parameter works correctly
- Effective score decreases after decay (integration check)
- Full scenario: active agent builds tier, then goes quiet — score drops

Full suite: **879/879 pass** (13 added, 0 regressions).