### PR TITLE
feat: agent-governance-vocabulary canonical naming layer

### DIFF
--- a/vocabulary/README.md
+++ b/vocabulary/README.md
@@ -1,0 +1,69 @@
+# Agent Governance Vocabulary
+
+A canonical naming layer for agent governance primitives, inspired by [IANA JWT Claims](https://www.iana.org/assignments/jwt/jwt.xhtml) and [W3C DID Registries](https://www.w3.org/TR/did-spec-registries/).
+
+## What this is
+
+Six+ agent governance implementations use different names for the same concepts. This vocabulary provides:
+
+- **`vocabulary.yaml`** — Canonical term definitions organized by category (identity, delegation, enforcement, execution, governance, coordination, reputation, data)
+- **`crosswalk/`** — Per-implementation mapping files that connect canonical terms to each system's actual types and functions
+- **`context.jsonld`** — JSON-LD `@context` for programmatic resolution of canonical terms
+- **`examples/`** — Worked examples showing cross-system interoperability via the vocabulary
+
+## What this is NOT
+
+- Not a new specification
+- Not a renaming mandate
+- Not a replacement for any existing system's types
+
+It's a **mapping layer** — a Rosetta Stone that lets different governance systems understand each other's primitives.
+
+## How to use
+
+### Reading a crosswalk
+
+Each crosswalk file (e.g., `crosswalk/aps.yaml`) maps canonical terms to implementation-specific types:
+
+```yaml
+delegation:
+  type: Delegation
+  module: src/core/delegation.ts
+  functions: [createDelegation, verifyDelegation]
+  notes: "Scoped authority with monotonic narrowing and depth limits"
+```
+
+### Adding your system's crosswalk
+
+1. Copy `crosswalk/aps.yaml` as a template
+2. Replace each `type`, `module`, and `functions` with your system's equivalents
+3. Add `notes` for any semantic differences
+4. Submit a PR
+
+### Programmatic resolution
+
+Use `context.jsonld` with any JSON-LD processor to resolve canonical terms:
+
+```json
+{
+  "@context": "https://raw.githubusercontent.com/aeoess/agent-passport-system/main/vocabulary/context.jsonld",
+  "delegation": { "scope": ["commerce/*"], "depth": 2 }
+}
+```
+
+## Categories
+
+| Category | Terms | Description |
+|----------|-------|-------------|
+| **Identity** | agent-identity, principal, key-rotation, endorsement | Who agents are and who vouches for them |
+| **Delegation** | delegation, scope, authority-narrowing, revocation, cascade-revocation | How authority is transferred and constrained |
+| **Enforcement** | policy, enforcement-mode, values-floor | Rules governing agent behavior |
+| **Execution** | action-receipt, execution-envelope, attestation | Proof of actions taken |
+| **Governance** | governance-artifact, governance-change-type, approval, charter | How governance itself is managed |
+| **Coordination** | task, intent, deliberation | How agents collaborate |
+| **Reputation** | trust-score, reputation-authority | How trust is quantified |
+| **Data** | derivation-rights, data-lifecycle | How data is governed |
+
+## Contributing
+
+Each governance system is invited to contribute its own crosswalk file. See `crosswalk/aps.yaml` for the format.

--- a/vocabulary/context.jsonld
+++ b/vocabulary/context.jsonld
@@ -1,0 +1,41 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "agov": "https://w3id.org/agent-governance-vocabulary#",
+    "aps": "https://github.com/aeoess/agent-passport-system/vocabulary#",
+
+    "agent-identity": "agov:agent-identity",
+    "principal": "agov:principal",
+    "key-rotation": "agov:key-rotation",
+    "endorsement": "agov:endorsement",
+
+    "delegation": "agov:delegation",
+    "scope": "agov:scope",
+    "authority-narrowing": "agov:authority-narrowing",
+    "revocation": "agov:revocation",
+    "cascade-revocation": "agov:cascade-revocation",
+
+    "policy": "agov:policy",
+    "enforcement-mode": "agov:enforcement-mode",
+    "values-floor": "agov:values-floor",
+
+    "action-receipt": "agov:action-receipt",
+    "execution-envelope": "agov:execution-envelope",
+    "attestation": "agov:attestation",
+
+    "governance-artifact": "agov:governance-artifact",
+    "governance-change-type": "agov:governance-change-type",
+    "approval": "agov:approval",
+    "charter": "agov:charter",
+
+    "task": "agov:task",
+    "intent": "agov:intent",
+    "deliberation": "agov:deliberation",
+
+    "trust-score": "agov:trust-score",
+    "reputation-authority": "agov:reputation-authority",
+
+    "derivation-rights": "agov:derivation-rights",
+    "data-lifecycle": "agov:data-lifecycle"
+  }
+}

