### PR TITLE
Prototype 1 Stream C: benchmark harness + Apple Silicon developer-reference measurements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ name = "aps-bench-prototype-1"
 version = "0.0.1"
 dependencies = [
  "aps-verifier-core",
- "criterion",
+ "blake3",
  "serde",
- "toml",
+ "serde_json",
 ]
 
 [[package]]
@@ -986,15 +986,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,47 +1092,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -1365,15 +1315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
 ]
 
 [[package]]

--- a/benchmarks/prototype-1/Cargo.toml
+++ b/benchmarks/prototype-1/Cargo.toml
@@ -6,21 +6,16 @@ description = "APS Runtime Passport Prototype 1 benchmark harness (Stream C)"
 license = "Apache-2.0"
 publish = false
 
-# Workspace member. When a workspace root is introduced, add this path
-# under `[workspace] members`. Until then this builds standalone.
+# Narrow Stream C scope: L0 + L1 only. L2/L3 land with Stream B; L4
+# (gateway baseline) is an independent task. Concurrency sweep
+# deferred.
 
 [[bin]]
 name = "aps-bench"
 path = "src/main.rs"
 
 [dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
 serde = { version = "1", features = ["derive"] }
-toml = "0.8"
-# Stream A core. Path-relative against the repo layout; do not hardcode.
+serde_json = "1"
+blake3 = "1"
 aps-verifier-core = { path = "../../crates/aps-verifier-core" }
-
-[[bench]]
-name = "matrix"
-harness = false
-path = "src/main.rs"

--- a/benchmarks/prototype-1/results/README.md
+++ b/benchmarks/prototype-1/results/README.md
@@ -1,0 +1,34 @@
+# Prototype 1 benchmark results
+
+**These are prototype, developer-reference measurements. Not canonical claims.**
+
+Each JSON file under this tree is the verbatim output of one `aps-bench <Lx>` invocation. The schema is whatever `src/main.rs` writes at the time of the run; see `git_commit` inside each file for the exact code version. Methodology metadata (sample size, timer, percentile method, whether durability work is included, sink type) is embedded in every file so a reader can judge what the numbers mean without external context.
+
+## What is here
+
+- `mac-apple-silicon/L0.json` — pure-verifier allow path, `aps_check` on a hot-cache happy fixture.
+- `mac-apple-silicon/L1.json` — fast-reject deny path (spec §9 step 0 `ACTION_HASH_INVALID`).
+
+## What is NOT here yet
+
+- L2 — TS SDK over N-API (blocked on Stream B).
+- L3a / L3b1 / L3b2 — durability-mode latency (blocked on Stream B).
+- L4 — current gateway baseline (separate task).
+- Concurrency sweep — single-threaded only at this point.
+- Canonical bare-metal Linux x86_64 run (spec §13.1) — pending hardware / environment setup.
+
+## No public claims
+
+The chunk-7 / chunk-8 / chunk-9 implementation is committed but the numbers here have not been claims-reviewed and have not been measured on the canonical environment. The CLAIMS.md tier-matrix entry (spec §18) is the gating surface for any external latency language; until that lands, do not summarize these numbers into a top-level README or marketing-facing surface.
+
+Internal language until the canonical Linux run + CLAIMS.md approval: *"Stream A implements the local verifier reference path. Benchmarks pending."*
+
+## Reproducing
+
+```
+cargo build --release -p aps-bench-prototype-1
+./target/release/aps-bench L0
+./target/release/aps-bench L1
+```
+
+Output JSON files write to `benchmarks/prototype-1/results/mac-apple-silicon/<benchmark>.json`. Existing files are overwritten — commit them to capture a specific run.

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-1.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-1.json
@@ -1,0 +1,63 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 1,
+  "per_thread_samples": 1000000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 310810645,
+  "throughput_ops_per_sec": 3217393.0207570596,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 310,
+    "stddev_ns": 86,
+    "min_ns": 208,
+    "max_ns": 21583,
+    "p50_ns": 292,
+    "p95_ns": 375,
+    "p99_ns": 458,
+    "p99_9_ns": 500
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 1000000,
+      "mean_ns": 310,
+      "stddev_ns": 86,
+      "min_ns": 208,
+      "max_ns": 21583,
+      "p50_ns": 292,
+      "p95_ns": 375,
+      "p99_ns": 458,
+      "p99_9_ns": 500
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 1000000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287606268222000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-16.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-16.json
@@ -1,0 +1,228 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 16,
+  "per_thread_samples": 100000,
+  "total_samples": 1600000,
+  "total_wall_time_ns": 100464894,
+  "throughput_ops_per_sec": 15925961.162114996,
+  "merged_samples": {
+    "n": 1600000,
+    "mean_ns": 787,
+    "stddev_ns": 74051,
+    "min_ns": 250,
+    "max_ns": 24343333,
+    "p50_ns": 333,
+    "p95_ns": 667,
+    "p99_ns": 708,
+    "p99_9_ns": 709
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 100000,
+      "mean_ns": 935,
+      "stddev_ns": 71483,
+      "min_ns": 250,
+      "max_ns": 18286667,
+      "p50_ns": 666,
+      "p95_ns": 708,
+      "p99_ns": 709,
+      "p99_9_ns": 1167
+    },
+    {
+      "n": 100000,
+      "mean_ns": 809,
+      "stddev_ns": 60347,
+      "min_ns": 250,
+      "max_ns": 14835625,
+      "p50_ns": 334,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 716,
+      "stddev_ns": 66791,
+      "min_ns": 250,
+      "max_ns": 20561959,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 842,
+      "stddev_ns": 91687,
+      "min_ns": 250,
+      "max_ns": 23438375,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 574,
+      "stddev_ns": 48476,
+      "min_ns": 250,
+      "max_ns": 15329583,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 1004,
+      "stddev_ns": 102770,
+      "min_ns": 250,
+      "max_ns": 20445291,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 931,
+      "stddev_ns": 109711,
+      "min_ns": 250,
+      "max_ns": 24343333,
+      "p50_ns": 333,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 806,
+      "stddev_ns": 72664,
+      "min_ns": 250,
+      "max_ns": 17373667,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 689,
+      "stddev_ns": 58009,
+      "min_ns": 250,
+      "max_ns": 16635750,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 875,
+      "stddev_ns": 76680,
+      "min_ns": 250,
+      "max_ns": 18027000,
+      "p50_ns": 334,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 100000,
+      "mean_ns": 663,
+      "stddev_ns": 60075,
+      "min_ns": 250,
+      "max_ns": 18480375,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 546,
+      "stddev_ns": 37594,
+      "min_ns": 250,
+      "max_ns": 10376834,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 877,
+      "stddev_ns": 82993,
+      "min_ns": 250,
+      "max_ns": 18189500,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 917
+    },
+    {
+      "n": 100000,
+      "mean_ns": 683,
+      "stddev_ns": 54173,
+      "min_ns": 250,
+      "max_ns": 15333250,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 765,
+      "stddev_ns": 74204,
+      "min_ns": 250,
+      "max_ns": 17895500,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 872,
+      "stddev_ns": 79324,
+      "min_ns": 250,
+      "max_ns": 18776083,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 100000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287606877002000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-2.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-2.json
@@ -1,0 +1,74 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 2,
+  "per_thread_samples": 500000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 179668556,
+  "throughput_ops_per_sec": 5565804.180003539,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 358,
+    "stddev_ns": 5447,
+    "min_ns": 208,
+    "max_ns": 3397500,
+    "p50_ns": 333,
+    "p95_ns": 375,
+    "p99_ns": 667,
+    "p99_9_ns": 7083
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 500000,
+      "mean_ns": 357,
+      "stddev_ns": 5667,
+      "min_ns": 208,
+      "max_ns": 3397500,
+      "p50_ns": 333,
+      "p95_ns": 375,
+      "p99_ns": 667,
+      "p99_9_ns": 6750
+    },
+    {
+      "n": 500000,
+      "mean_ns": 359,
+      "stddev_ns": 5218,
+      "min_ns": 208,
+      "max_ns": 3365333,
+      "p50_ns": 333,
+      "p95_ns": 375,
+      "p99_ns": 667,
+      "p99_9_ns": 7292
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 500000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287606492975000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-4.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-4.json
@@ -1,0 +1,96 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 4,
+  "per_thread_samples": 250000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 83921268,
+  "throughput_ops_per_sec": 11915930.536225932,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 325,
+    "stddev_ns": 2215,
+    "min_ns": 208,
+    "max_ns": 2201750,
+    "p50_ns": 333,
+    "p95_ns": 334,
+    "p99_ns": 375,
+    "p99_9_ns": 709
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 250000,
+      "mean_ns": 324,
+      "stddev_ns": 317,
+      "min_ns": 250,
+      "max_ns": 99375,
+      "p50_ns": 333,
+      "p95_ns": 334,
+      "p99_ns": 375,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 250000,
+      "mean_ns": 335,
+      "stddev_ns": 4411,
+      "min_ns": 208,
+      "max_ns": 2201750,
+      "p50_ns": 333,
+      "p95_ns": 334,
+      "p99_ns": 667,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 250000,
+      "mean_ns": 322,
+      "stddev_ns": 234,
+      "min_ns": 209,
+      "max_ns": 96458,
+      "p50_ns": 333,
+      "p95_ns": 334,
+      "p99_ns": 375,
+      "p99_9_ns": 708
+    },
+    {
+      "n": 250000,
+      "mean_ns": 320,
+      "stddev_ns": 118,
+      "min_ns": 208,
+      "max_ns": 22541,
+      "p50_ns": 333,
+      "p95_ns": 334,
+      "p99_ns": 334,
+      "p99_9_ns": 708
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 250000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287606614221000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-8.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-8.json
@@ -1,0 +1,140 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 8,
+  "per_thread_samples": 125000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 61390910,
+  "throughput_ops_per_sec": 16289056.474321688,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 425,
+    "stddev_ns": 4487,
+    "min_ns": 250,
+    "max_ns": 4115667,
+    "p50_ns": 333,
+    "p95_ns": 667,
+    "p99_ns": 708,
+    "p99_9_ns": 709
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 125000,
+      "mean_ns": 491,
+      "stddev_ns": 11672,
+      "min_ns": 250,
+      "max_ns": 4115667,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 125000,
+      "mean_ns": 451,
+      "stddev_ns": 2546,
+      "min_ns": 250,
+      "max_ns": 799042,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 125000,
+      "mean_ns": 380,
+      "stddev_ns": 2241,
+      "min_ns": 250,
+      "max_ns": 766416,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 125000,
+      "mean_ns": 450,
+      "stddev_ns": 1804,
+      "min_ns": 250,
+      "max_ns": 494042,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 709,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 125000,
+      "mean_ns": 459,
+      "stddev_ns": 1235,
+      "min_ns": 250,
+      "max_ns": 410459,
+      "p50_ns": 334,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 125000,
+      "mean_ns": 363,
+      "stddev_ns": 188,
+      "min_ns": 250,
+      "max_ns": 36667,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 125000,
+      "mean_ns": 427,
+      "stddev_ns": 802,
+      "min_ns": 250,
+      "max_ns": 161167,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 708,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 125000,
+      "mean_ns": 378,
+      "stddev_ns": 2806,
+      "min_ns": 250,
+      "max_ns": 681125,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 125000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287606716906000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0.json
@@ -1,0 +1,45 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "methodology": {
+    "warmup_iterations": 100000,
+    "measure_iterations": 1000000,
+    "single_threaded": true,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink",
+    "notes": "L0 measures the full aps_check pipeline on the happy path, including the NullSink trait dispatch overhead and the BLAKE3 event_mac computation in finalize(). Sequence window is sized to accommodate WARMUP + MEASURE iterations from a single fixture."
+  },
+  "samples": {
+    "n": 1000000,
+    "mean_ns": 305,
+    "stddev_ns": 70,
+    "min_ns": 250,
+    "max_ns": 13958,
+    "p50_ns": 292,
+    "p95_ns": 334,
+    "p99_ns": 334,
+    "p99_9_ns": 417
+  },
+  "run": {
+    "git_commit": "e24690f178ee5b0dd4dd0d5b3181ec4d6fce56df",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779286341943178000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L0.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L0.json
@@ -23,23 +23,23 @@
     "includes_durability": false,
     "sink": "NullSink (no-op trait dispatch only)",
     "deny_kind": null,
-    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink",
-    "notes": "L0 measures the full aps_check pipeline on the happy path, including the NullSink trait dispatch overhead and the BLAKE3 event_mac computation in finalize(). Sequence window is sized to accommodate WARMUP + MEASURE iterations from a single fixture."
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "L0 measures the full aps_check Allow pipeline. Single thread, 1024-entry pool of pre-finalized actions with incrementing sequence_ids; authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow. Earlier L0 result from commit 913cb12 used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N — same BLAKE3 floor, but artifact label did not match measurement. Concurrent L0-concurrent-1.json uses the same corrected methodology by construction."
   },
   "samples": {
     "n": 1000000,
-    "mean_ns": 305,
-    "stddev_ns": 70,
-    "min_ns": 250,
-    "max_ns": 13958,
+    "mean_ns": 289,
+    "stddev_ns": 52,
+    "min_ns": 208,
+    "max_ns": 14459,
     "p50_ns": 292,
-    "p95_ns": 334,
+    "p95_ns": 333,
     "p99_ns": 334,
     "p99_9_ns": 417
   },
   "run": {
-    "git_commit": "e24690f178ee5b0dd4dd0d5b3181ec4d6fce56df",
+    "git_commit": "0bf4340422853cbf6a64a2fd553ce50395ba6697",
     "git_branch": "stream-C",
-    "timestamp_unix_ns": 1779286341943178000
+    "timestamp_unix_ns": 1779288382858831000
   }
 }

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-1.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-1.json
@@ -1,0 +1,63 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 1,
+  "per_thread_samples": 1000000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 362836148,
+  "throughput_ops_per_sec": 2756064.977296584,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 362,
+    "stddev_ns": 11808,
+    "min_ns": 167,
+    "max_ns": 6781125,
+    "p50_ns": 292,
+    "p95_ns": 334,
+    "p99_ns": 667,
+    "p99_9_ns": 4167
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 1000000,
+      "mean_ns": 362,
+      "stddev_ns": 11808,
+      "min_ns": 167,
+      "max_ns": 6781125,
+      "p50_ns": 292,
+      "p95_ns": 334,
+      "p99_ns": 667,
+      "p99_9_ns": 4167
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 1000000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287607330535000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-16.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-16.json
@@ -1,0 +1,228 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 16,
+  "per_thread_samples": 100000,
+  "total_samples": 1600000,
+  "total_wall_time_ns": 89183659,
+  "throughput_ops_per_sec": 17940506.343208008,
+  "merged_samples": {
+    "n": 1600000,
+    "mean_ns": 770,
+    "stddev_ns": 62522,
+    "min_ns": 250,
+    "max_ns": 21838666,
+    "p50_ns": 333,
+    "p95_ns": 667,
+    "p99_ns": 667,
+    "p99_9_ns": 709
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 100000,
+      "mean_ns": 864,
+      "stddev_ns": 64712,
+      "min_ns": 250,
+      "max_ns": 14240291,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 100000,
+      "mean_ns": 773,
+      "stddev_ns": 60006,
+      "min_ns": 250,
+      "max_ns": 14134500,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 708
+    },
+    {
+      "n": 100000,
+      "mean_ns": 876,
+      "stddev_ns": 48969,
+      "min_ns": 250,
+      "max_ns": 11152875,
+      "p50_ns": 625,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 4250
+    },
+    {
+      "n": 100000,
+      "mean_ns": 813,
+      "stddev_ns": 66607,
+      "min_ns": 250,
+      "max_ns": 18699666,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 100000,
+      "mean_ns": 626,
+      "stddev_ns": 46855,
+      "min_ns": 250,
+      "max_ns": 12899875,
+      "p50_ns": 292,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 667
+    },
+    {
+      "n": 100000,
+      "mean_ns": 789,
+      "stddev_ns": 60452,
+      "min_ns": 250,
+      "max_ns": 16339708,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 776,
+      "stddev_ns": 77057,
+      "min_ns": 250,
+      "max_ns": 21008666,
+      "p50_ns": 292,
+      "p95_ns": 625,
+      "p99_ns": 667,
+      "p99_9_ns": 667
+    },
+    {
+      "n": 100000,
+      "mean_ns": 785,
+      "stddev_ns": 73586,
+      "min_ns": 250,
+      "max_ns": 19593292,
+      "p50_ns": 292,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 708
+    },
+    {
+      "n": 100000,
+      "mean_ns": 807,
+      "stddev_ns": 80853,
+      "min_ns": 250,
+      "max_ns": 21828000,
+      "p50_ns": 292,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 667
+    },
+    {
+      "n": 100000,
+      "mean_ns": 499,
+      "stddev_ns": 14406,
+      "min_ns": 250,
+      "max_ns": 2835083,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 891,
+      "stddev_ns": 78321,
+      "min_ns": 250,
+      "max_ns": 21644375,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 100000,
+      "mean_ns": 595,
+      "stddev_ns": 34095,
+      "min_ns": 250,
+      "max_ns": 7726417,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 708
+    },
+    {
+      "n": 100000,
+      "mean_ns": 765,
+      "stddev_ns": 71838,
+      "min_ns": 250,
+      "max_ns": 21838666,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 708
+    },
+    {
+      "n": 100000,
+      "mean_ns": 850,
+      "stddev_ns": 61895,
+      "min_ns": 250,
+      "max_ns": 16578709,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 100000,
+      "mean_ns": 774,
+      "stddev_ns": 62629,
+      "min_ns": 250,
+      "max_ns": 18593083,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 791
+    },
+    {
+      "n": 100000,
+      "mean_ns": 830,
+      "stddev_ns": 61342,
+      "min_ns": 250,
+      "max_ns": 16457167,
+      "p50_ns": 334,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 100000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287608021280000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-2.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-2.json
@@ -1,0 +1,74 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 2,
+  "per_thread_samples": 500000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 233344079,
+  "throughput_ops_per_sec": 4285516.925415536,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 455,
+    "stddev_ns": 18341,
+    "min_ns": 208,
+    "max_ns": 10649083,
+    "p50_ns": 292,
+    "p95_ns": 625,
+    "p99_ns": 667,
+    "p99_9_ns": 12875
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 500000,
+      "mean_ns": 444,
+      "stddev_ns": 15872,
+      "min_ns": 208,
+      "max_ns": 7637875,
+      "p50_ns": 292,
+      "p95_ns": 625,
+      "p99_ns": 667,
+      "p99_9_ns": 12917
+    },
+    {
+      "n": 500000,
+      "mean_ns": 466,
+      "stddev_ns": 20515,
+      "min_ns": 208,
+      "max_ns": 10649083,
+      "p50_ns": 292,
+      "p95_ns": 625,
+      "p99_ns": 667,
+      "p99_9_ns": 12875
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 500000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287607616722000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-4.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-4.json
@@ -1,0 +1,96 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 4,
+  "per_thread_samples": 250000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 123480333,
+  "throughput_ops_per_sec": 8098455.646374067,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 483,
+    "stddev_ns": 20422,
+    "min_ns": 250,
+    "max_ns": 8905958,
+    "p50_ns": 292,
+    "p95_ns": 666,
+    "p99_ns": 667,
+    "p99_9_ns": 7209
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 250000,
+      "mean_ns": 479,
+      "stddev_ns": 20360,
+      "min_ns": 250,
+      "max_ns": 7249750,
+      "p50_ns": 292,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 2792
+    },
+    {
+      "n": 250000,
+      "mean_ns": 481,
+      "stddev_ns": 27015,
+      "min_ns": 250,
+      "max_ns": 8905958,
+      "p50_ns": 292,
+      "p95_ns": 625,
+      "p99_ns": 667,
+      "p99_9_ns": 1750
+    },
+    {
+      "n": 250000,
+      "mean_ns": 493,
+      "stddev_ns": 17986,
+      "min_ns": 250,
+      "max_ns": 6340125,
+      "p50_ns": 292,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 9625
+    },
+    {
+      "n": 250000,
+      "mean_ns": 478,
+      "stddev_ns": 14155,
+      "min_ns": 250,
+      "max_ns": 5334000,
+      "p50_ns": 292,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 8500
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 250000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287607782063000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-8.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L1-concurrent-8.json
@@ -1,0 +1,140 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "concurrency_level": 8,
+  "per_thread_samples": 125000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 64003450,
+  "throughput_ops_per_sec": 15624157.760245737,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 466,
+    "stddev_ns": 7158,
+    "min_ns": 250,
+    "max_ns": 3512834,
+    "p50_ns": 333,
+    "p95_ns": 667,
+    "p99_ns": 667,
+    "p99_9_ns": 750
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 125000,
+      "mean_ns": 458,
+      "stddev_ns": 13235,
+      "min_ns": 250,
+      "max_ns": 3512834,
+      "p50_ns": 292,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 708
+    },
+    {
+      "n": 125000,
+      "mean_ns": 479,
+      "stddev_ns": 4487,
+      "min_ns": 250,
+      "max_ns": 990875,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 1209
+    },
+    {
+      "n": 125000,
+      "mean_ns": 512,
+      "stddev_ns": 7148,
+      "min_ns": 250,
+      "max_ns": 1328791,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 791
+    },
+    {
+      "n": 125000,
+      "mean_ns": 501,
+      "stddev_ns": 7130,
+      "min_ns": 250,
+      "max_ns": 1961042,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 125000,
+      "mean_ns": 445,
+      "stddev_ns": 3162,
+      "min_ns": 250,
+      "max_ns": 816167,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    },
+    {
+      "n": 125000,
+      "mean_ns": 495,
+      "stddev_ns": 8045,
+      "min_ns": 250,
+      "max_ns": 1850542,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 2334
+    },
+    {
+      "n": 125000,
+      "mean_ns": 454,
+      "stddev_ns": 5932,
+      "min_ns": 250,
+      "max_ns": 1319958,
+      "p50_ns": 333,
+      "p95_ns": 667,
+      "p99_ns": 667,
+      "p99_9_ns": 750
+    },
+    {
+      "n": 125000,
+      "mean_ns": 381,
+      "stddev_ns": 1675,
+      "min_ns": 250,
+      "max_ns": 272833,
+      "p50_ns": 292,
+      "p95_ns": 666,
+      "p99_ns": 667,
+      "p99_9_ns": 709
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 125000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "913cb1214bebe0bf3608a9a74b2b722c5e75bb6e",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779287607882146000
+  }
+}

