### PR TITLE
Add budget_reservation claim_type verifier acceptance; fix pre-existing sync/async asymmetry for rail.payment.v1 literals

### DIFF
--- a/src/v2/payment-rails/hooks.ts
+++ b/src/v2/payment-rails/hooks.ts
@@ -53,6 +53,15 @@ const LEGACY_PAYMENT_RECEIPT_CLAIM_TYPE = 'aps:payment_receipt:v1' as const
 const RAIL_PAYMENT_DENIAL_CLAIM_TYPE = 'rail.payment.denial.v1' as const
 const LEGACY_PAYMENT_DENIAL_CLAIM_TYPE = 'aps:payment_denial:v1' as const
 
+// budget_reservation namespace (vocab #91, SDK #25). Three lifecycle
+// literals confirmed by Cycles (amavashev) and goodmeta (Ectsang).
+// Verifier-side acceptance only — no emit path change in this commit.
+// permit + release ride the receipt-verify path; denial rides the
+// denial-verify path.
+const RAIL_BUDGET_RESERVATION_PERMIT_CLAIM_TYPE = 'rail.budget_reservation.permit.v1' as const
+const RAIL_BUDGET_RESERVATION_RELEASE_CLAIM_TYPE = 'rail.budget_reservation.release.v1' as const
+const RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE = 'rail.budget_reservation.denial.v1' as const
+
 /** Default scope_of_claim for foundation receipts. Override via
  *  EmitReceiptInput.scope_of_claim when caller has a richer assertion. */
 function defaultPaymentReceiptScope(): ScopeOfClaim {
@@ -463,9 +472,14 @@ export interface VerifyReceiptOptions {
  */
 export function verifyPaymentReceipt(receipt: PaymentReceipt): ReceiptVerifyResult {
   // Phase 4.1 / Q1: accept both legacy and accountability-aligned literals.
+  // Vocab #91 / SDK #25: also accept the two budget_reservation receipt
+  // literals (permit, release). The denial literal is handled in
+  // verifyPaymentDenial; this path is receipt-only.
   if (
     receipt.claim_type !== LEGACY_PAYMENT_RECEIPT_CLAIM_TYPE &&
-    receipt.claim_type !== RAIL_PAYMENT_RECEIPT_CLAIM_TYPE
+    receipt.claim_type !== RAIL_PAYMENT_RECEIPT_CLAIM_TYPE &&
+    receipt.claim_type !== RAIL_BUDGET_RESERVATION_PERMIT_CLAIM_TYPE &&
+    receipt.claim_type !== RAIL_BUDGET_RESERVATION_RELEASE_CLAIM_TYPE
   ) {
     return { valid: false, reason: 'INVALID_CLAIM_TYPE' }
   }
@@ -514,7 +528,17 @@ export async function verifyPaymentReceiptWithDID(
   receipt: PaymentReceipt,
   options: VerifyReceiptOptions = {},
 ): Promise<ReceiptVerifyResult> {
-  if (receipt.claim_type !== 'aps:payment_receipt:v1') {
+  // Vocab #91 / SDK #25: accepted-literal set is harmonized with the
+  // sync verifyPaymentReceipt path — legacy + rail.payment.v1 + the two
+  // budget_reservation receipt literals (permit, release). Closes the
+  // pre-existing sync/async asymmetry where this path previously only
+  // accepted the legacy literal.
+  if (
+    receipt.claim_type !== LEGACY_PAYMENT_RECEIPT_CLAIM_TYPE &&
+    receipt.claim_type !== RAIL_PAYMENT_RECEIPT_CLAIM_TYPE &&
+    receipt.claim_type !== RAIL_BUDGET_RESERVATION_PERMIT_CLAIM_TYPE &&
+    receipt.claim_type !== RAIL_BUDGET_RESERVATION_RELEASE_CLAIM_TYPE
+  ) {
     return { valid: false, reason: 'INVALID_CLAIM_TYPE' }
   }
   const expectedId = sha256Hex(canonicalizeReceiptForId(receipt))
@@ -585,9 +609,13 @@ export interface DenialVerifyResult {
 }
 
 export function verifyPaymentDenial(denial: PaymentDenial): DenialVerifyResult {
+  // Vocab #91 / SDK #25: also accept the budget_reservation denial
+  // literal. The permit and release receipt literals belong on the
+  // receipt-verify path.
   if (
     denial.claim_type !== LEGACY_PAYMENT_DENIAL_CLAIM_TYPE &&
-    denial.claim_type !== RAIL_PAYMENT_DENIAL_CLAIM_TYPE
+    denial.claim_type !== RAIL_PAYMENT_DENIAL_CLAIM_TYPE &&
+    denial.claim_type !== RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE
   ) {
     return { valid: false, reason: 'INVALID_CLAIM_TYPE' }
   }
@@ -623,7 +651,16 @@ export async function verifyPaymentDenialWithDID(
   denial: PaymentDenial,
   options: VerifyReceiptOptions = {},
 ): Promise<DenialVerifyResult> {
-  if (denial.claim_type !== 'aps:payment_denial:v1') {
+  // Vocab #91 / SDK #25: accepted-literal set is harmonized with the
+  // sync verifyPaymentDenial path — legacy + rail.payment.denial.v1 +
+  // the budget_reservation denial literal. Closes the pre-existing
+  // sync/async asymmetry where this path previously only accepted the
+  // legacy literal.
+  if (
+    denial.claim_type !== LEGACY_PAYMENT_DENIAL_CLAIM_TYPE &&
+    denial.claim_type !== RAIL_PAYMENT_DENIAL_CLAIM_TYPE &&
+    denial.claim_type !== RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE
+  ) {
     return { valid: false, reason: 'INVALID_CLAIM_TYPE' }
   }
   if (!VALID_DENIAL_REASONS.includes(denial.denial_reason)) {

--- a/src/v2/payment-rails/types.ts
+++ b/src/v2/payment-rails/types.ts
@@ -90,8 +90,16 @@ export interface PaymentInvoice {
  * no scope_of_claim) continue to verify under the existing path.
  */
 export interface PaymentReceipt {
-  /** Legacy literal `'aps:payment_receipt:v1'` OR new accountability-aligned
-   *  `'rail.payment.v1'`. Verifier accepts both. */
+  /** Accepted literals (verifier-side, superset over time):
+   *    - Legacy:                   `'aps:payment_receipt:v1'`
+   *    - Phase 4.1 / Q1 rail:      `'rail.payment.v1'`
+   *    - Vocab #91 / SDK #25 budget_reservation lifecycle:
+   *      `'rail.budget_reservation.permit.v1'`
+   *      `'rail.budget_reservation.release.v1'`
+   *  The default emit path still produces `'rail.payment.v1'` (or legacy
+   *  on the legacy emit path); the additional literals are receiver-side
+   *  acceptance for receipts issued by Cycles / goodmeta and any other
+   *  rail that adopts the budget_reservation namespace. */
   claim_type: string
   /** sha256 hex of canonical(receipt without signature). Content-addressed. */
   receipt_id: string
@@ -135,8 +143,15 @@ export interface PaymentReceipt {
 }
 
 export interface PaymentDenial {
-  /** Legacy literal `'aps:payment_denial:v1'` OR new accountability-aligned
-   *  `'rail.payment.denial.v1'`. Verifier accepts both. */
+  /** Accepted literals (verifier-side, superset over time):
+   *    - Legacy:                   `'aps:payment_denial:v1'`
+   *    - Phase 4.1 / Q1 rail:      `'rail.payment.denial.v1'`
+   *    - Vocab #91 / SDK #25 budget_reservation:
+   *      `'rail.budget_reservation.denial.v1'`
+   *  The default emit path still produces `'rail.payment.denial.v1'` (or
+   *  legacy on the legacy emit path); the additional literal is
+   *  receiver-side acceptance for denials issued by Cycles / goodmeta and
+   *  any other rail that adopts the budget_reservation namespace. */
   claim_type: string
   /** sha256 hex of canonical(denial without signature). */
   receipt_id: string

--- a/tests/v2/payment-rails/governance.test.ts
+++ b/tests/v2/payment-rails/governance.test.ts
@@ -8,13 +8,20 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import {
+  canonicalizeDenialForId,
+  canonicalizeDenialForSig,
+  canonicalizeReceiptForId,
+  canonicalizeReceiptForSig,
   createDefaultGovernanceHooks,
   createNanoRail,
   emitDenial,
   emitReceipt,
+  paymentRailsSha256Hex,
   preAuthorize,
   verifyPaymentDenial,
+  verifyPaymentDenialWithDID,
   verifyPaymentReceipt,
+  verifyPaymentReceiptWithDID,
   xnoToRaw,
 } from '../../../src/v2/payment-rails/index.js'
 import type {
@@ -22,7 +29,7 @@ import type {
   PaymentDenial,
   PaymentReceipt,
 } from '../../../src/v2/payment-rails/index.js'
-import { generateKeyPair, publicKeyFromPrivate } from '../../../src/crypto/keys.js'
+import { generateKeyPair, publicKeyFromPrivate, sign } from '../../../src/crypto/keys.js'
 import {
   recordOwnerConfirmation,
   requestOwnerConfirmation,
@@ -655,5 +662,179 @@ describe('Phase 4.1 / Q1 — foundation accountability shape', () => {
     )
     assert.deepEqual(r.scope_of_claim, custom)
     assert.equal(r.claim_type, 'rail.payment.v1')
+  })
+})
+
+// ── Vocab #91 / SDK #25 — budget_reservation literal acceptance ───
+// Positive-case coverage for the three claim_type literals added by
+// PR #27 across the four verifier entry points. Each test mints a
+// legacy-shape receipt/denial via the existing emit path, rebrands
+// claim_type to the budget_reservation literal, and recomputes
+// receipt_id + signature with the same canonicalize/sha256/sign
+// helpers the emit path uses. No new fixture shape; the DID-aware
+// verifiers exercise their raw-hex branch (same pattern as the
+// P12 "legacy raw-hex" case in did-uri-signing.test.ts).
+
+describe('verifier — rail.budget_reservation claim_type acceptance', () => {
+  it('verifyPaymentReceipt accepts rail.budget_reservation.permit.v1', () => {
+    const base = emitReceipt(
+      {
+        delegation_ref: 'd'.repeat(64),
+        action_ref: 'a'.repeat(64),
+        rail_name: 'nano',
+        amount_base_units: xnoToRaw('0.001'),
+        currency: 'XNO',
+        tx_proof: 'b'.repeat(64),
+        issued_at: FIXED_TS,
+      },
+      ISSUER_PRIV,
+    )
+    const draft: PaymentReceipt = {
+      ...base,
+      claim_type: 'rail.budget_reservation.permit.v1',
+      receipt_id: '',
+      signature: '',
+    }
+    const receipt_id = paymentRailsSha256Hex(canonicalizeReceiptForId(draft))
+    const withId: PaymentReceipt = { ...draft, receipt_id }
+    const signature = sign(canonicalizeReceiptForSig(withId), ISSUER_PRIV)
+    const r: PaymentReceipt = { ...withId, signature }
+    assert.equal(r.claim_type, 'rail.budget_reservation.permit.v1')
+    assert.equal(verifyPaymentReceipt(r).valid, true)
+  })
+
+  it('verifyPaymentReceipt accepts rail.budget_reservation.release.v1', () => {
+    const base = emitReceipt(
+      {
+        delegation_ref: 'd'.repeat(64),
+        action_ref: 'a'.repeat(64),
+        rail_name: 'nano',
+        amount_base_units: xnoToRaw('0.001'),
+        currency: 'XNO',
+        tx_proof: 'b'.repeat(64),
+        issued_at: FIXED_TS,
+      },
+      ISSUER_PRIV,
+    )
+    const draft: PaymentReceipt = {
+      ...base,
+      claim_type: 'rail.budget_reservation.release.v1',
+      receipt_id: '',
+      signature: '',
+    }
+    const receipt_id = paymentRailsSha256Hex(canonicalizeReceiptForId(draft))
+    const withId: PaymentReceipt = { ...draft, receipt_id }
+    const signature = sign(canonicalizeReceiptForSig(withId), ISSUER_PRIV)
+    const r: PaymentReceipt = { ...withId, signature }
+    assert.equal(r.claim_type, 'rail.budget_reservation.release.v1')
+    assert.equal(verifyPaymentReceipt(r).valid, true)
+  })
+
+  it('verifyPaymentReceiptWithDID accepts rail.budget_reservation.permit.v1', async () => {
+    const base = emitReceipt(
+      {
+        delegation_ref: 'd'.repeat(64),
+        action_ref: 'a'.repeat(64),
+        rail_name: 'nano',
+        amount_base_units: xnoToRaw('0.001'),
+        currency: 'XNO',
+        tx_proof: 'b'.repeat(64),
+        issued_at: FIXED_TS,
+      },
+      ISSUER_PRIV,
+    )
+    const draft: PaymentReceipt = {
+      ...base,
+      claim_type: 'rail.budget_reservation.permit.v1',
+      receipt_id: '',
+      signature: '',
+    }
+    const receipt_id = paymentRailsSha256Hex(canonicalizeReceiptForId(draft))
+    const withId: PaymentReceipt = { ...draft, receipt_id }
+    const signature = sign(canonicalizeReceiptForSig(withId), ISSUER_PRIV)
+    const r: PaymentReceipt = { ...withId, signature }
+    const v = await verifyPaymentReceiptWithDID(r)
+    assert.equal(v.valid, true, `expected valid, got ${v.reason}`)
+  })
+
+  it('verifyPaymentReceiptWithDID accepts rail.budget_reservation.release.v1', async () => {
+    const base = emitReceipt(
+      {
+        delegation_ref: 'd'.repeat(64),
+        action_ref: 'a'.repeat(64),
+        rail_name: 'nano',
+        amount_base_units: xnoToRaw('0.001'),
+        currency: 'XNO',
+        tx_proof: 'b'.repeat(64),
+        issued_at: FIXED_TS,
+      },
+      ISSUER_PRIV,
+    )
+    const draft: PaymentReceipt = {
+      ...base,
+      claim_type: 'rail.budget_reservation.release.v1',
+      receipt_id: '',
+      signature: '',
+    }
+    const receipt_id = paymentRailsSha256Hex(canonicalizeReceiptForId(draft))
+    const withId: PaymentReceipt = { ...draft, receipt_id }
+    const signature = sign(canonicalizeReceiptForSig(withId), ISSUER_PRIV)
+    const r: PaymentReceipt = { ...withId, signature }
+    const v = await verifyPaymentReceiptWithDID(r)
+    assert.equal(v.valid, true, `expected valid, got ${v.reason}`)
+  })
+
+  it('verifyPaymentDenial accepts rail.budget_reservation.denial.v1', () => {
+    const base = emitDenial(
+      {
+        delegation_ref: 'd'.repeat(64),
+        action_ref: 'a'.repeat(64),
+        rail_name: 'nano',
+        amount_base_units: xnoToRaw('0.001'),
+        currency: 'XNO',
+        denial_reason: 'no_commerce_scope',
+        issued_at: FIXED_TS,
+      },
+      ISSUER_PRIV,
+    )
+    const draft: PaymentDenial = {
+      ...base,
+      claim_type: 'rail.budget_reservation.denial.v1',
+      receipt_id: '',
+      signature: '',
+    }
+    const receipt_id = paymentRailsSha256Hex(canonicalizeDenialForId(draft))
+    const withId: PaymentDenial = { ...draft, receipt_id }
+    const signature = sign(canonicalizeDenialForSig(withId), ISSUER_PRIV)
+    const d: PaymentDenial = { ...withId, signature }
+    assert.equal(d.claim_type, 'rail.budget_reservation.denial.v1')
+    assert.equal(verifyPaymentDenial(d).valid, true)
+  })
+
+  it('verifyPaymentDenialWithDID accepts rail.budget_reservation.denial.v1', async () => {
+    const base = emitDenial(
+      {
+        delegation_ref: 'd'.repeat(64),
+        action_ref: 'a'.repeat(64),
+        rail_name: 'nano',
+        amount_base_units: xnoToRaw('0.001'),
+        currency: 'XNO',
+        denial_reason: 'no_commerce_scope',
+        issued_at: FIXED_TS,
+      },
+      ISSUER_PRIV,
+    )
+    const draft: PaymentDenial = {
+      ...base,
+      claim_type: 'rail.budget_reservation.denial.v1',
+      receipt_id: '',
+      signature: '',
+    }
+    const receipt_id = paymentRailsSha256Hex(canonicalizeDenialForId(draft))
+    const withId: PaymentDenial = { ...draft, receipt_id }
+    const signature = sign(canonicalizeDenialForSig(withId), ISSUER_PRIV)
+    const d: PaymentDenial = { ...withId, signature }
+    const v = await verifyPaymentDenialWithDID(d)
+    assert.equal(v.valid, true, `expected valid, got ${v.reason}`)
   })
 })


### PR DESCRIPTION
## Summary

Adds the three `rail.budget_reservation` lifecycle literals to the payment-rails verifier accepted set, closing the live commitment from #25 (the `budget_reservation` claim_type namespace, confirmed direction with @amavashev and @Ectsang). The vocabulary side already merged as aeoess/agent-governance-vocabulary#91.

## What changed

**Verifier acceptance (the in-scope ask)** — `src/v2/payment-rails/hooks.ts`:
- `verifyPaymentReceipt` and `verifyPaymentReceiptWithDID` now accept `rail.budget_reservation.permit.v1` and `rail.budget_reservation.release.v1`
- `verifyPaymentDenial` and `verifyPaymentDenialWithDID` now accept `rail.budget_reservation.denial.v1`

**Pre-existing sync/async asymmetry fix (small in-scope correction)** — the DID-aware verifiers (`verifyPaymentReceiptWithDID`, `verifyPaymentDenialWithDID`) previously accepted only the legacy `aps:payment_receipt:v1` / `aps:payment_denial:v1` literals, not `rail.payment.v1` / `rail.payment.denial.v1` — while their sync counterparts accepted both. Shipping the new budget_reservation literals on both sync and async paths while leaving `rail.payment.v1` sync-only would have produced an inconsistent verifier surface where the new literals verify more broadly than the primary rail literal. The four accepted-literal blocks are now identical across sync/async.

## Scope boundaries held

- No version bump (`2.6.0-alpha.3` unchanged)
- No emit-path change — emit sites still produce `rail.payment.v1` / `rail.payment.denial.v1` on the new path and legacy literals on the legacy path
- No new interfaces or constants — reuses literals already defined in the same file
- Verifier acceptance only

## Test

`npm run build` clean. `npm test` — 2911 pass / 0 fail across 709 suites.

Refs #25, aeoess/agent-governance-vocabulary#91