--- a/vocabulary/crosswalk/aps.yaml
+++ b/vocabulary/crosswalk/aps.yaml
@@ -1,0 +1,161 @@
+# Crosswalk: Agent Passport System (APS) → Canonical Vocabulary
+# Maps APS-specific type and function names to canonical governance terms.
+
+system:
+  name: Agent Passport System
+  version: ">=1.41.0"
+  repository: https://github.com/aeoess/agent-passport-system
+  spec-references:
+    - docs/governance/agent-charter.md
+    - docs/governance/restraint-spec.md
+    - docs/governance/deliberation-framework.md
+
+mappings:
+
+  # Identity
+  agent-identity:
+    type: AgentPassport
+    module: src/types/passport.ts
+    functions: [createPassport, verifyPassport]
+    notes: "Passport grades 0-3 based on attestation evidence"
+
+  principal:
+    type: Principal
+    module: src/types/principal.ts
+    functions: [createPrincipal, endorseAgent]
+    notes: "Human/org entity; agents cannot exist without a principal"
+
+  key-rotation:
+    type: RotationLog
+    module: src/core/identity.ts
+    functions: [rotateKey]
+    notes: "Dual-signed rotation: old key authorizes, new key activates"
+
+  endorsement:
+    type: PrincipalEndorsement
+    module: src/core/principal.ts
+    functions: [endorseAgent, verifyEndorsement]
+
+  # Delegation
+  delegation:
+    type: Delegation
+    module: src/core/delegation.ts
+    functions: [createDelegation, verifyDelegation]
+    notes: "Scoped authority with monotonic narrowing and depth limits"
+
+  scope:
+    type: "string[]"
+    module: src/types/passport.ts
+    notes: "Hierarchical/glob scope arrays on delegations"
+
+  authority-narrowing:
+    type: MonotonicNarrowingResult
+    module: src/core/delegation.ts
+    functions: [verifyMonotonicNarrowing]
+    notes: "Sub-delegation cannot grant more than parent holds"
+
+  revocation:
+    type: RevocationRecord
+    module: src/core/delegation.ts
+    functions: [revokeDelegation]
+
+  cascade-revocation:
+    type: CascadeRevocationResult
+    module: src/core/delegation.ts
+    functions: [cascadeRevoke, getDescendants]
+
+  # Policy & Enforcement
+  policy:
+    type: PolicyDefinition
+    module: src/types/policy.ts
+    functions: [evaluatePolicy]
+
+  enforcement-mode:
+    type: EnforcementMode
+    module: src/types/policy.ts
+    values: ["inline", "audit", "warn"]
+    notes: "inline=blocking, audit=logging, warn=advisory"
+
+  values-floor:
+    type: ValuesFloor
+    module: src/core/values.ts
+    functions: [checkValuesCompliance]
+
+  # Execution & Attestation
+  action-receipt:
+    type: ActionReceipt
+    module: src/types/execution-attestation.ts
+    functions: [createActionReceipt]
+
+  execution-envelope:
+    type: ExecutionEnvelope
+    module: src/types/execution-envelope.ts
+    functions: [createExecutionEnvelope, verifyEnvelope]
+    notes: "3-signature chain: intent → policy gate → receipt"
+
+  attestation:
+    type: Attestation
+    module: src/types/attestation.ts
+    functions: [createAttestation, verifyAttestation]
+
+  # Governance
+  governance-artifact:
+    type: GovernanceArtifact
+    module: src/types/governance.ts
+    functions: [createGovernanceArtifact, verifyGovernanceArtifact]
+
+  governance-change-type:
+    type: GovernanceChangeType
+    module: src/types/governance.ts
+    values: ["strengthening", "neutral", "weakening", "mixed", "initial"]
+
+  approval:
+    type: GovernanceApproval
+    module: src/types/governance.ts
+    functions: [approveGovernanceChange]
+
+  charter:
+    type: Charter
+    module: src/core/charter.ts
+    functions: [createCharter]
+
+  # Coordination
+  task:
+    type: Task
+    module: src/core/coordination.ts
+    functions: [createTask, advanceTaskState]
+    notes: "9-state lifecycle machine"
+
+  intent:
+    type: IntentCard
+    module: src/core/intent-network.ts
+    functions: [createIntentCard, evaluateIntent]
+    notes: "Double-opt-in before collaboration"
+
+  deliberation:
+    type: DeliberationSession
+    module: src/core/coordination.ts
+    functions: [initiateDeliberation]
+
+  # Reputation
+  trust-score:
+    type: TrustScore
+    module: src/core/reputation-authority.ts
+    functions: [computeTrustScore]
+    notes: "Bayesian trust scoring across tiers"
+
+  reputation-authority:
+    type: ReputationAuthority
+    module: src/core/reputation-authority.ts
+    functions: [createReputationAuthority, resolveAuthorityTier]
+
+  # Data Governance
+  derivation-rights:
+    type: DerivationRights
+    module: src/types/data-lifecycle.ts
+    notes: "Who can train on outputs, copy, distribute"
+
+  data-lifecycle:
+    type: DataLifecyclePolicy
+    module: src/types/data-lifecycle.ts
+    functions: [enforceDataLifecycle]

