### PR TITLE
integration: SINT Protocol — physical-world enforcement layer (9/9 cross-verify)

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -102,3 +102,32 @@ const valid = verifyDelegation(delegation, principal.publicKey)
 103 modules. 2,764 tests. 132 MCP tools. Apache-2.0.
 
 Build your thing on top. Don't rebuild what's underneath.
+
+### Physical-World Enforcement (SINT Protocol)
+You handle digital-world constraints. SINT handles physical-world enforcement.
+```typescript
+import { apsScopeToSintMapping, sintTokenToApsProjection } from '@sint/bridge-a2a'
+
+// APS delegation → SINT capability token (with physical constraints)
+const mapping = apsScopeToSintMapping(delegation.scope, delegation.spendLimit)
+// mapping.resource: "ros2:///cmd_vel" | "mcp://filesystem/writeFile" | ...
+// mapping.physicalConstraints: { maxVelocityMps, maxForceNewtons, geofence }
+// mapping.tierDelta: 0 | +1 (attestationGrade < 2 raises effective tier)
+
+// SINT capability token → APS attestation projection
+const projection = sintTokenToApsProjection(sintToken)
+// projection.attestationGrade: 2 (always — physical constraints imply strong verification)
+// projection.dataAccessTerms: { "sint:maxVelocityMps": 0.5, "sint:geofence": {...} }
+```
+
+**Cross-verified: 9/9 tests passing — zero code changes on either side.**
+
+```
+SINT keyToDid(pubkeyHex) === motebit publicKeyToDidKey(pubkeyBytes)  // did:key:z6Mk...
+SINT keyToDid(pubkeyHex) === APS toDIDKey(publicKey)                 // did:key:z6Mk...
+```
+
+The physical constraint layer is the dimension missing from all other integrations. Force limits, velocity caps, and geofence boundaries follow the same monotonic narrowing invariant as digital scope: they can tighten at each delegation hop, never loosen. An APS delegation with `spendLimit: 5000` delegating to a SINT robot token automatically constrains the robot to the narrowed physical envelope.
+
+See: [`packages/bridge-a2a/src/aps-mapping.ts`](https://github.com/sint-ai/sint-protocol/tree/main/packages/bridge-a2a/src/aps-mapping.ts) — 38 tests
+See: [`packages/capability-tokens/__tests__/aps-crossverify.test.ts`](https://github.com/sint-ai/sint-protocol/tree/main/packages/capability-tokens/__tests__/aps-crossverify.test.ts) — 9 tests


### PR DESCRIPTION
## What this does

Adds SINT Protocol as a documented integration option in `INTEGRATION.md` for APS deployments that need physical-world action enforcement.

## Where the two systems overlap — and where they don't

APS and SINT share the same identity primitive: Ed25519 public keys encoded as `did:key:z6Mk...` via `[0xed, 0x01]` multicodec prefix + base58btc. 9/9 cross-verification tests pass with zero code changes on either side — this is independently converged, not coordinated.

The integration stops there. **This PR does not propose that APS adopt SINT's capability token format or that SINT adopt APS's scope semantics.** The open question — whether scope semantics should be harmonized across the two delegation chains — is not resolved here. It's made visible.

The current gap: when an agent holds an APS credential and a SINT capability token, there are two delegation chains with no specified precedence. `apsScopeToSintMapping()` in this PR is a translation shim, not a resolution. If APS maintainers think the precedence question should be resolved at the spec level rather than left to implementers, that's the right next conversation.

## What was added

`INTEGRATION.md` — new section **"Physical-World Enforcement (SINT Protocol)"**:
- `apsScopeToSintMapping()` — translates APS permission strings to SINT resource URIs
- `sintTokenToApsProjection()` — projects SINT tokens back to APS scope representation
- Approval tier semantics (T0 auto-approve → T3 human sign-off)

## Verify the cross-verification claim

```bash
git clone https://github.com/sint-ai/sint-protocol
cd sint-protocol && pnpm install && pnpm run build
pnpm --filter @sint/gate-capability-tokens test -- --reporter=verbose
```

`aps-crossverify.test.ts` — 9 tests, 0 changes to either codebase.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)