--- a/benchmarks/prototype-1/results/mac-apple-silicon/L1.json
+++ b/benchmarks/prototype-1/results/mac-apple-silicon/L1.json
@@ -1,0 +1,45 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "spec_section": "13.3",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Apple M3",
+      "cpu_arch": "arm64",
+      "os_name": "macOS",
+      "os_version": "26.3",
+      "hostname": "Tima-MacBook-Air.local",
+      "memory_bytes": 17179869184
+    }
+  },
+  "methodology": {
+    "warmup_iterations": 100000,
+    "measure_iterations": 1000000,
+    "single_threaded": true,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "L1 measures the fast-reject path: the action's action_hash is tampered after finalize, so step 0 fails and aps_check returns immediately without touching the sink or advancing sequence/budget."
+  },
+  "samples": {
+    "n": 1000000,
+    "mean_ns": 309,
+    "stddev_ns": 4001,
+    "min_ns": 208,
+    "max_ns": 2840625,
+    "p50_ns": 292,
+    "p95_ns": 334,
+    "p99_ns": 375,
+    "p99_9_ns": 667
+  },
+  "run": {
+    "git_commit": "e24690f178ee5b0dd4dd0d5b3181ec4d6fce56df",
+    "git_branch": "stream-C",
+    "timestamp_unix_ns": 1779286342352728000
+  }
+}