--- a/vocabulary/examples/cross-system-validate-capabilities.yaml
+++ b/vocabulary/examples/cross-system-validate-capabilities.yaml
@@ -1,0 +1,48 @@
+# Worked Example: Cross-System Capability Validation
+#
+# Scenario: System B receives a delegation from System A (which uses APS)
+# and needs to verify the agent's capabilities using canonical vocabulary.
+
+steps:
+  - name: "Receive delegation from APS-based system"
+    canonical-term: delegation
+    aps-mapping:
+      type: Delegation
+      function: verifyDelegation
+    description: >
+      System B receives a delegation object. Using the crosswalk, it maps
+      the APS `Delegation` type to the canonical `delegation` term.
+
+  - name: "Check scope coverage"
+    canonical-term: scope
+    aps-mapping:
+      type: "string[]"
+      notes: "Hierarchical glob patterns like 'commerce/*'"
+    description: >
+      System B reads the delegation's scope array. The canonical `scope`
+      term tells it this represents bounded permissions. System B maps
+      these to its own permission model.
+
+  - name: "Verify authority narrowing"
+    canonical-term: authority-narrowing
+    aps-mapping:
+      type: MonotonicNarrowingResult
+      function: verifyMonotonicNarrowing
+    description: >
+      System B confirms the delegation doesn't exceed its parent's authority.
+      The canonical term `authority-narrowing` maps to APS's monotonic
+      narrowing verification.
+
+  - name: "Check trust score"
+    canonical-term: trust-score
+    aps-mapping:
+      type: TrustScore
+      function: computeTrustScore
+    description: >
+      System B queries the agent's trust score. The canonical `trust-score`
+      maps to APS's Bayesian trust scoring via `ReputationAuthority`.
+
+result: >
+  System B successfully validated the agent's capabilities using canonical
+  vocabulary terms, without needing to understand APS-specific type names
+  or function signatures directly.

--- a/vocabulary/examples/cross-system-verify-attestation.yaml
+++ b/vocabulary/examples/cross-system-verify-attestation.yaml
@@ -1,0 +1,57 @@
+# Worked Example: Cross-System Attestation Verification
+#
+# Scenario: An auditor system needs to verify an execution record
+# produced by an APS-governed agent.
+
+steps:
+  - name: "Receive execution envelope"
+    canonical-term: execution-envelope
+    aps-mapping:
+      type: ExecutionEnvelope
+      function: verifyEnvelope
+    description: >
+      The auditor receives a wrapped action. The canonical `execution-envelope`
+      term tells it this contains intent, authorization, and receipt — the
+      3-signature chain pattern.
+
+  - name: "Extract action receipt"
+    canonical-term: action-receipt
+    aps-mapping:
+      type: ActionReceipt
+      function: createActionReceipt
+    description: >
+      The auditor extracts the signed action receipt. The canonical
+      `action-receipt` maps to APS's `ActionReceipt` type.
+
+  - name: "Verify attestation"
+    canonical-term: attestation
+    aps-mapping:
+      type: Attestation
+      function: verifyAttestation
+    description: >
+      The auditor verifies the cryptographic proof. The canonical
+      `attestation` term maps to APS's attestation verification.
+
+  - name: "Check governance compliance"
+    canonical-term: governance-change-type
+    aps-mapping:
+      type: GovernanceChangeType
+      values: [strengthening, neutral, weakening, mixed, initial]
+    description: >
+      The auditor classifies what kind of governance change this action
+      represents. The canonical `governance-change-type` maps directly
+      to APS's classification enum.
+
+  - name: "Verify principal endorsement"
+    canonical-term: endorsement
+    aps-mapping:
+      type: PrincipalEndorsement
+      function: verifyEndorsement
+    description: >
+      The auditor traces the action back to a human/org principal.
+      The canonical `endorsement` maps to APS's principal endorsement chain.
+
+result: >
+  The auditor verified the entire execution chain — from principal endorsement
+  through governance compliance to action receipt — using only canonical
+  vocabulary terms and the APS crosswalk file.