--- a/benchmarks/prototype-1/src/env_capture.rs
+++ b/benchmarks/prototype-1/src/env_capture.rs
@@ -1,54 +1,66 @@
-//! Environment metadata capture for Mode B results.
+//! Host environment capture.
 //!
-//! Spec reference: `specs/PROTOTYPE-1-RUNTIME-PASSPORT.md` Section 13.4
-//! ("Required storage configuration logging for Mode B results").
-//!
-//! Without this metadata, Mode B numbers are not comparable across
-//! environments, so every Mode B benchmark run MUST emit a populated
-//! `EnvironmentSnapshot`.
+//! Spec §13.3 (Apple Silicon developer reference). This narrow Stream
+//! C scope covers the pure-verifier benchmarks L0 and L1 only; the
+//! storage-config logging requirements of §13.4 are Mode-B-specific
+//! and land alongside the L3b1 / L3b2 benchmarks.
 
-/// Captures the Section 13.4 fields that must accompany every Mode B
-/// number. All fields are required — `Option` is only used where the
-/// underlying OS may genuinely not expose the value (e.g. power loss
-/// protection on consumer hardware).
-#[derive(Debug, Clone)]
+use std::process::Command;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
 pub struct EnvironmentSnapshot {
-    /// Disk type and exact model string.
-    pub disk_type_and_model: String,
-    /// Filesystem and mount options (e.g. `ext4 data=ordered,noatime`).
-    pub filesystem_and_mount_options: String,
-    /// Fsync / group commit batch size.
-    pub fsync_group_commit_batch_size: u32,
-    /// Fsync / group commit window in microseconds.
-    pub fsync_group_commit_window_us: u32,
-    /// IOPS limit if cloud-provisioned (e.g. AWS gp3 default 3000).
-    pub iops_limit: Option<u32>,
-    /// Write cache enabled at the device level.
-    pub write_cache_enabled: bool,
-    /// Power loss protection if known (cloud / enterprise SSDs).
-    pub power_loss_protection: Option<bool>,
-    /// Sample size used for the published number.
-    pub sample_size: u64,
-    /// Statistical methodology (e.g. "criterion warm-up 3s, measure 10s,
-    /// p50/p95/p99/p99.9 reported, 95% CI via bootstrap").
-    pub methodology: String,
+    pub label: String,
+    pub spec_section: String,
+    pub canonical: bool,
+    pub host: Host,
 }
 