--- a/vocabulary/vocabulary.yaml
+++ b/vocabulary/vocabulary.yaml
@@ -1,0 +1,158 @@
+# Agent Governance Vocabulary — Canonical Terms
+# Modeled after IANA JWT Claims Registry and W3C DID Registries
+# Version: 0.1.0
+
+metadata:
+  title: Agent Governance Vocabulary
+  version: 0.1.0
+  status: draft
+  maintainer: agent-passport-system contributors
+  license: Apache-2.0
+  description: >
+    A shared vocabulary mapping governance primitives across agent governance
+    implementations. Not a new spec or renaming mandate — just a mapping layer.
+
+# Each canonical term maps a governance primitive to its definition.
+# Implementations provide their own crosswalk files in crosswalk/.
+
+terms:
+
+  # --- Identity ---
+  agent-identity:
+    definition: Persistent cryptographic identity of an autonomous agent
+    category: identity
+    related: [principal, key-rotation]
+
+  principal:
+    definition: Human or organizational entity that endorses an agent into existence
+    category: identity
+    related: [agent-identity, endorsement]
+
+  key-rotation:
+    definition: Process of replacing an agent's signing key while preserving identity continuity
+    category: identity
+    related: [agent-identity]
+
+  endorsement:
+    definition: Cryptographic attestation by a principal vouching for an agent
+    category: identity
+    related: [principal, attestation]
+
+  # --- Delegation ---
+  delegation:
+    definition: Scoped transfer of authority from one entity to another
+    category: delegation
+    related: [scope, authority-narrowing, revocation]
+
+  scope:
+    definition: Bounded set of permissions or capabilities granted in a delegation
+    category: delegation
+    related: [delegation]
+
+  authority-narrowing:
+    definition: Constraint that sub-delegations cannot exceed parent delegation authority
+    category: delegation
+    related: [delegation, scope]
+
+  revocation:
+    definition: Withdrawal of a previously granted delegation
+    category: delegation
+    related: [delegation, cascade-revocation]
+
+  cascade-revocation:
+    definition: Transitive revocation of all descendant delegations when a parent is revoked
+    category: delegation
+    related: [revocation, delegation]
+
+  # --- Policy & Enforcement ---
+  policy:
+    definition: Declarative rule governing what actions an agent may or must perform
+    category: enforcement
+    related: [enforcement-mode, values-floor]
+
+  enforcement-mode:
+    definition: How policy violations are handled (blocking, logging, or advisory)
+    category: enforcement
+    related: [policy]
+    typical-values: [inline, audit, warn]
+
+  values-floor:
+    definition: Minimum set of human values constraints that bound agent behavior
+    category: enforcement
+    related: [policy]
+
+  # --- Execution & Attestation ---
+  action-receipt:
+    definition: Signed record of an action taken by an agent
+    category: execution
+    related: [execution-envelope, attestation]
+
+  execution-envelope:
+    definition: Container wrapping an agent action with intent, authorization, and receipt
+    category: execution
+    related: [action-receipt]
+
+  attestation:
+    definition: Cryptographic proof of a claim about an agent or its actions
+    category: execution
+    related: [action-receipt, endorsement]
+
+  # --- Governance ---
+  governance-artifact:
+    definition: Signed, versioned governance document (policies, charters, configurations)
+    category: governance
+    related: [governance-change-type, approval]
+
+  governance-change-type:
+    definition: Classification of governance updates by their effect on constraints
+    category: governance
+    related: [governance-artifact]
+    typical-values: [strengthening, neutral, weakening, mixed, initial]
+
+  approval:
+    definition: Multi-party authorization for governance changes
+    category: governance
+    related: [governance-artifact, principal]
+
+  charter:
+    definition: Institutional identity document defining roles, offices, and federation rules
+    category: governance
+    related: [governance-artifact, principal]
+
+  # --- Coordination ---
+  task:
+    definition: Unit of work with a defined lifecycle and role-bound review
+    category: coordination
+    related: [intent, deliberation]
+
+  intent:
+    definition: Declared capability or need published by an agent for collaboration matching
+    category: coordination
+    related: [task]
+
+  deliberation:
+    definition: Structured disagreement resolution process between agents
+    category: coordination
+    related: [task, coordination]
+
+  # --- Reputation ---
+  trust-score:
+    definition: Quantitative measure of an agent's trustworthiness in a given scope
+    category: reputation
+    related: [reputation-authority]
+
+  reputation-authority:
+    definition: Entity that computes and maintains trust scores for agents
+    category: reputation
+    related: [trust-score, scope]
+
+  # --- Data Governance ---
+  derivation-rights:
+    definition: Permissions governing who can train on, copy, or distribute agent outputs
+    category: data
+    related: [data-lifecycle]
+
+  data-lifecycle:
+    definition: Governed stages of data from creation through access, consent, and deletion
+    category: data
+    related: [derivation-rights]


### PR DESCRIPTION
Implements the vocabulary proposal — a canonical naming layer mapping governance primitives across different agent governance systems, modeled after IANA JWT Claims and W3C DID Registries.

Includes the vocabulary definition (25 terms across 8 categories), an APS crosswalk mapping each term to actual types/functions in this repo, a JSON-LD context for programmatic resolution, and two worked examples showing cross-system interop.

Not a new spec or renaming mandate — just a mapping layer so different systems can understand each other's primitives.

Closes #13