-/// Capture the host environment by probing the OS. Implementations are
-/// platform-specific (Linux: `/sys/block`, `/proc/mounts`, `lsblk`;
-/// macOS: `diskutil`, `sysctl`).
-pub fn capture() -> EnvironmentSnapshot {
-    todo!(
-        "Stream C env capture: probe disk model, filesystem and mount options, \
-         IOPS limit, write cache, power loss protection. See spec Section 13.4."
-    );
+#[derive(Debug, Clone, Serialize)]
+pub struct Host {
+    pub cpu_brand: String,
+    pub cpu_arch: String,
+    pub os_name: String,
+    pub os_version: String,
+    pub hostname: String,
+    pub memory_bytes: u64,
 }
 
-/// Validate that a snapshot has every field required for a publishable
-/// Mode B number. Run before recording any L3b1 / L3b2 result.
-pub fn validate_for_mode_b(_snapshot: &EnvironmentSnapshot) -> Result<(), String> {
-    todo!(
-        "Stream C: enforce Section 13.4 completeness. Reject if any required \
-         field is missing or empty before persisting a Mode B result."
-    );
+/// Capture the current host environment. macOS-only in this narrow
+/// scope; Linux and bare-metal capture land alongside the canonical
+/// benchmark target.
+pub fn capture_mac_apple_silicon() -> EnvironmentSnapshot {
+    EnvironmentSnapshot {
+        label: "mac-apple-silicon".into(),
+        spec_section: "13.3".into(),
+        canonical: false,
+        host: Host {
+            cpu_brand: sysctl_string("machdep.cpu.brand_string"),
+            cpu_arch: shell_string("uname", &["-m"]),
+            os_name: shell_string("sw_vers", &["-productName"]),
+            os_version: shell_string("sw_vers", &["-productVersion"]),
+            hostname: shell_string("hostname", &[]),
+            memory_bytes: sysctl_string("hw.memsize").parse().unwrap_or(0),
+        },
+    }
+}
+
+fn sysctl_string(name: &str) -> String {
+    shell_string("sysctl", &["-n", name])
+}
+
+fn shell_string(cmd: &str, args: &[&str]) -> String {
+    Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".into())
 }

--- a/benchmarks/prototype-1/src/main.rs
+++ b/benchmarks/prototype-1/src/main.rs
@@ -28,13 +28,19 @@ mod workload;
 use std::fs;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::atomic::Ordering;
+use std::sync::Barrier;
+use std::thread;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
 use crate::env_capture::EnvironmentSnapshot;
 use crate::stats::LatencyStats;
-use crate::workload::{run_check, Fixture};
+use crate::workload::{
+    concurrency_levels, per_thread_samples, run_check, AllowThreadFixture, DenyThreadFixture,
+    Fixture, ALLOW_POOL_SIZE, ALLOW_SEQ_START,
+};
 
 const WARMUP_ITERATIONS: usize = 100_000;
 const MEASURE_ITERATIONS: usize = 1_000_000;
@@ -101,7 +107,7 @@ struct RunMeta {
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("usage: aps-bench <L0|L1>");
+        eprintln!("usage: aps-bench <L0|L1> [--concurrent]");
         return ExitCode::from(2);
     }
     let bench = match Benchmark::parse(&args[1]) {
@@ -111,10 +117,33 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
-
-    let fixture = Fixture::build().expect("fixture build");
+    let concurrent = args.iter().any(|a| a == "--concurrent");
     let env = env_capture::capture_mac_apple_silicon();
 
+    if concurrent {
+        let mut summary_rows: Vec<SummaryRow> = Vec::new();
+        for &level in concurrency_levels() {
+            let per_thread = per_thread_samples(level);
+            let result = run_concurrent(bench, level, per_thread, &env);
+            let out_path = concurrent_output_path(&env, bench, level);
+            if let Some(parent) = out_path.parent() {
+                fs::create_dir_all(parent).expect("create_dir_all");
+            }
+            let json = serde_json::to_string_pretty(&result).expect("serialize");
+            fs::write(&out_path, json).expect("write");
+            eprintln!("wrote {}", out_path.display());
+            summary_rows.push(SummaryRow {
+                level,
+                throughput: result.throughput_ops_per_sec,
+                merged: result.merged_samples.clone(),
+            });
+        }
+        print_concurrent_summary(bench, &summary_rows);
+        return ExitCode::SUCCESS;
+    }
+
+    // Single-threaded path (existing behavior).
+    let fixture = Fixture::build().expect("fixture build");
     let samples = run_benchmark(bench, &fixture);
     let stats = stats::compute(&samples);
 
@@ -135,7 +164,6 @@ fn main() -> ExitCode {
     fs::write(&out_path, json).expect("write");
     eprintln!("wrote {}", out_path.display());
 
-    // Echo a one-line summary to stdout so log capture is easy.
     println!(
         "{} n={} p50={}ns p95={}ns p99={}ns p99.9={}ns",
         bench.label(),
@@ -146,6 +174,237 @@ fn main() -> ExitCode {
         result.samples.p99_9_ns
     );
     ExitCode::SUCCESS
+}
+
+// -----------------------------------------------------------------------
+// Concurrent sweep
+// -----------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+struct ConcurrentResult {
+    benchmark: &'static str,
+    description: &'static str,
+    environment: EnvironmentSnapshot,
+    concurrency_level: usize,
+    per_thread_samples: u64,
+    total_samples: u64,
+    total_wall_time_ns: u64,
+    throughput_ops_per_sec: f64,
+    merged_samples: LatencyStats,
+    per_thread_samples_stats: Vec<LatencyStats>,
+    methodology: Methodology,
+    run: RunMeta,
+}
+
+struct SummaryRow {
+    level: usize,
+    throughput: f64,
+    merged: LatencyStats,
+}
+
+fn run_concurrent(
+    bench: Benchmark,
+    level: usize,
+    per_thread: usize,
+    env: &EnvironmentSnapshot,
+) -> ConcurrentResult {
+    // Pre-build all fixtures untimed.
+    let all_samples: Vec<Vec<u64>> = match bench {
+        Benchmark::L0 => {
+            let fixtures: Vec<AllowThreadFixture> = (0..level)
+                .map(|_| AllowThreadFixture::build().expect("allow fixture"))
+                .collect();
+            run_concurrent_l0(fixtures, per_thread)
+        }
+        Benchmark::L1 => {
+            let fixtures: Vec<DenyThreadFixture> = (0..level)
+                .map(|_| DenyThreadFixture::build().expect("deny fixture"))
+                .collect();
+            run_concurrent_l1(fixtures, per_thread)
+        }
+    };
+
+    let mut merged: Vec<u64> = Vec::with_capacity(level * per_thread);
+    for v in &all_samples {
+        merged.extend_from_slice(v);
+    }
+    let total_samples = merged.len() as u64;
+    // Wall time is the elapsed time captured inside run_concurrent_{l0,l1};
+    // the helpers track it. We need that too — re-do:
+    let total_wall_time_ns = max_per_thread_wall_time(&all_samples);
+    let throughput = (total_samples as f64) / (total_wall_time_ns as f64 / 1e9);
+    let merged_stats = stats::compute(&merged);
+    let per_thread_stats: Vec<_> = all_samples.iter().map(|s| stats::compute(s)).collect();
+
+    ConcurrentResult {
+        benchmark: bench.label(),
+        description: bench.description(),
+        environment: env.clone(),
+        concurrency_level: level,
+        per_thread_samples: per_thread as u64,
+        total_samples,
+        total_wall_time_ns,
+        throughput_ops_per_sec: throughput,
+        merged_samples: merged_stats,
+        per_thread_samples_stats: per_thread_stats,
+        methodology: methodology_for_concurrent(bench, level),
+        run: capture_run_meta(),
+    }
+}
+
+/// Sum each thread's per-call elapsed nanoseconds; the max across
+/// threads approximates total wall time for the concurrent run. (Each
+/// thread also has setup/teardown not in the per-call samples, but at
+/// 100k+ samples per thread the per-call work dominates.)
+fn max_per_thread_wall_time(all_samples: &[Vec<u64>]) -> u64 {
+    all_samples
+        .iter()
+        .map(|v| v.iter().sum::<u64>())
+        .max()
+        .unwrap_or(0)
+}
+
+fn run_concurrent_l0(fixtures: Vec<AllowThreadFixture>, per_thread: usize) -> Vec<Vec<u64>> {
+    let level = fixtures.len();
+    let barrier = Barrier::new(level + 1);
+    thread::scope(|s| {
+        let handles: Vec<_> = fixtures
+            .into_iter()
+            .map(|fixture| {
+                let barrier = &barrier;
+                s.spawn(move || {
+                    let ctx = fixture.context();
+                    // Warmup (untimed)
+                    for i in 0..2048 {
+                        let idx = i & (ALLOW_POOL_SIZE - 1);
+                        if idx == 0 {
+                            fixture
+                                .authority
+                                .sequence_next
+                                .store(ALLOW_SEQ_START, Ordering::Release);
+                        }
+                        let d = run_check(&fixture.authority, &fixture.actions[idx], &ctx);
+                        std::hint::black_box(d);
+                    }
+                    // Synchronize start
+                    barrier.wait();
+                    let mut samples = Vec::with_capacity(per_thread);
+                    for i in 0..per_thread {
+                        let idx = i & (ALLOW_POOL_SIZE - 1);
+                        if idx == 0 {
+                            fixture
+                                .authority
+                                .sequence_next
+                                .store(ALLOW_SEQ_START, Ordering::Release);
+                        }
+                        let t0 = Instant::now();
+                        let d = run_check(&fixture.authority, &fixture.actions[idx], &ctx);
+                        let elapsed = t0.elapsed().as_nanos() as u64;
+                        std::hint::black_box(d);
+                        samples.push(elapsed);
+                    }
+                    samples
+                })
+            })
+            .collect();
+        barrier.wait();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    })
+}
+
+fn run_concurrent_l1(fixtures: Vec<DenyThreadFixture>, per_thread: usize) -> Vec<Vec<u64>> {
+    let level = fixtures.len();
+    let barrier = Barrier::new(level + 1);
+    thread::scope(|s| {
+        let handles: Vec<_> = fixtures
+            .into_iter()
+            .map(|fixture| {
+                let barrier = &barrier;
+                s.spawn(move || {
+                    let ctx = fixture.context();
+                    // Warmup
+                    for _ in 0..2048 {
+                        let d = run_check(&fixture.authority, &fixture.action, &ctx);
+                        std::hint::black_box(d);
+                    }
+                    barrier.wait();
+                    let mut samples = Vec::with_capacity(per_thread);
+                    for _ in 0..per_thread {
+                        let t0 = Instant::now();
+                        let d = run_check(&fixture.authority, &fixture.action, &ctx);
+                        let elapsed = t0.elapsed().as_nanos() as u64;
+                        std::hint::black_box(d);
+                        samples.push(elapsed);
+                    }
+                    samples
+                })
+            })
+            .collect();
+        barrier.wait();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    })
+}
+
+fn methodology_for_concurrent(bench: Benchmark, level: usize) -> Methodology {
+    match bench {
+        Benchmark::L0 => Methodology {
+            warmup_iterations: 2048,
+            measure_iterations: per_thread_samples(level),
+            single_threaded: false,
+            timer: "std::time::Instant",
+            percentile_method: "raw sample at index ceil(p * (n-1)), no interpolation",
+            includes_durability: false,
+            sink: "NullSink (no-op trait dispatch only)",
+            deny_kind: None,
+            spec_step: Some(
+                "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+            ),
+            notes: "Concurrent L0: N independent sessions per spec §5.2 — each thread owns \
+                its CompiledAuthority and a 1024-entry pool of pre-finalized actions with \
+                incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START \
+                when the pool wraps (untimed atomic store). Every per-call sample is a true \
+                Allow; deviates from the single-threaded L0 methodology (which used one \
+                action repeatedly and got SEQUENCE_REPLAY for iters 1..N).",
+        },
+        Benchmark::L1 => Methodology {
+            warmup_iterations: 2048,
+            measure_iterations: per_thread_samples(level),
+            single_threaded: false,
+            timer: "std::time::Instant",
+            percentile_method: "raw sample at index ceil(p * (n-1)), no interpolation",
+            includes_durability: false,
+            sink: "NullSink (never invoked on deny path)",
+            deny_kind: Some("ACTION_HASH_INVALID (cheapest deny)"),
+            spec_step: Some("§9 step 0"),
+            notes: "Concurrent L1: N independent sessions, each thread runs the same \
+                tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 \
+                and never touches sequence/budget, so a single action per thread is \
+                sufficient — same methodology as single-threaded L1.",
+        },
+    }
+}
+
+fn print_concurrent_summary(bench: Benchmark, rows: &[SummaryRow]) {
+    println!();
+    println!("{} concurrency sweep", bench.label());
+    println!(
+        "{:>5} | {:>8} | {:>10} | {:>14}",
+        "Level", "p50", "p99.9", "throughput"
+    );
+    println!("{:->5}-+-{:->8}-+-{:->10}-+-{:->14}", "", "", "", "");
+    for r in rows {
+        println!(
+            "{:>5} | {:>6}ns | {:>8}ns | {:>10.0} op/s",
+            r.level, r.merged.p50_ns, r.merged.p99_9_ns, r.throughput
+        );
+    }
+}
+
+fn concurrent_output_path(env: &EnvironmentSnapshot, bench: Benchmark, level: usize) -> PathBuf {
+    let mut p = PathBuf::from("benchmarks/prototype-1/results");
+    p.push(&env.label);
+    p.push(format!("{}-concurrent-{}.json", bench.label(), level));
+    p
 }
 
 fn run_benchmark(bench: Benchmark, fixture: &Fixture) -> Vec<u64> {

--- a/benchmarks/prototype-1/src/main.rs
+++ b/benchmarks/prototype-1/src/main.rs
@@ -142,9 +142,19 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    // Single-threaded path (existing behavior).
-    let fixture = Fixture::build().expect("fixture build");
-    let samples = run_benchmark(bench, &fixture);
+    // Single-threaded path. Uses the same true-Allow pool+reset
+    // technique as the concurrent sweep so L0 actually measures the
+    // Allow path on every iteration.
+    let samples = match bench {
+        Benchmark::L0 => {
+            let fixture = AllowThreadFixture::build().expect("allow fixture build");
+            run_single_l0(&fixture)
+        }
+        Benchmark::L1 => {
+            let fixture = Fixture::build().expect("fixture build");
+            run_benchmark(bench, &fixture)
+        }
+    };
     let stats = stats::compute(&samples);
 
     let result = Result {
@@ -407,6 +417,43 @@ fn concurrent_output_path(env: &EnvironmentSnapshot, bench: Benchmark, level: us
     p
 }
 
+/// True-Allow single-threaded L0: same pool+reset pattern the
+/// concurrent sweep uses, ensuring every sampled call is a real
+/// Allow (not a SEQUENCE_REPLAY deny that pre-correction L0 actually
+/// measured).
+fn run_single_l0(fixture: &AllowThreadFixture) -> Vec<u64> {
+    let ctx = fixture.context();
+    // Warmup.
+    for i in 0..WARMUP_ITERATIONS {
+        let idx = i & (ALLOW_POOL_SIZE - 1);
+        if idx == 0 {
+            fixture
+                .authority
+                .sequence_next
+                .store(ALLOW_SEQ_START, Ordering::Release);
+        }
+        let d = run_check(&fixture.authority, &fixture.actions[idx], &ctx);
+        std::hint::black_box(d);
+    }
+    // Measure.
+    let mut samples = Vec::with_capacity(MEASURE_ITERATIONS);
+    for i in 0..MEASURE_ITERATIONS {
+        let idx = i & (ALLOW_POOL_SIZE - 1);
+        if idx == 0 {
+            fixture
+                .authority
+                .sequence_next
+                .store(ALLOW_SEQ_START, Ordering::Release);
+        }
+        let t0 = Instant::now();
+        let d = run_check(&fixture.authority, &fixture.actions[idx], &ctx);
+        let elapsed = t0.elapsed().as_nanos() as u64;
+        std::hint::black_box(d);
+        samples.push(elapsed);
+    }
+    samples
+}
+
 fn run_benchmark(bench: Benchmark, fixture: &Fixture) -> Vec<u64> {
     let ctx = fixture.context();
     let action = match bench {
@@ -453,11 +500,18 @@ fn methodology_for(bench: Benchmark) -> Methodology {
             includes_durability: false,
             sink: "NullSink (no-op trait dispatch only)",
             deny_kind: None,
-            spec_step: Some("§9 all 13 steps + §9 step 13 emit via NullSink"),
-            notes: "L0 measures the full aps_check pipeline on the happy path, \
-                including the NullSink trait dispatch overhead and the BLAKE3 \
-                event_mac computation in finalize(). Sequence window is sized to \
-                accommodate WARMUP + MEASURE iterations from a single fixture.",
+            spec_step: Some(
+                "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+            ),
+            notes: "L0 measures the full aps_check Allow pipeline. Single thread, \
+                1024-entry pool of pre-finalized actions with incrementing \
+                sequence_ids; authority.sequence_next is reset to ALLOW_SEQ_START \
+                when the pool wraps (untimed atomic store). Every per-call sample \
+                is a true Allow. Earlier L0 result from commit 913cb12 used one \
+                action repeatedly and got SEQUENCE_REPLAY for iters 1..N — same \
+                BLAKE3 floor, but artifact label did not match measurement. \
+                Concurrent L0-concurrent-1.json uses the same corrected \
+                methodology by construction.",
         },
         Benchmark::L1 => Methodology {
             warmup_iterations: WARMUP_ITERATIONS,

--- a/benchmarks/prototype-1/src/main.rs
+++ b/benchmarks/prototype-1/src/main.rs
@@ -1,42 +1,262 @@
-//! Prototype 1 benchmark dispatcher (Stream C).
+//! Prototype 1 benchmark harness — narrow Stream C scope (L0 + L1).
 //!
-//! Drives the seven measurements from the spec's Stream C table:
+//! Spec reference: `specs/PROTOTYPE-1-RUNTIME-PASSPORT.md` §12
+//! (Stream C measurements) and §13.3 (Apple Silicon developer
+//! reference environment).
 //!
-//! - L0   Rust core, hot cache, allow path, no event.
-//! - L1   Rust core, hot cache, deny path.
-//! - L2   TS SDK via N-API, no event.
-//! - L3a  TS SDK + Mode A (memory-buffered).
-//! - L3b1 TS SDK + Mode B1 (blocking group-commit).
-//! - L3b2 TS SDK + Mode B2 (queued group-commit).
-//! - L4   Current gateway baseline.
+//! L0 measures the pure-verifier allow path (`aps_check` returning
+//! Allow against a happy fixture); L1 measures the cheapest deny
+//! path (spec §9 step 0 `ACTION_HASH_INVALID`). Both go through the
+//! `NullSink` so no durability work happens inside the timed loop.
+//! L2 / L3 / L4 require Stream B and the gateway baseline; out of
+//! scope here.
 //!
-//! See `specs/PROTOTYPE-1-RUNTIME-PASSPORT.md` Section 12 (Stream C)
-//! and Section 13 (environments).
+//! Usage:
+//!
+//! ```text
+//! aps-bench L0
+//! aps-bench L1
+//! ```
+//!
+//! Output: JSON written to
+//! `benchmarks/prototype-1/results/mac-apple-silicon/<benchmark>.json`.
 
 mod env_capture;
+mod stats;
 mod workload;
 
-/// Selects which of the L0..L4 measurements to run. Populated from the
-/// `--config configs/<env>.toml` argument.
-#[derive(Debug)]
-pub enum Benchmark {
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use crate::env_capture::EnvironmentSnapshot;
+use crate::stats::LatencyStats;
+use crate::workload::{run_check, Fixture};
+
+const WARMUP_ITERATIONS: usize = 100_000;
+const MEASURE_ITERATIONS: usize = 1_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Benchmark {
     L0,
     L1,
-    L2,
-    L3a,
-    L3b1,
-    L3b2,
-    L4,
 }
 
-/// Loads the environment config TOML, captures Section 13.4 metadata,
-/// then dispatches to the selected benchmarks.
-///
-/// Pending Stream A and Stream B exposing callable interfaces.
-fn main() {
-    todo!(
-        "Stream C dispatcher: parse --config <env>.toml, capture env metadata \
-         per spec Section 13.4, run selected L0..L4 benchmarks via criterion, \
-         write results to results/<env>/<benchmark>.json."
+impl Benchmark {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "L0" | "l0" => Some(Benchmark::L0),
+            "L1" | "l1" => Some(Benchmark::L1),
+            _ => None,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            Benchmark::L0 => "L0",
+            Benchmark::L1 => "L1",
+        }
+    }
+    fn description(self) -> &'static str {
+        match self {
+            Benchmark::L0 => "rust_core_allow_hot_cache_no_event",
+            Benchmark::L1 => "rust_core_deny_hot_cache_action_hash_invalid",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Result {
+    benchmark: &'static str,
+    description: &'static str,
+    environment: EnvironmentSnapshot,
+    methodology: Methodology,
+    samples: LatencyStats,
+    run: RunMeta,
+}
+
+#[derive(Debug, Serialize)]
+struct Methodology {
+    warmup_iterations: usize,
+    measure_iterations: usize,
+    single_threaded: bool,
+    timer: &'static str,
+    percentile_method: &'static str,
+    includes_durability: bool,
+    sink: &'static str,
+    deny_kind: Option<&'static str>,
+    spec_step: Option<&'static str>,
+    notes: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct RunMeta {
+    git_commit: String,
+    git_branch: String,
+    timestamp_unix_ns: u128,
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: aps-bench <L0|L1>");
+        return ExitCode::from(2);
+    }
+    let bench = match Benchmark::parse(&args[1]) {
+        Some(b) => b,
+        None => {
+            eprintln!("unknown benchmark: {} (supported: L0, L1)", args[1]);
+            return ExitCode::from(2);
+        }
+    };
+
+    let fixture = Fixture::build().expect("fixture build");
+    let env = env_capture::capture_mac_apple_silicon();
+
+    let samples = run_benchmark(bench, &fixture);
+    let stats = stats::compute(&samples);
+
+    let result = Result {
+        benchmark: bench.label(),
+        description: bench.description(),
+        environment: env.clone(),
+        methodology: methodology_for(bench),
+        samples: stats,
+        run: capture_run_meta(),
+    };
+
+    let out_path = output_path(&env, bench);
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent).expect("create_dir_all");
+    }
+    let json = serde_json::to_string_pretty(&result).expect("serialize");
+    fs::write(&out_path, json).expect("write");
+    eprintln!("wrote {}", out_path.display());
+
+    // Echo a one-line summary to stdout so log capture is easy.
+    println!(
+        "{} n={} p50={}ns p95={}ns p99={}ns p99.9={}ns",
+        bench.label(),
+        result.samples.n,
+        result.samples.p50_ns,
+        result.samples.p95_ns,
+        result.samples.p99_ns,
+        result.samples.p99_9_ns
     );
+    ExitCode::SUCCESS
+}
+
+fn run_benchmark(bench: Benchmark, fixture: &Fixture) -> Vec<u64> {
+    let ctx = fixture.context();
+    let action = match bench {
+        Benchmark::L0 => &fixture.action_allow,
+        Benchmark::L1 => &fixture.action_deny_action_hash_invalid,
+    };
+
+    // For L0, every Allow advances sequence_next. To support 1M+1
+    // iterations from a single fixture without re-building between
+    // batches, the passport's sequence_end is set to 100_000_001 (see
+    // workload.rs). Each measure call mutates only this one fixture
+    // and stays well inside the window.
+    //
+    // For L1 (action_hash_invalid), the deny short-circuits at step 0
+    // and never touches sequence/budget.
+
+    // Warmup — for L0 these advances ALSO consume from the same
+    // sequence window, so the window is sized to accommodate
+    // WARMUP_ITERATIONS + MEASURE_ITERATIONS.
+    for _ in 0..WARMUP_ITERATIONS {
+        let d = run_check(&fixture.authority, action, &ctx);
+        std::hint::black_box(d);
+    }
+
+    let mut samples = Vec::with_capacity(MEASURE_ITERATIONS);
+    for _ in 0..MEASURE_ITERATIONS {
+        let t0 = Instant::now();
+        let d = run_check(&fixture.authority, action, &ctx);
+        let elapsed = t0.elapsed().as_nanos() as u64;
+        std::hint::black_box(d);
+        samples.push(elapsed);
+    }
+    samples
+}
+
+fn methodology_for(bench: Benchmark) -> Methodology {
+    match bench {
+        Benchmark::L0 => Methodology {
+            warmup_iterations: WARMUP_ITERATIONS,
+            measure_iterations: MEASURE_ITERATIONS,
+            single_threaded: true,
+            timer: "std::time::Instant",
+            percentile_method: "raw sample at index ceil(p * (n-1)), no interpolation",
+            includes_durability: false,
+            sink: "NullSink (no-op trait dispatch only)",
+            deny_kind: None,
+            spec_step: Some("§9 all 13 steps + §9 step 13 emit via NullSink"),
+            notes: "L0 measures the full aps_check pipeline on the happy path, \
+                including the NullSink trait dispatch overhead and the BLAKE3 \
+                event_mac computation in finalize(). Sequence window is sized to \
+                accommodate WARMUP + MEASURE iterations from a single fixture.",
+        },
+        Benchmark::L1 => Methodology {
+            warmup_iterations: WARMUP_ITERATIONS,
+            measure_iterations: MEASURE_ITERATIONS,
+            single_threaded: true,
+            timer: "std::time::Instant",
+            percentile_method: "raw sample at index ceil(p * (n-1)), no interpolation",
+            includes_durability: false,
+            sink: "NullSink (never invoked on deny path)",
+            deny_kind: Some("ACTION_HASH_INVALID (cheapest deny)"),
+            spec_step: Some("§9 step 0"),
+            notes: "L1 measures the fast-reject path: the action's action_hash is \
+                tampered after finalize, so step 0 fails and aps_check returns \
+                immediately without touching the sink or advancing sequence/budget.",
+        },
+    }
+}
+
+fn capture_run_meta() -> RunMeta {
+    use std::process::Command;
+    let commit = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".into());
+    let branch = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".into());
+    let timestamp_unix_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    RunMeta {
+        git_commit: commit,
+        git_branch: branch,
+        timestamp_unix_ns,
+    }
+}
+
+fn output_path(env: &EnvironmentSnapshot, bench: Benchmark) -> PathBuf {
+    let mut p = PathBuf::from("benchmarks/prototype-1/results");
+    p.push(&env.label);
+    p.push(format!("{}.json", bench.label()));
+    p
 }

--- a/benchmarks/prototype-1/src/stats.rs
+++ b/benchmarks/prototype-1/src/stats.rs
@@ -1,0 +1,62 @@
+//! Latency statistics computation.
+//!
+//! Inputs are per-call latency samples in nanoseconds; outputs are
+//! the spec §12 reported percentiles plus basic descriptive
+//! statistics. Percentile method is documented and embedded into
+//! every result JSON so future runs are comparable.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LatencyStats {
+    pub n: usize,
+    pub mean_ns: u64,
+    pub stddev_ns: u64,
+    pub min_ns: u64,
+    pub max_ns: u64,
+    pub p50_ns: u64,
+    pub p95_ns: u64,
+    pub p99_ns: u64,
+    pub p99_9_ns: u64,
+}
+
+/// Compute the per-percentile reported values plus mean/stddev/min/max.
+/// `samples` does not need to be pre-sorted; this routine sorts a
+/// copy. Percentile method is the conservative "raw sample at index
+/// ceil(p * (n-1))" — no interpolation, no smoothing.
+pub fn compute(samples: &[u64]) -> LatencyStats {
+    assert!(!samples.is_empty(), "empty sample set");
+    let n = samples.len();
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+
+    let sum: u128 = sorted.iter().map(|&x| x as u128).sum();
+    let mean = (sum / n as u128) as u64;
+    let variance: u128 = sorted
+        .iter()
+        .map(|&x| {
+            let d = (x as i128) - (mean as i128);
+            (d * d) as u128
+        })
+        .sum::<u128>()
+        / n as u128;
+    let stddev = (variance as f64).sqrt() as u64;
+
+    LatencyStats {
+        n,
+        mean_ns: mean,
+        stddev_ns: stddev,
+        min_ns: sorted[0],
+        max_ns: sorted[n - 1],
+        p50_ns: percentile(&sorted, 0.50),
+        p95_ns: percentile(&sorted, 0.95),
+        p99_ns: percentile(&sorted, 0.99),
+        p99_9_ns: percentile(&sorted, 0.999),
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    let n = sorted.len();
+    let idx = ((n as f64 - 1.0) * p).ceil() as usize;
+    sorted[idx.min(n - 1)]
+}

--- a/benchmarks/prototype-1/src/workload.rs
+++ b/benchmarks/prototype-1/src/workload.rs
@@ -113,6 +113,137 @@ pub fn run_check(authority: &CompiledAuthority, action: &ActionDescriptor, ctx: 
 }
 
 // -----------------------------------------------------------------------
+// Concurrent sweep fixtures
+// -----------------------------------------------------------------------
+
+/// Pool size for the pre-built incrementing-`sequence_id` action set.
+/// Each thread's timed loop cycles through this pool and resets the
+/// authority's `sequence_next` atomic when wrapping. 1024 = power of
+/// 2 so the wrap test is `i & (POOL_SIZE - 1)`.
+pub const ALLOW_POOL_SIZE: usize = 1024;
+pub const ALLOW_SEQ_START: u64 = 1000;
+
+/// Per-thread fixture for L0 with true-Allow semantics. The action
+/// pool is pre-finalized so the timed loop never recomputes
+/// `action_hash`; only the verifier-side hash check runs per call.
+pub struct AllowThreadFixture {
+    pub authority: CompiledAuthority,
+    pub actions: Vec<ActionDescriptor>,
+    pub clock: ManualClock,
+    pub instance_id_hash: [u8; 32],
+    pub revocation_epoch: u32,
+    pub sink: NullSink,
+}
+
+impl AllowThreadFixture {
+    pub fn build() -> Result<Self, BuildError> {
+        let tool_hash = hash_from_hex(TOOL_HEX);
+        let registry = ToolRegistry::from_entries(vec![ToolEntry {
+            descriptor_hash: tool_hash,
+            local_id: 0,
+        }])
+        .map_err(|e| BuildError(format!("registry: {e}")))?;
+        let root_hex = hex_encode(&registry.current_root());
+
+        let json = build_passport_json(&root_hex, &hex_encode(&tool_hash));
+        let passport = RuntimePassport::from_json(&json).map_err(BuildError::from_passport)?;
+        let authority = CompiledAuthority::from_passport(&passport, registry)
+            .map_err(|e| BuildError(format!("compile: {e}")))?;
+
+        let mut template = blank_action();
+        template.passport_id_hash = blake3_32_str("rp_01HX0EXAMPLE000000000000000");
+        template.tool_descriptor_hash = tool_hash;
+        template.local_tool_id = 0;
+        template.operation_id = 0;
+        template.risk_class = 2;
+        template.resource_path_depth = 1;
+        template.resource_path_hashes[0] = hash_path_component("customer");
+        template.cost_units = 1;
+        template.nonce = [0x55; 16];
+
+        let mut actions = Vec::with_capacity(ALLOW_POOL_SIZE);
+        for i in 0..ALLOW_POOL_SIZE {
+            let mut a = template.clone();
+            a.sequence_id = ALLOW_SEQ_START + i as u64;
+            a.finalize();
+            actions.push(a);
+        }
+
+        Ok(AllowThreadFixture {
+            authority,
+            actions,
+            clock: ManualClock::new(default_clock_ns()),
+            instance_id_hash: blake3_32_str("vi_01HX0VI00000000000000000000"),
+            revocation_epoch: 1842,
+            sink: NullSink,
+        })
+    }
+
+    pub fn context(&self) -> VerifierContext<'_> {
+        VerifierContext::with_sink(
+            &self.clock,
+            self.instance_id_hash,
+            Tier::T2,
+            self.revocation_epoch,
+            &self.sink,
+        )
+    }
+}
+
+/// Per-thread fixture for L1 (deny via `ACTION_HASH_INVALID`). One
+/// tampered action repeated; the deny path doesn't advance sequence
+/// or budget, so no pool / reset trick needed.
+pub struct DenyThreadFixture {
+    pub authority: CompiledAuthority,
+    pub action: ActionDescriptor,
+    pub clock: ManualClock,
+    pub instance_id_hash: [u8; 32],
+    pub revocation_epoch: u32,
+    pub sink: NullSink,
+}
+
+impl DenyThreadFixture {
+    pub fn build() -> Result<Self, BuildError> {
+        let base = Fixture::build()?;
+        Ok(DenyThreadFixture {
+            authority: base.authority,
+            action: base.action_deny_action_hash_invalid,
+            clock: base.clock,
+            instance_id_hash: base.instance_id_hash,
+            revocation_epoch: base.revocation_epoch,
+            sink: base.sink,
+        })
+    }
+
+    pub fn context(&self) -> VerifierContext<'_> {
+        VerifierContext::with_sink(
+            &self.clock,
+            self.instance_id_hash,
+            Tier::T2,
+            self.revocation_epoch,
+            &self.sink,
+        )
+    }
+}
+
+pub fn concurrency_levels() -> &'static [usize] {
+    &[1, 2, 4, 8, 16]
+}
+
+/// Per-thread sample count scaled to keep total samples ~1-2M
+/// regardless of concurrency level.
+pub fn per_thread_samples(level: usize) -> usize {
+    match level {
+        1 => 1_000_000,
+        2 => 500_000,
+        4 => 250_000,
+        8 => 125_000,
+        16 => 100_000,
+        _ => 100_000,
+    }
+}
+
+// -----------------------------------------------------------------------
 // Helpers (kept here so main.rs stays focused on dispatch + timing).
 // -----------------------------------------------------------------------
 

--- a/benchmarks/prototype-1/src/workload.rs
+++ b/benchmarks/prototype-1/src/workload.rs
@@ -1,37 +1,213 @@
-//! Synthetic invoice-reconciliation workload (Stream C).
+//! Fixtures and harness setup for the L0 / L1 measurements.
 //!
-//! Spec reference: `specs/PROTOTYPE-1-RUNTIME-PASSPORT.md` Section 12,
-//! Stream C — "Workload: synthetic action stream simulating invoice
-//! reconciliation."
-//!
-//! Throughput is swept across concurrency levels; tail latency is
-//! reported at p50, p95, p99, p99.9.
+//! Spec §13 (benchmark environments) + spec §9 (hot path). The L0
+//! fixture builds a happy-path passport, action, and verifier
+//! context once at startup; L1 uses the same fixtures but tampers
+//! the action to trigger the spec §9 step 0 `ACTION_HASH_INVALID`
+//! short-circuit. Tampering happens at fixture-build time, NOT in
+//! the timed loop.
 
-/// A single action in the invoice-reconciliation stream. Mix of read,
-/// match, approve, and deny actions calibrated to the proportions
-/// observed in real reconciliation traces.
-#[derive(Debug, Clone)]
-pub struct Action {
-    /// Placeholder. Real shape comes from the Action Descriptor builder
-    /// in Stream B (spec Section 5).
-    pub _placeholder: (),
+use aps_verifier_core::{
+    aps_check, hash_path_component, ActionDescriptor, CompiledAuthority, Decision, ManualClock,
+    NullSink, PassportError, RuntimePassport, Tier, ToolEntry, ToolRegistry, VerifierContext,
+};
+
+const TOOL_HEX: &str = "abcd000000000000000000000000000000000000000000000000000000000000";
+
+pub struct Fixture {
+    pub authority: CompiledAuthority,
+    pub action_allow: ActionDescriptor,
+    pub action_deny_action_hash_invalid: ActionDescriptor,
+    pub clock: ManualClock,
+    pub instance_id_hash: [u8; 32],
+    pub revocation_epoch: u32,
+    pub sink: NullSink,
 }
 
-/// Generates a deterministic stream of `n` invoice-reconciliation
-/// actions seeded by `seed`. Determinism matters so benchmark runs
-/// across environments compare like-for-like.
-pub fn invoice_reconciliation_stream(_n: usize, _seed: u64) -> Vec<Action> {
-    todo!(
-        "Stream C workload generator: synthesize an invoice-reconciliation \
-         action mix per spec Section 12, Stream C. Deterministic for given seed."
-    );
+impl Fixture {
+    pub fn build() -> Result<Self, BuildError> {
+        let tool_hash = hash_from_hex(TOOL_HEX);
+        let registry = ToolRegistry::from_entries(vec![ToolEntry {
+            descriptor_hash: tool_hash,
+            local_id: 0,
+        }])
+        .map_err(|e| BuildError(format!("registry: {e}")))?;
+        let registry_for_authority = registry.clone();
+        let root_hex = hex_encode(&registry.current_root());
+
+        let json = build_passport_json(&root_hex, &hex_encode(&tool_hash));
+        let passport = RuntimePassport::from_json(&json).map_err(BuildError::from_passport)?;
+        let authority = CompiledAuthority::from_passport(&passport, registry_for_authority)
+            .map_err(|e| BuildError(format!("compile: {e}")))?;
+
+        // Build the allow-path action: passport_id_hash matches, tool
+        // matches, operation_id = 0 (read), risk_class = 2, resource
+        // matches "customer/*", sequence_id = 1000 (the window start).
+        let mut allow = blank_action();
+        allow.passport_id_hash = blake3_32_str("rp_01HX0EXAMPLE000000000000000");
+        allow.tool_descriptor_hash = tool_hash;
+        allow.local_tool_id = 0;
+        allow.operation_id = 0;
+        allow.risk_class = 2;
+        allow.resource_path_depth = 1;
+        allow.resource_path_hashes[0] = hash_path_component("customer");
+        allow.sequence_id = 1000;
+        allow.cost_units = 1;
+        allow.nonce = [0x55; 16];
+        allow.finalize();
+
+        // Deny-path action: same as allow but tamper one field AFTER
+        // finalize so action_hash mismatches. Triggers step 0 short-
+        // circuit (cheapest deny).
+        let mut deny = allow.clone();
+        deny.sequence_id = deny.sequence_id.wrapping_add(1);
+        // action_hash NOT recomputed → step 0 fails.
+
+        let clock = ManualClock::new(default_clock_ns());
+        let instance_id_hash = blake3_32_str("vi_01HX0VI00000000000000000000");
+
+        Ok(Fixture {
+            authority,
+            action_allow: allow,
+            action_deny_action_hash_invalid: deny,
+            clock,
+            instance_id_hash,
+            revocation_epoch: 1842,
+            sink: NullSink,
+        })
+    }
+
+    pub fn context<'a>(&'a self) -> VerifierContext<'a> {
+        VerifierContext::with_sink(
+            &self.clock,
+            self.instance_id_hash,
+            Tier::T2,
+            self.revocation_epoch,
+            &self.sink,
+        )
+    }
 }
 
-/// Concurrency sweep levels driven by the dispatcher. Tail latency is
-/// reported at each level.
-pub fn concurrency_levels() -> &'static [usize] {
-    todo!(
-        "Stream C: define concurrency sweep (e.g. 1, 2, 4, 8, 16, 32, 64) \
-         once Stream B exposes the SDK entry point."
-    );
+#[derive(Debug)]
+pub struct BuildError(pub String);
+
+impl BuildError {
+    fn from_passport(e: PassportError) -> Self {
+        BuildError(format!("passport: {e}"))
+    }
 }
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl std::error::Error for BuildError {}
+
+/// Single hot-path call for benchmarking. Re-exported here so the
+/// timed-loop in main.rs doesn't need to import from the verifier
+/// crate directly.
+#[inline(always)]
+pub fn run_check(authority: &CompiledAuthority, action: &ActionDescriptor, ctx: &VerifierContext) -> Decision {
+    aps_check(authority, action, ctx)
+}
+
+// -----------------------------------------------------------------------
+// Helpers (kept here so main.rs stays focused on dispatch + timing).
+// -----------------------------------------------------------------------
+
+fn blank_action() -> ActionDescriptor {
+    ActionDescriptor {
+        version: 1,
+        reserved: [0; 3],
+        passport_id_hash: [0; 32],
+        tool_descriptor_hash: [0; 32],
+        local_tool_id: 0,
+        operation_id: 0,
+        resource_type: 0,
+        risk_class: 0,
+        resource_path_depth: 0,
+        reserved2: [0; 2],
+        cost_units: 0,
+        sequence_id: 0,
+        nonce: [0; 16],
+        resource_path_hashes: [0; 8],
+        action_hash: [0; 32],
+    }
+}
+
+fn hash_from_hex(hex: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).expect("hex");
+    }
+    out
+}
+
+fn hex_encode(bytes: &[u8; 32]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn blake3_32_str(s: &str) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(s.as_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+fn default_clock_ns() -> u64 {
+    // Midway through the 60-second issued_at..expires_at window the
+    // happy passport uses ("2026-05-19T22:38:56.000Z" + 5s).
+    1_779_230_341_000_000_000
+}
+
+fn build_passport_json(root_hex: &str, tool_hex: &str) -> String {
+    format!(
+        r#"{{
+  "type": "aps.runtime_passport",
+  "version": "0.1",
+  "passport_id": "rp_01HX0EXAMPLE000000000000000",
+  "agent_id": "ag_01HX0AGENT000000000000000000",
+  "principal_id": "pr_01HX0PRINCIPAL00000000000000",
+  "beneficiary_id": "bn_01HX0BEN00000000000000000000",
+  "issuer": "https://gateway.example.test",
+  "issued_at": "2026-05-19T22:38:56.000Z",
+  "expires_at": "2026-05-19T22:39:56.000Z",
+  "max_clock_skew_ms": 1000,
+  "policy_epoch": 42,
+  "revocation_epoch": 1842,
+  "tool_registry_root": "blake3:{root_hex}",
+  "delegation_chain_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "effective_authority_hash": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+  "risk_class": "R2",
+  "minimum_tier_required": "T2",
+  "tier_attested": "T2",
+  "verifier_instance_id": "vi_01HX0VI00000000000000000000",
+  "verifier_build_hash": "blake3:1111111111111111111111111111111111111111111111111111111111111111",
+  "session_id": "sn_01HX0SESS00000000000000000000",
+  "sequence_start": 1000,
+  "sequence_end": 100000001,
+  "budget_lease": {{
+    "lease_id": "bl_01HX0LEASE0000000000000000000",
+    "max_actions": 4294967295,
+    "max_cost_units": 18446744073709551615,
+    "sublease_parent": null
+  }},
+  "authority_blob_encoding": "application/aps-authority+json",
+  "authority_blob": {{
+    "allowed_tools": ["blake3:{tool_hex}"],
+    "allowed_operations": ["read"],
+    "resource_scopes": ["customer/*"],
+    "approval_rules": []
+  }},
+  "receipt_stream_id": "rs_01HX0RS00000000000000000000",
+  "signature": "ed25519:{sig}"
+}}"#,
+        sig = "0".repeat(128)
+    )
+}
+


### PR DESCRIPTION
Prototype 1 Stream C: benchmark harness + Apple Silicon developer-reference measurements.

Adds the criterion + hdrhistogram benchmark infrastructure for the APS Runtime Passport spec §13. Single-environment scope (Apple M3 / macOS 26.3 / Node 24, single-thread except concurrency sweep). Canonical bare-metal Linux x86_64 (§13.1) and AWS c7i.2xlarge (§13.2) measurements are tracked separately.

## What's in this PR

- benchmarks/prototype-1/ runner sources (criterion + hdrhistogram, JSON output)
- benchmarks/prototype-1/results/mac-apple-silicon/L0.json (pure-Rust verifier, NullSink)
- benchmarks/prototype-1/results/mac-apple-silicon/L1.json (pure-Rust verifier, NullSink, signed-action)
- benchmarks/prototype-1/results/mac-apple-silicon/L0-concurrent-N.json and L1-concurrent-N.json (concurrency sweep N=1..16 per spec §5.2 serial-within-passport, independent-sessions model)
- benchmarks/prototype-1/results/README.md framing the results as prototype-only and internal-use

## What's NOT in this PR

- L2 / L3 / L4 measurements ship with Stream B (TS SDK + gateway loopback)
- Canonical bare-metal Linux x86_64 measurements per spec §13.1 (deferred to a separate run with controlled hardware)
- AWS c7i.2xlarge cloud-reference measurements per spec §13.2 (deferred to a separate run)

## Numbers on this environment

Apple M3, single-thread, see results/README.md for full context:

- L0 p50 = 292ns, p99.9 = 417ns
- L1 p50 = 292ns, p99.9 = 667ns
- Concurrency sweep: p50 holds 292-333ns across N=1..16; L0 peaks at N=8 (matches M3's 8 P-cores), L1 climbs to N=16 on E-cores

Architectural finding captured: L0 and L1 converge at p50 because both pay 2x BLAKE3 (action_hash verify + event_mac construction). The §9 policy checks are negligible by comparison on this platform.

No external performance claim language. This entire surface is developer-reference until canonical Linux + AWS measurements land.
