### PR TITLE
Canonical-measurement infrastructure + AWS c7i.2xlarge results (§13.2)

### DIFF
--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-1.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-1.json
@@ -1,0 +1,63 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 1,
+  "per_thread_samples": 1000000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 352096809,
+  "throughput_ops_per_sec": 2840127.9830968305,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 352,
+    "stddev_ns": 95,
+    "min_ns": 331,
+    "max_ns": 45208,
+    "p50_ns": 347,
+    "p95_ns": 402,
+    "p99_ns": 406,
+    "p99_9_ns": 435
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 1000000,
+      "mean_ns": 352,
+      "stddev_ns": 95,
+      "min_ns": 331,
+      "max_ns": 45208,
+      "p50_ns": 347,
+      "p95_ns": 402,
+      "p99_ns": 406,
+      "p99_9_ns": 435
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 1000000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307387895961169
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-16.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-16.json
@@ -1,0 +1,228 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 16,
+  "per_thread_samples": 100000,
+  "total_samples": 1600000,
+  "total_wall_time_ns": 79237272,
+  "throughput_ops_per_sec": 20192517.48091479,
+  "merged_samples": {
+    "n": 1600000,
+    "mean_ns": 525,
+    "stddev_ns": 35175,
+    "min_ns": 331,
+    "max_ns": 20018848,
+    "p50_ns": 421,
+    "p95_ns": 487,
+    "p99_ns": 500,
+    "p99_9_ns": 571
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 100000,
+      "mean_ns": 497,
+      "stddev_ns": 20428,
+      "min_ns": 355,
+      "max_ns": 6460354,
+      "p50_ns": 422,
+      "p95_ns": 489,
+      "p99_ns": 501,
+      "p99_9_ns": 584
+    },
+    {
+      "n": 100000,
+      "mean_ns": 429,
+      "stddev_ns": 97,
+      "min_ns": 353,
+      "max_ns": 12920,
+      "p50_ns": 421,
+      "p95_ns": 486,
+      "p99_ns": 500,
+      "p99_9_ns": 632
+    },
+    {
+      "n": 100000,
+      "mean_ns": 432,
+      "stddev_ns": 157,
+      "min_ns": 363,
+      "max_ns": 33875,
+      "p50_ns": 422,
+      "p95_ns": 490,
+      "p99_ns": 504,
+      "p99_9_ns": 574
+    },
+    {
+      "n": 100000,
+      "mean_ns": 698,
+      "stddev_ns": 61535,
+      "min_ns": 352,
+      "max_ns": 16685159,
+      "p50_ns": 421,
+      "p95_ns": 488,
+      "p99_ns": 501,
+      "p99_9_ns": 575
+    },
+    {
+      "n": 100000,
+      "mean_ns": 531,
+      "stddev_ns": 31664,
+      "min_ns": 351,
+      "max_ns": 10013557,
+      "p50_ns": 422,
+      "p95_ns": 488,
+      "p99_ns": 500,
+      "p99_9_ns": 532
+    },
+    {
+      "n": 100000,
+      "mean_ns": 430,
+      "stddev_ns": 142,
+      "min_ns": 353,
+      "max_ns": 29473,
+      "p50_ns": 421,
+      "p95_ns": 487,
+      "p99_ns": 499,
+      "p99_9_ns": 527
+    },
+    {
+      "n": 100000,
+      "mean_ns": 575,
+      "stddev_ns": 38520,
+      "min_ns": 341,
+      "max_ns": 10031822,
+      "p50_ns": 415,
+      "p95_ns": 485,
+      "p99_ns": 498,
+      "p99_9_ns": 532
+    },
+    {
+      "n": 100000,
+      "mean_ns": 792,
+      "stddev_ns": 73975,
+      "min_ns": 342,
+      "max_ns": 20015651,
+      "p50_ns": 420,
+      "p95_ns": 488,
+      "p99_ns": 499,
+      "p99_9_ns": 530
+    },
+    {
+      "n": 100000,
+      "mean_ns": 431,
+      "stddev_ns": 96,
+      "min_ns": 354,
+      "max_ns": 15062,
+      "p50_ns": 422,
+      "p95_ns": 488,
+      "p99_ns": 500,
+      "p99_9_ns": 530
+    },
+    {
+      "n": 100000,
+      "mean_ns": 551,
+      "stddev_ns": 34072,
+      "min_ns": 331,
+      "max_ns": 10015687,
+      "p50_ns": 418,
+      "p95_ns": 484,
+      "p99_ns": 499,
+      "p99_9_ns": 604
+    },
+    {
+      "n": 100000,
+      "mean_ns": 598,
+      "stddev_ns": 38255,
+      "min_ns": 354,
+      "max_ns": 10013869,
+      "p50_ns": 421,
+      "p95_ns": 487,
+      "p99_ns": 504,
+      "p99_9_ns": 600
+    },
+    {
+      "n": 100000,
+      "mean_ns": 418,
+      "stddev_ns": 108,
+      "min_ns": 340,
+      "max_ns": 15234,
+      "p50_ns": 420,
+      "p95_ns": 485,
+      "p99_ns": 498,
+      "p99_9_ns": 548
+    },
+    {
+      "n": 100000,
+      "mean_ns": 419,
+      "stddev_ns": 145,
+      "min_ns": 333,
+      "max_ns": 33862,
+      "p50_ns": 420,
+      "p95_ns": 485,
+      "p99_ns": 498,
+      "p99_9_ns": 536
+    },
+    {
+      "n": 100000,
+      "mean_ns": 430,
+      "stddev_ns": 138,
+      "min_ns": 353,
+      "max_ns": 22312,
+      "p50_ns": 421,
+      "p95_ns": 487,
+      "p99_ns": 499,
+      "p99_9_ns": 568
+    },
+    {
+      "n": 100000,
+      "mean_ns": 731,
+      "stddev_ns": 70780,
+      "min_ns": 352,
+      "max_ns": 20018848,
+      "p50_ns": 422,
+      "p95_ns": 488,
+      "p99_ns": 500,
+      "p99_9_ns": 570
+    },
+    {
+      "n": 100000,
+      "mean_ns": 432,
+      "stddev_ns": 105,
+      "min_ns": 344,
+      "max_ns": 22453,
+      "p50_ns": 422,
+      "p95_ns": 490,
+      "p99_ns": 505,
+      "p99_9_ns": 578
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 100000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307388486643803
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-2.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-2.json
@@ -1,0 +1,74 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 2,
+  "per_thread_samples": 500000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 177558473,
+  "throughput_ops_per_sec": 5631947.510609646,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 355,
+    "stddev_ns": 94,
+    "min_ns": 331,
+    "max_ns": 34158,
+    "p50_ns": 348,
+    "p95_ns": 403,
+    "p99_ns": 406,
+    "p99_9_ns": 473
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 500000,
+      "mean_ns": 355,
+      "stddev_ns": 83,
+      "min_ns": 331,
+      "max_ns": 20893,
+      "p50_ns": 348,
+      "p95_ns": 403,
+      "p99_ns": 406,
+      "p99_9_ns": 470
+    },
+    {
+      "n": 500000,
+      "mean_ns": 354,
+      "stddev_ns": 104,
+      "min_ns": 332,
+      "max_ns": 34158,
+      "p50_ns": 348,
+      "p95_ns": 402,
+      "p99_ns": 406,
+      "p99_9_ns": 476
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 500000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307388108430873
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-4.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-4.json
@@ -1,0 +1,96 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 4,
+  "per_thread_samples": 250000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 89385832,
+  "throughput_ops_per_sec": 11187455.300522346,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 357,
+    "stddev_ns": 103,
+    "min_ns": 340,
+    "max_ns": 37415,
+    "p50_ns": 349,
+    "p95_ns": 403,
+    "p99_ns": 406,
+    "p99_9_ns": 435
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 250000,
+      "mean_ns": 356,
+      "stddev_ns": 87,
+      "min_ns": 340,
+      "max_ns": 23023,
+      "p50_ns": 349,
+      "p95_ns": 402,
+      "p99_ns": 406,
+      "p99_9_ns": 435
+    },
+    {
+      "n": 250000,
+      "mean_ns": 357,
+      "stddev_ns": 120,
+      "min_ns": 340,
+      "max_ns": 37415,
+      "p50_ns": 349,
+      "p95_ns": 403,
+      "p99_ns": 406,
+      "p99_9_ns": 433
+    },
+    {
+      "n": 250000,
+      "mean_ns": 357,
+      "stddev_ns": 101,
+      "min_ns": 340,
+      "max_ns": 27394,
+      "p50_ns": 349,
+      "p95_ns": 403,
+      "p99_ns": 406,
+      "p99_9_ns": 440
+    },
+    {
+      "n": 250000,
+      "mean_ns": 357,
+      "stddev_ns": 100,
+      "min_ns": 341,
+      "max_ns": 25032,
+      "p50_ns": 349,
+      "p95_ns": 403,
+      "p99_ns": 407,
+      "p99_9_ns": 434
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 250000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307388227676274
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-8.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L0-concurrent-8.json
@@ -1,0 +1,140 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 8,
+  "per_thread_samples": 125000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 76010919,
+  "throughput_ops_per_sec": 13156004.599812824,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 459,
+    "stddev_ns": 21165,
+    "min_ns": 332,
+    "max_ns": 10017577,
+    "p50_ns": 418,
+    "p95_ns": 487,
+    "p99_ns": 500,
+    "p99_9_ns": 593
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 125000,
+      "mean_ns": 434,
+      "stddev_ns": 475,
+      "min_ns": 354,
+      "max_ns": 164430,
+      "p50_ns": 421,
+      "p95_ns": 490,
+      "p99_ns": 506,
+      "p99_9_ns": 646
+    },
+    {
+      "n": 125000,
+      "mean_ns": 431,
+      "stddev_ns": 107,
+      "min_ns": 359,
+      "max_ns": 18628,
+      "p50_ns": 421,
+      "p95_ns": 489,
+      "p99_ns": 505,
+      "p99_9_ns": 629
+    },
+    {
+      "n": 125000,
+      "mean_ns": 553,
+      "stddev_ns": 40068,
+      "min_ns": 333,
+      "max_ns": 10017577,
+      "p50_ns": 404,
+      "p95_ns": 485,
+      "p99_ns": 500,
+      "p99_9_ns": 581
+    },
+    {
+      "n": 125000,
+      "mean_ns": 430,
+      "stddev_ns": 82,
+      "min_ns": 355,
+      "max_ns": 11941,
+      "p50_ns": 421,
+      "p95_ns": 488,
+      "p99_ns": 499,
+      "p99_9_ns": 528
+    },
+    {
+      "n": 125000,
+      "mean_ns": 608,
+      "stddev_ns": 44474,
+      "min_ns": 332,
+      "max_ns": 10014683,
+      "p50_ns": 407,
+      "p95_ns": 480,
+      "p99_ns": 495,
+      "p99_9_ns": 548
+    },
+    {
+      "n": 125000,
+      "mean_ns": 357,
+      "stddev_ns": 98,
+      "min_ns": 341,
+      "max_ns": 20960,
+      "p50_ns": 349,
+      "p95_ns": 403,
+      "p99_ns": 406,
+      "p99_9_ns": 460
+    },
+    {
+      "n": 125000,
+      "mean_ns": 431,
+      "stddev_ns": 112,
+      "min_ns": 343,
+      "max_ns": 19094,
+      "p50_ns": 421,
+      "p95_ns": 489,
+      "p99_ns": 505,
+      "p99_9_ns": 637
+    },
+    {
+      "n": 125000,
+      "mean_ns": 430,
+      "stddev_ns": 112,
+      "min_ns": 351,
+      "max_ns": 19160,
+      "p50_ns": 421,
+      "p95_ns": 488,
+      "p99_ns": 499,
+      "p99_9_ns": 530
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 125000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307388336377733
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L0.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L0.json
@@ -1,0 +1,45 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "methodology": {
+    "warmup_iterations": 100000,
+    "measure_iterations": 1000000,
+    "single_threaded": true,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "L0 measures the full aps_check Allow pipeline. Single thread, 1024-entry pool of pre-finalized actions with incrementing sequence_ids; authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow. Earlier L0 result from commit 913cb12 used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N — same BLAKE3 floor, but artifact label did not match measurement. Concurrent L0-concurrent-1.json uses the same corrected methodology by construction."
+  },
+  "samples": {
+    "n": 1000000,
+    "mean_ns": 352,
+    "stddev_ns": 93,
+    "min_ns": 330,
+    "max_ns": 55518,
+    "p50_ns": 347,
+    "p95_ns": 402,
+    "p99_ns": 405,
+    "p99_9_ns": 431
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307386954474991
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-1.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-1.json
@@ -1,0 +1,63 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 1,
+  "per_thread_samples": 1000000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 323161897,
+  "throughput_ops_per_sec": 3094424.2167262686,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 323,
+    "stddev_ns": 95,
+    "min_ns": 303,
+    "max_ns": 38494,
+    "p50_ns": 319,
+    "p95_ns": 368,
+    "p99_ns": 371,
+    "p99_9_ns": 388
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 1000000,
+      "mean_ns": 323,
+      "stddev_ns": 95,
+      "min_ns": 303,
+      "max_ns": 38494,
+      "p50_ns": 319,
+      "p95_ns": 368,
+      "p99_ns": 371,
+      "p99_9_ns": 388
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 1000000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307388933926005
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-16.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-16.json
@@ -1,0 +1,228 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 16,
+  "per_thread_samples": 100000,
+  "total_samples": 1600000,
+  "total_wall_time_ns": 69719078,
+  "throughput_ops_per_sec": 22949242.099845324,
+  "merged_samples": {
+    "n": 1600000,
+    "mean_ns": 562,
+    "stddev_ns": 47399,
+    "min_ns": 305,
+    "max_ns": 20019991,
+    "p50_ns": 388,
+    "p95_ns": 448,
+    "p99_ns": 461,
+    "p99_9_ns": 489
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 100000,
+      "mean_ns": 596,
+      "stddev_ns": 44784,
+      "min_ns": 315,
+      "max_ns": 10015722,
+      "p50_ns": 389,
+      "p95_ns": 450,
+      "p99_ns": 462,
+      "p99_9_ns": 488
+    },
+    {
+      "n": 100000,
+      "mean_ns": 670,
+      "stddev_ns": 50820,
+      "min_ns": 332,
+      "max_ns": 10026795,
+      "p50_ns": 389,
+      "p95_ns": 443,
+      "p99_ns": 459,
+      "p99_9_ns": 488
+    },
+    {
+      "n": 100000,
+      "mean_ns": 697,
+      "stddev_ns": 70769,
+      "min_ns": 321,
+      "max_ns": 20014811,
+      "p50_ns": 390,
+      "p95_ns": 450,
+      "p99_ns": 463,
+      "p99_9_ns": 491
+    },
+    {
+      "n": 100000,
+      "mean_ns": 696,
+      "stddev_ns": 70787,
+      "min_ns": 318,
+      "max_ns": 20019991,
+      "p50_ns": 389,
+      "p95_ns": 449,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 397,
+      "stddev_ns": 97,
+      "min_ns": 325,
+      "max_ns": 15279,
+      "p50_ns": 390,
+      "p95_ns": 450,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 435,
+      "stddev_ns": 12476,
+      "min_ns": 326,
+      "max_ns": 3945563,
+      "p50_ns": 389,
+      "p95_ns": 448,
+      "p99_ns": 461,
+      "p99_9_ns": 491
+    },
+    {
+      "n": 100000,
+      "mean_ns": 627,
+      "stddev_ns": 64328,
+      "min_ns": 312,
+      "max_ns": 20013570,
+      "p50_ns": 387,
+      "p95_ns": 449,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 684,
+      "stddev_ns": 70779,
+      "min_ns": 313,
+      "max_ns": 20018102,
+      "p50_ns": 386,
+      "p95_ns": 447,
+      "p99_ns": 460,
+      "p99_9_ns": 487
+    },
+    {
+      "n": 100000,
+      "mean_ns": 597,
+      "stddev_ns": 44778,
+      "min_ns": 321,
+      "max_ns": 10014030,
+      "p50_ns": 389,
+      "p95_ns": 452,
+      "p99_ns": 464,
+      "p99_9_ns": 492
+    },
+    {
+      "n": 100000,
+      "mean_ns": 533,
+      "stddev_ns": 33865,
+      "min_ns": 320,
+      "max_ns": 10014060,
+      "p50_ns": 389,
+      "p95_ns": 446,
+      "p99_ns": 461,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 427,
+      "stddev_ns": 23924,
+      "min_ns": 311,
+      "max_ns": 7565797,
+      "p50_ns": 321,
+      "p95_ns": 406,
+      "p99_ns": 453,
+      "p99_9_ns": 478
+    },
+    {
+      "n": 100000,
+      "mean_ns": 596,
+      "stddev_ns": 44786,
+      "min_ns": 318,
+      "max_ns": 10015847,
+      "p50_ns": 390,
+      "p95_ns": 449,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 535,
+      "stddev_ns": 34102,
+      "min_ns": 320,
+      "max_ns": 10027162,
+      "p50_ns": 388,
+      "p95_ns": 450,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 532,
+      "stddev_ns": 33732,
+      "min_ns": 325,
+      "max_ns": 10018312,
+      "p50_ns": 388,
+      "p95_ns": 449,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 396,
+      "stddev_ns": 114,
+      "min_ns": 322,
+      "max_ns": 24588,
+      "p50_ns": 389,
+      "p95_ns": 449,
+      "p99_ns": 461,
+      "p99_9_ns": 487
+    },
+    {
+      "n": 100000,
+      "mean_ns": 570,
+      "stddev_ns": 63287,
+      "min_ns": 305,
+      "max_ns": 20013652,
+      "p50_ns": 380,
+      "p95_ns": 444,
+      "p99_ns": 460,
+      "p99_9_ns": 490
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 100000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307389478814405
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-2.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-2.json
@@ -1,0 +1,74 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 2,
+  "per_thread_samples": 500000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 163278788,
+  "throughput_ops_per_sec": 6124494.260699681,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 326,
+    "stddev_ns": 80,
+    "min_ns": 303,
+    "max_ns": 21906,
+    "p50_ns": 319,
+    "p95_ns": 369,
+    "p99_ns": 372,
+    "p99_9_ns": 424
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 500000,
+      "mean_ns": 326,
+      "stddev_ns": 76,
+      "min_ns": 303,
+      "max_ns": 19620,
+      "p50_ns": 319,
+      "p95_ns": 369,
+      "p99_ns": 372,
+      "p99_9_ns": 424
+    },
+    {
+      "n": 500000,
+      "mean_ns": 325,
+      "stddev_ns": 84,
+      "min_ns": 304,
+      "max_ns": 21906,
+      "p50_ns": 319,
+      "p95_ns": 369,
+      "p99_ns": 372,
+      "p99_9_ns": 424
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 500000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307389131376021
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-4.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-4.json
@@ -1,0 +1,96 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 4,
+  "per_thread_samples": 250000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 98932860,
+  "throughput_ops_per_sec": 10107865.071322108,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 361,
+    "stddev_ns": 108,
+    "min_ns": 311,
+    "max_ns": 31531,
+    "p50_ns": 370,
+    "p95_ns": 440,
+    "p99_ns": 458,
+    "p99_9_ns": 485
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 250000,
+      "mean_ns": 326,
+      "stddev_ns": 109,
+      "min_ns": 311,
+      "max_ns": 31531,
+      "p50_ns": 320,
+      "p95_ns": 369,
+      "p99_ns": 372,
+      "p99_9_ns": 390
+    },
+    {
+      "n": 250000,
+      "mean_ns": 395,
+      "stddev_ns": 126,
+      "min_ns": 318,
+      "max_ns": 31302,
+      "p50_ns": 388,
+      "p95_ns": 450,
+      "p99_ns": 462,
+      "p99_9_ns": 493
+    },
+    {
+      "n": 250000,
+      "mean_ns": 327,
+      "stddev_ns": 67,
+      "min_ns": 311,
+      "max_ns": 12392,
+      "p50_ns": 319,
+      "p95_ns": 369,
+      "p99_ns": 372,
+      "p99_9_ns": 387
+    },
+    {
+      "n": 250000,
+      "mean_ns": 395,
+      "stddev_ns": 100,
+      "min_ns": 312,
+      "max_ns": 19817,
+      "p50_ns": 388,
+      "p95_ns": 450,
+      "p99_ns": 463,
+      "p99_9_ns": 491
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 250000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307389263581730
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-8.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L1-concurrent-8.json
@@ -1,0 +1,140 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "concurrency_level": 8,
+  "per_thread_samples": 125000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 49686573,
+  "throughput_ops_per_sec": 20126161.649345387,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 396,
+    "stddev_ns": 109,
+    "min_ns": 313,
+    "max_ns": 35198,
+    "p50_ns": 389,
+    "p95_ns": 450,
+    "p99_ns": 462,
+    "p99_9_ns": 489
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 125000,
+      "mean_ns": 395,
+      "stddev_ns": 110,
+      "min_ns": 333,
+      "max_ns": 22723,
+      "p50_ns": 388,
+      "p95_ns": 446,
+      "p99_ns": 460,
+      "p99_9_ns": 488
+    },
+    {
+      "n": 125000,
+      "mean_ns": 397,
+      "stddev_ns": 138,
+      "min_ns": 327,
+      "max_ns": 35198,
+      "p50_ns": 389,
+      "p95_ns": 451,
+      "p99_ns": 463,
+      "p99_9_ns": 493
+    },
+    {
+      "n": 125000,
+      "mean_ns": 396,
+      "stddev_ns": 97,
+      "min_ns": 326,
+      "max_ns": 18855,
+      "p50_ns": 389,
+      "p95_ns": 450,
+      "p99_ns": 462,
+      "p99_9_ns": 489
+    },
+    {
+      "n": 125000,
+      "mean_ns": 396,
+      "stddev_ns": 96,
+      "min_ns": 324,
+      "max_ns": 21372,
+      "p50_ns": 389,
+      "p95_ns": 451,
+      "p99_ns": 463,
+      "p99_9_ns": 489
+    },
+    {
+      "n": 125000,
+      "mean_ns": 394,
+      "stddev_ns": 103,
+      "min_ns": 338,
+      "max_ns": 22492,
+      "p50_ns": 388,
+      "p95_ns": 446,
+      "p99_ns": 460,
+      "p99_9_ns": 485
+    },
+    {
+      "n": 125000,
+      "mean_ns": 396,
+      "stddev_ns": 108,
+      "min_ns": 314,
+      "max_ns": 19419,
+      "p50_ns": 389,
+      "p95_ns": 451,
+      "p99_ns": 462,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 125000,
+      "mean_ns": 397,
+      "stddev_ns": 120,
+      "min_ns": 321,
+      "max_ns": 29555,
+      "p50_ns": 389,
+      "p95_ns": 451,
+      "p99_ns": 463,
+      "p99_9_ns": 491
+    },
+    {
+      "n": 125000,
+      "mean_ns": 396,
+      "stddev_ns": 94,
+      "min_ns": 313,
+      "max_ns": 17890,
+      "p50_ns": 389,
+      "p95_ns": 450,
+      "p99_ns": 462,
+      "p99_9_ns": 488
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 125000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307389341236671
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L1.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L1.json
@@ -1,0 +1,45 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "aws-c7i-gp3",
+    "spec_section": "13.2",
+    "canonical": false,
+    "host": {
+      "cpu_brand": "Intel(R) Xeon(R) Platinum 8488C",
+      "cpu_arch": "x86_64",
+      "os_name": "Amazon Linux 2023.11.20260514",
+      "os_version": "6.18.25-57.109.amzn2023.x86_64",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memory_bytes": 16466726912
+    }
+  },
+  "methodology": {
+    "warmup_iterations": 100000,
+    "measure_iterations": 1000000,
+    "single_threaded": true,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "L1 measures the fast-reject path: the action's action_hash is tampered after finalize, so step 0 fails and aps_check returns immediately without touching the sink or advancing sequence/budget."
+  },
+  "samples": {
+    "n": 1000000,
+    "mean_ns": 323,
+    "stddev_ns": 487,
+    "min_ns": 303,
+    "max_ns": 422909,
+    "p50_ns": 318,
+    "p95_ns": 368,
+    "p99_ns": 371,
+    "p99_9_ns": 386
+  },
+  "run": {
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db",
+    "git_branch": "canonical-linux-infrastructure",
+    "timestamp_unix_ns": 1779307387419632795
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L2.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L2.json
@@ -3,16 +3,16 @@
   "description": "ts_sdk_napi_null_sink",
   "sink_mode": "Null",
   "environment": {
-    "label": "mac-apple-silicon",
-    "specSection": "13.3",
+    "label": "aws-c7i-gp3",
+    "specSection": "13.2",
     "canonical": false,
     "host": {
-      "cpuBrand": "unknown",
+      "cpuBrand": "Intel(R) Xeon(R) Platinum 8488C",
       "cpuArch": "x86_64",
-      "osName": "unknown",
-      "osVersion": "unknown",
+      "osName": "Amazon Linux 2023.11.20260514",
+      "osVersion": "6.18.25-57.109.amzn2023.x86_64",
       "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
-      "memoryBytes": 0
+      "memoryBytes": 16466726912
     }
   },
   "methodology": {

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L2.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L2.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L2",
+  "description": "ts_sdk_napi_null_sink",
+  "sink_mode": "Null",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "specSection": "13.3",
+    "canonical": false,
+    "host": {
+      "cpuBrand": "unknown",
+      "cpuArch": "x86_64",
+      "osName": "unknown",
+      "osVersion": "unknown",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memoryBytes": 0
+    }
+  },
+  "methodology": {
+    "sample_count": 100000,
+    "warmup_count": 2000,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink_buffer_capacity": null,
+    "sink_flush_interval_ms": null,
+    "sink_batch_size": null,
+    "sink_batch_window_ms": null,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 100000,
+    "meanNs": 5818,
+    "stddevNs": 1641,
+    "minNs": 5352,
+    "maxNs": 317463,
+    "p50Ns": 5712,
+    "p95Ns": 6624,
+    "p99Ns": 6999,
+    "p99_9Ns": 13707
+  },
+  "throughput_ops_per_sec": 168347.200734783,
+  "total_wall_time_ns": 594010471,
+  "run": {
+    "timestamp_unix_ns": "208298168910",
+    "node_version": "v24.15.0",
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db"
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L3a.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L3a.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L3a",
+  "description": "ts_sdk_napi_mode_a_memory_buffered",
+  "sink_mode": "ModeA",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "specSection": "13.3",
+    "canonical": false,
+    "host": {
+      "cpuBrand": "unknown",
+      "cpuArch": "x86_64",
+      "osName": "unknown",
+      "osVersion": "unknown",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memoryBytes": 0
+    }
+  },
+  "methodology": {
+    "sample_count": 50000,
+    "warmup_count": 2000,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "sink_buffer_capacity": 131072,
+    "sink_flush_interval_ms": 25,
+    "sink_batch_size": null,
+    "sink_batch_window_ms": null,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 50000,
+    "meanNs": 6016,
+    "stddevNs": 12534,
+    "minNs": 5379,
+    "maxNs": 898648,
+    "p50Ns": 5705,
+    "p95Ns": 6618,
+    "p99Ns": 6808,
+    "p99_9Ns": 17781
+  },
+  "throughput_ops_per_sec": 163333.46671144225,
+  "total_wall_time_ns": 306122199,
+  "run": {
+    "timestamp_unix_ns": "208651281337",
+    "node_version": "v24.15.0",
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db"
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L3a.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L3a.json
@@ -3,16 +3,16 @@
   "description": "ts_sdk_napi_mode_a_memory_buffered",
   "sink_mode": "ModeA",
   "environment": {
-    "label": "mac-apple-silicon",
-    "specSection": "13.3",
+    "label": "aws-c7i-gp3",
+    "specSection": "13.2",
     "canonical": false,
     "host": {
-      "cpuBrand": "unknown",
+      "cpuBrand": "Intel(R) Xeon(R) Platinum 8488C",
       "cpuArch": "x86_64",
-      "osName": "unknown",
-      "osVersion": "unknown",
+      "osName": "Amazon Linux 2023.11.20260514",
+      "osVersion": "6.18.25-57.109.amzn2023.x86_64",
       "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
-      "memoryBytes": 0
+      "memoryBytes": 16466726912
     }
   },
   "methodology": {

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L3b1.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L3b1.json
@@ -3,16 +3,16 @@
   "description": "ts_sdk_napi_mode_b1_blocking_group_commit",
   "sink_mode": "ModeB1",
   "environment": {
-    "label": "mac-apple-silicon",
-    "specSection": "13.3",
+    "label": "aws-c7i-gp3",
+    "specSection": "13.2",
     "canonical": false,
     "host": {
-      "cpuBrand": "unknown",
+      "cpuBrand": "Intel(R) Xeon(R) Platinum 8488C",
       "cpuArch": "x86_64",
-      "osName": "unknown",
-      "osVersion": "unknown",
+      "osName": "Amazon Linux 2023.11.20260514",
+      "osVersion": "6.18.25-57.109.amzn2023.x86_64",
       "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
-      "memoryBytes": 0
+      "memoryBytes": 16466726912
     }
   },
   "methodology": {

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L3b1.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L3b1.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L3b1",
+  "description": "ts_sdk_napi_mode_b1_blocking_group_commit",
+  "sink_mode": "ModeB1",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "specSection": "13.3",
+    "canonical": false,
+    "host": {
+      "cpuBrand": "unknown",
+      "cpuArch": "x86_64",
+      "osName": "unknown",
+      "osVersion": "unknown",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memoryBytes": 0
+    }
+  },
+  "methodology": {
+    "sample_count": 5000,
+    "warmup_count": 200,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "sink_buffer_capacity": 1024,
+    "sink_flush_interval_ms": null,
+    "sink_batch_size": 64,
+    "sink_batch_window_ms": 1,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 5000,
+    "meanNs": 1353629,
+    "stddevNs": 84100,
+    "minNs": 1095308,
+    "maxNs": 1741664,
+    "p50Ns": 1350839,
+    "p95Ns": 1501675,
+    "p99Ns": 1585468,
+    "p99_9Ns": 1700847
+  },
+  "throughput_ops_per_sec": 738.1389424724944,
+  "total_wall_time_ns": 6773792456,
+  "run": {
+    "timestamp_unix_ns": "215704014385",
+    "node_version": "v24.15.0",
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db"
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L3b2.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L3b2.json
@@ -3,16 +3,16 @@
   "description": "ts_sdk_napi_mode_b2_queued_group_commit",
   "sink_mode": "ModeB2",
   "environment": {
-    "label": "mac-apple-silicon",
-    "specSection": "13.3",
+    "label": "aws-c7i-gp3",
+    "specSection": "13.2",
     "canonical": false,
     "host": {
-      "cpuBrand": "unknown",
+      "cpuBrand": "Intel(R) Xeon(R) Platinum 8488C",
       "cpuArch": "x86_64",
-      "osName": "unknown",
-      "osVersion": "unknown",
+      "osName": "Amazon Linux 2023.11.20260514",
+      "osVersion": "6.18.25-57.109.amzn2023.x86_64",
       "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
-      "memoryBytes": 0
+      "memoryBytes": 16466726912
     }
   },
   "methodology": {

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L3b2.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L3b2.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L3b2",
+  "description": "ts_sdk_napi_mode_b2_queued_group_commit",
+  "sink_mode": "ModeB2",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "specSection": "13.3",
+    "canonical": false,
+    "host": {
+      "cpuBrand": "unknown",
+      "cpuArch": "x86_64",
+      "osName": "unknown",
+      "osVersion": "unknown",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memoryBytes": 0
+    }
+  },
+  "methodology": {
+    "sample_count": 50000,
+    "warmup_count": 2000,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "sink_buffer_capacity": 131072,
+    "sink_flush_interval_ms": null,
+    "sink_batch_size": 64,
+    "sink_batch_window_ms": 1,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 50000,
+    "meanNs": 6759,
+    "stddevNs": 2000,
+    "minNs": 5625,
+    "maxNs": 244138,
+    "p50Ns": 6669,
+    "p95Ns": 7774,
+    "p99Ns": 8545,
+    "p99_9Ns": 16480
+  },
+  "throughput_ops_per_sec": 145038.07416240548,
+  "total_wall_time_ns": 344737065,
+  "run": {
+    "timestamp_unix_ns": "216083228786",
+    "node_version": "v24.15.0",
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db"
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L4.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L4.json
@@ -6,16 +6,16 @@
   "http_method": "POST",
   "network_path": "loopback",
   "environment": {
-    "label": "mac-apple-silicon",
-    "specSection": "13.3",
+    "label": "aws-c7i-gp3",
+    "specSection": "13.2",
     "canonical": false,
     "host": {
-      "cpuBrand": "unknown",
+      "cpuBrand": "Intel(R) Xeon(R) Platinum 8488C",
       "cpuArch": "x86_64",
-      "osName": "unknown",
-      "osVersion": "unknown",
+      "osName": "Amazon Linux 2023.11.20260514",
+      "osVersion": "6.18.25-57.109.amzn2023.x86_64",
       "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
-      "memoryBytes": 0
+      "memoryBytes": 16466726912
     }
   },
   "methodology": {

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/L4.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/L4.json
@@ -1,0 +1,48 @@
+{
+  "benchmark": "L4",
+  "description": "gateway_bound_authorization_round_trip",
+  "gateway_endpoint": "http://localhost:3200/api/v1/evaluate",
+  "gateway_location": "aws-c7i-gp3",
+  "http_method": "POST",
+  "network_path": "loopback",
+  "environment": {
+    "label": "mac-apple-silicon",
+    "specSection": "13.3",
+    "canonical": false,
+    "host": {
+      "cpuBrand": "unknown",
+      "cpuArch": "x86_64",
+      "osName": "unknown",
+      "osVersion": "unknown",
+      "hostname": "ip-172-31-42-150.us-east-2.compute.internal",
+      "memoryBytes": 0
+    }
+  },
+  "methodology": {
+    "sample_count": 1000,
+    "warmup_count": 100,
+    "single_threaded": true,
+    "sequential": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "includes_network": false,
+    "notes": "TS fetch() to gateway /api/v1/evaluate. Each call lands a permit row in policy_evaluations + mints an evaluation receipt. Body is the same on every iteration; cache effects are exercised by warmup."
+  },
+  "samples": {
+    "n": 1000,
+    "minNs": 543505,
+    "maxNs": 13867765,
+    "p50Ns": 1071695,
+    "p95Ns": 1620625,
+    "p99Ns": 6077454,
+    "p99_9Ns": 13867765
+  },
+  "throughput_ops_per_sec": 830.3257419615009,
+  "total_wall_time_ns": 1204346619,
+  "run": {
+    "timestamp_unix_ns": "222305756133",
+    "node_version": "v24.15.0",
+    "git_commit": "0998f3a619ec101231fb6dd0fed9b0e4a35647db"
+  }
+}

--- a/benchmarks/prototype-1/results/aws-c7i-gp3/env_capture.json
+++ b/benchmarks/prototype-1/results/aws-c7i-gp3/env_capture.json
@@ -1,0 +1,14 @@
+{
+  "environment_tag": "aws-c7i-gp3",
+  "cpu_model": "Intel(R) Xeon(R) Platinum 8488C",
+  "microcode": "0x2b000661",
+  "kernel": "Linux ip-172-31-42-150.us-east-2.compute.internal 6.18.25-57.109.amzn2023.x86_64 #2 SMP PREEMPT_DYNAMIC Thu May 14 12:23:59 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+  "glibc": "glibc 2.34",
+  "node_version": "v24.15.0",
+  "rust_version": "rustc 1.95.0 (59807616e 2026-04-14)",
+  "ram_kb": 16080788,
+  "hypervisor": "none",
+  "filesystem_type": "xfs",
+  "thermal_zone0_milli_c": null,
+  "timestamp_utc": "20260520T200156Z"
+}

--- a/benchmarks/prototype-1/scripts/run-canonical.sh
+++ b/benchmarks/prototype-1/scripts/run-canonical.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+# Canonical-measurement runner for APS Runtime Passport spec §13.1 (bare-metal
+# Linux x86_64) and §13.2 (AWS c7i.2xlarge).
+#
+# Run unattended on a fresh Linux box. Installs prerequisites, builds the
+# verifier crate and TS SDK, runs L0/L1/L2/L3/L4 benchmarks, captures
+# environment metadata, tars the results, prints the tar path.
+#
+# Env-tag string convention matches stream-C's configs/ and the new
+# env_capture::capture() labels:
+#   aws-c7i-gp3        for AWS EC2 c7i.2xlarge
+#   bare-metal-linux   for bare-metal Linux x86_64
+#
+# The aps-bench Rust binary detects the environment internally via
+# /sys/class/dmi and IMDSv2, so the bash side mostly logs and chooses
+# whether to run L4.
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------
+# Configuration
+# ----------------------------------------------------------------------
+
+readonly REPO_URL="${APS_REPO_URL:-https://github.com/aeoess/agent-passport-system.git}"
+readonly REPO_REF="${APS_REPO_REF:-main}"
+readonly WORK_DIR="${APS_WORK_DIR:-$HOME/aps-canonical-run}"
+readonly GATEWAY_PORT="${APS_GATEWAY_PORT:-3200}"
+readonly GATEWAY_REPO_URL="${APS_GATEWAY_REPO_URL:-}"  # optional; if unset, L4 is skipped
+readonly L4_SAMPLE_COUNT="${L4_SAMPLE_COUNT:-1000}"
+readonly L4_WARMUP_COUNT="${L4_WARMUP_COUNT:-100}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+readonly TIMESTAMP
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*" >&2
+}
+
+die() {
+    log "FATAL: $*"
+    exit 1
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+# ----------------------------------------------------------------------
+# Environment detection (bash side; used for logging + L4 gating only).
+# Source of truth for the result-JSON label is the Rust binary's own
+# env_capture::capture(), which writes the label into each output file.
+# ----------------------------------------------------------------------
+
+detect_environment_tag() {
+    local sys_vendor=""
+    local hypervisor=""
+    local instance_type=""
+
+    if [[ -r /sys/class/dmi/id/sys_vendor ]]; then
+        sys_vendor="$(tr -d '\n' < /sys/class/dmi/id/sys_vendor)"
+    fi
+    if [[ -r /sys/hypervisor/type ]]; then
+        hypervisor="$(tr -d '\n' < /sys/hypervisor/type)"
+    fi
+
+    if [[ "$sys_vendor" == "Amazon EC2" ]]; then
+        # IMDSv2 instance-type lookup. Required to be c7i.2xlarge for §13.2.
+        local token
+        token="$(curl -fsS -X PUT \
+            -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
+            http://169.254.169.254/latest/api/token 2>/dev/null || true)"
+        if [[ -z "$token" ]]; then
+            die "IMDSv2 token request failed on EC2 host"
+        fi
+        instance_type="$(curl -fsS \
+            -H "X-aws-ec2-metadata-token: $token" \
+            http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null || true)"
+        if [[ "$instance_type" != "c7i.2xlarge" ]]; then
+            die "§13.2 requires c7i.2xlarge; IMDSv2 reports: $instance_type"
+        fi
+        echo "aws-c7i-gp3"
+        return
+    fi
+
+    if [[ -n "$hypervisor" ]] && [[ "$hypervisor" != "none" ]]; then
+        die "hypervisor detected ($hypervisor); §13.1 requires bare metal"
+    fi
+
+    echo "bare-metal-linux"
+}
+
+# ----------------------------------------------------------------------
+# Prerequisite install
+# ----------------------------------------------------------------------
+
+install_prereqs() {
+    log "installing prerequisites"
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential pkg-config libssl-dev sqlite3 libsqlite3-dev \
+            git curl ca-certificates jq
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y gcc gcc-c++ make pkgconf-pkg-config openssl-devel \
+            sqlite sqlite-devel git curl jq tar gzip
+    elif command -v yum >/dev/null 2>&1; then
+        sudo yum install -y gcc gcc-c++ make pkgconfig openssl-devel \
+            sqlite sqlite-devel git curl jq tar gzip
+    else
+        die "no supported package manager found (apt-get, dnf, yum)"
+    fi
+
+    if ! command -v rustc >/dev/null 2>&1; then
+        log "installing Rust via rustup"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable
+        # shellcheck disable=SC1091
+        source "$HOME/.cargo/env"
+    fi
+    require_cmd cargo
+    require_cmd rustc
+
+    if ! command -v node >/dev/null 2>&1; then
+        log "installing Node 24.x via NodeSource"
+        if command -v apt-get >/dev/null 2>&1; then
+            curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+        elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+            curl -fsSL https://rpm.nodesource.com/setup_24.x | sudo -E bash -
+            if command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y nodejs
+            else
+                sudo yum install -y nodejs
+            fi
+        fi
+    fi
+    require_cmd node
+    require_cmd npm
+}
+
+# ----------------------------------------------------------------------
+# Repo clone
+# ----------------------------------------------------------------------
+
+clone_repo() {
+    local repo_dir="$1"
+    if [[ -d "$repo_dir/.git" ]]; then
+        log "repo already cloned at $repo_dir, fetching latest"
+        git -C "$repo_dir" fetch origin --prune
+        git -C "$repo_dir" checkout "$REPO_REF"
+        git -C "$repo_dir" reset --hard "origin/$REPO_REF"
+    else
+        log "cloning $REPO_URL at $REPO_REF into $repo_dir"
+        git clone --depth 50 "$REPO_URL" "$repo_dir"
+        git -C "$repo_dir" fetch origin "$REPO_REF"
+        git -C "$repo_dir" checkout "$REPO_REF"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Environment capture (system metadata supplementing aps-bench's own)
+# ----------------------------------------------------------------------
+
+write_env_capture() {
+    local out_path="$1"
+    local env_tag="$2"
+
+    local cpu_model microcode kernel glibc node_ver rust_ver ram_kb hyper fs_type thermal
+    cpu_model="$(grep -m1 'model name' /proc/cpuinfo | sed 's/.*: //')"
+    microcode="$(grep -m1 'microcode' /proc/cpuinfo | sed 's/.*: //' || echo 'unknown')"
+    kernel="$(uname -a)"
+    glibc="$(getconf GNU_LIBC_VERSION 2>/dev/null || echo 'unknown')"
+    node_ver="$(node --version)"
+    rust_ver="$(rustc --version)"
+    ram_kb="$(grep -m1 MemTotal /proc/meminfo | awk '{print $2}')"
+    hyper="$(cat /sys/hypervisor/type 2>/dev/null || echo 'none')"
+    fs_type="$(stat -f -c %T . 2>/dev/null || echo 'unknown')"
+    thermal=""
+    if [[ -r /sys/class/thermal/thermal_zone0/temp ]]; then
+        thermal="$(cat /sys/class/thermal/thermal_zone0/temp)"
+    fi
+
+    jq -n \
+        --arg env_tag "$env_tag" \
+        --arg cpu "$cpu_model" \
+        --arg microcode "$microcode" \
+        --arg kernel "$kernel" \
+        --arg glibc "$glibc" \
+        --arg node_ver "$node_ver" \
+        --arg rust_ver "$rust_ver" \
+        --arg ram_kb "$ram_kb" \
+        --arg hyper "$hyper" \
+        --arg fs_type "$fs_type" \
+        --arg thermal "$thermal" \
+        --arg ts "$TIMESTAMP" \
+        '{
+            environment_tag: $env_tag,
+            cpu_model: $cpu,
+            microcode: $microcode,
+            kernel: $kernel,
+            glibc: $glibc,
+            node_version: $node_ver,
+            rust_version: $rust_ver,
+            ram_kb: ($ram_kb | tonumber),
+            hypervisor: $hyper,
+            filesystem_type: $fs_type,
+            thermal_zone0_milli_c: (if $thermal == "" then null else ($thermal | tonumber) end),
+            timestamp_utc: $ts
+        }' > "$out_path"
+}
+
+# ----------------------------------------------------------------------
+# Build steps
+# ----------------------------------------------------------------------
+
+build_rust() {
+    local repo_dir="$1"
+    log "cargo build --release for verifier + benchmark harness"
+    ( cd "$repo_dir" && cargo build --release -p aps-verifier-core )
+    ( cd "$repo_dir" && cargo build --release -p aps-bench-prototype-1 )
+}
+
+build_ts_sdk() {
+    local repo_dir="$1"
+    log "npm install + napi build for aps-sdk-runtime"
+    ( cd "$repo_dir/packages/aps-sdk-runtime" && npm install --no-audit --no-fund )
+    ( cd "$repo_dir/packages/aps-sdk-runtime" && npm run build )
+}
+
+# ----------------------------------------------------------------------
+# Benchmark execution. aps-bench uses positional args: L0 or L1, with an
+# optional --concurrent flag for the sweep. No --config flag exists; the
+# binary detects its environment via env_capture::capture().
+# ----------------------------------------------------------------------
+
+run_l0_l1() {
+    local repo_dir="$1"
+    log "running L0 (single-thread)"
+    ( cd "$repo_dir" && cargo run --release --bin aps-bench -- L0 )
+    log "running L1 (single-thread)"
+    ( cd "$repo_dir" && cargo run --release --bin aps-bench -- L1 )
+    log "running L0 concurrency sweep N=1..16"
+    ( cd "$repo_dir" && cargo run --release --bin aps-bench -- L0 --concurrent )
+    log "running L1 concurrency sweep N=1..16"
+    ( cd "$repo_dir" && cargo run --release --bin aps-bench -- L1 --concurrent )
+}
+
+run_l2_l3() {
+    local repo_dir="$1"
+    local env_tag="$2"
+    log "running L2/L3a/L3b1/L3b2 via TS bench runner"
+    ( cd "$repo_dir/packages/aps-sdk-runtime" \
+      && APS_RESULTS_ENV_TAG="$env_tag" npx tsx benchmarks/runner.ts )
+}
+
+run_l4() {
+    local repo_dir="$1"
+    local env_tag="$2"
+    local gateway_repo_dir="$3"
+
+    log "starting local gateway on :$GATEWAY_PORT"
+    (   cd "$gateway_repo_dir" \
+        && PORT="$GATEWAY_PORT" npx tsx src/server.ts \
+            > /tmp/gateway-canonical.log 2>&1 & echo $! > /tmp/gateway-canonical.pid )
+    sleep 2
+
+    local healthy=0
+    for _ in $(seq 1 30); do
+        if curl -fs -m 2 "http://localhost:$GATEWAY_PORT/healthz" >/dev/null 2>&1; then
+            healthy=1
+            break
+        fi
+        sleep 1
+    done
+    if [[ "$healthy" != "1" ]]; then
+        die "gateway never became healthy on :$GATEWAY_PORT (see /tmp/gateway-canonical.log)"
+    fi
+
+    log "seeding L4 test tenant"
+    # shellcheck disable=SC1091
+    L4_DB_PATH="$gateway_repo_dir/gateway.db" \
+    L4_GATEWAY_URL="http://localhost:$GATEWAY_PORT" \
+        source "$repo_dir/benchmarks/prototype-1/scripts/seed-l4-tenant.sh"
+    # seed-l4-tenant.sh exports L4_API_KEY, L4_TENANT_ID, L4_AGENT_ID
+
+    log "running L4 benchmark (sample=$L4_SAMPLE_COUNT warmup=$L4_WARMUP_COUNT)"
+    (   cd "$repo_dir/packages/aps-sdk-runtime" \
+      && L4_API_KEY="$L4_API_KEY" \
+         L4_GATEWAY_URL="http://localhost:$GATEWAY_PORT" \
+         L4_GATEWAY_LOC="$env_tag" \
+         L4_AGENT_ID="$L4_AGENT_ID" \
+         L4_SAMPLE_COUNT="$L4_SAMPLE_COUNT" \
+         L4_WARMUP_COUNT="$L4_WARMUP_COUNT" \
+         APS_RESULTS_ENV_TAG="$env_tag" \
+         npx tsx benchmarks/l4-runner.ts )
+}
+
+cleanup_l4() {
+    local gateway_repo_dir="$1"
+    local tenant_name="${L4_TENANT_NAME:-l4-bench}"
+
+    if [[ -f /tmp/gateway-canonical.pid ]]; then
+        local pid
+        pid="$(cat /tmp/gateway-canonical.pid)"
+        if kill -0 "$pid" 2>/dev/null; then
+            log "stopping local gateway pid=$pid"
+            kill "$pid" || true
+            sleep 1
+        fi
+        rm -f /tmp/gateway-canonical.pid
+    fi
+
+    if [[ -f "$gateway_repo_dir/gateway.db" ]]; then
+        log "cleaning L4 test rows from gateway.db"
+        sqlite3 "$gateway_repo_dir/gateway.db" \
+            "DELETE FROM tenants WHERE name='$tenant_name';
+             DELETE FROM agents WHERE agent_id='l4-bench-agent';
+             DELETE FROM delegations WHERE parent_agent_id='l4-bench-agent';" \
+            || true
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Schema validation
+# ----------------------------------------------------------------------
+
+validate_schemas() {
+    local results_dir="$1"
+    local errors=0
+    for f in L0.json L1.json L2.json L3a.json L3b1.json L3b2.json L4.json; do
+        if [[ ! -f "$results_dir/$f" ]]; then
+            log "schema validation: missing $f"
+            errors=$((errors+1))
+        fi
+    done
+    if [[ ! -f "$results_dir/env_capture.json" ]]; then
+        log "schema validation: missing env_capture.json"
+        errors=$((errors+1))
+    fi
+    if [[ $errors -gt 0 ]]; then
+        die "schema validation failed: $errors missing file(s)"
+    fi
+    log "schema validation OK"
+}
+
+# ----------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------
+
+main() {
+    require_cmd date
+    require_cmd uname
+
+    log "APS canonical-measurement runner starting"
+
+    install_prereqs
+    require_cmd jq
+    require_cmd git
+
+    local env_tag
+    env_tag="$(detect_environment_tag)"
+    log "environment-tag = $env_tag"
+
+    mkdir -p "$WORK_DIR"
+    local repo_dir="$WORK_DIR/agent-passport-system"
+    clone_repo "$repo_dir"
+
+    local results_dir="$repo_dir/benchmarks/prototype-1/results/$env_tag"
+    mkdir -p "$results_dir"
+
+    write_env_capture "$results_dir/env_capture.json" "$env_tag"
+
+    build_rust "$repo_dir"
+    build_ts_sdk "$repo_dir"
+
+    run_l0_l1 "$repo_dir"
+    run_l2_l3 "$repo_dir" "$env_tag"
+
+    if [[ -n "$GATEWAY_REPO_URL" ]]; then
+        local gateway_repo_dir
+        if [[ "$GATEWAY_REPO_URL" =~ ^file:// ]]; then
+            gateway_repo_dir="${GATEWAY_REPO_URL#file://}"
+        else
+            gateway_repo_dir="$WORK_DIR/aeoess-gateway"
+            if [[ ! -d "$gateway_repo_dir/.git" ]]; then
+                log "cloning gateway repo for L4"
+                git clone --depth 1 "$GATEWAY_REPO_URL" "$gateway_repo_dir"
+            fi
+        fi
+        if [[ ! -d "$gateway_repo_dir/node_modules" ]]; then
+            log "installing gateway npm dependencies"
+            ( cd "$gateway_repo_dir" && npm install --no-audit --no-fund )
+        fi
+        trap 'cleanup_l4 "'"$gateway_repo_dir"'"' EXIT
+        run_l4 "$repo_dir" "$env_tag" "$gateway_repo_dir"
+    else
+        log "APS_GATEWAY_REPO_URL not set; skipping L4. Set it to enable."
+    fi
+
+    validate_schemas "$results_dir"
+
+    local tar_path
+    tar_path="/tmp/aps-prototype-1-results-${env_tag}-${TIMESTAMP}.tar.gz"
+    tar -czf "$tar_path" -C "$repo_dir/benchmarks/prototype-1/results" "$env_tag"
+    log "results tar: $tar_path"
+    echo "$tar_path"
+}
+
+main "$@"

--- a/benchmarks/prototype-1/scripts/run-canonical.sh
+++ b/benchmarks/prototype-1/scripts/run-canonical.sh
@@ -104,11 +104,14 @@ install_prereqs() {
             build-essential pkg-config libssl-dev sqlite3 libsqlite3-dev \
             git curl ca-certificates jq
     elif command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y gcc gcc-c++ make pkgconf-pkg-config openssl-devel \
-            sqlite sqlite-devel git curl jq tar gzip
+        # curl is omitted: AL2023 ships curl-minimal preinstalled and the
+        # full curl package conflicts with it. curl-minimal is sufficient
+        # for the IMDSv2 + healthz probes we do.
+        sudo dnf install -y --allowerasing gcc gcc-c++ make pkgconf-pkg-config \
+            openssl-devel sqlite sqlite-devel git jq tar gzip
     elif command -v yum >/dev/null 2>&1; then
         sudo yum install -y gcc gcc-c++ make pkgconfig openssl-devel \
-            sqlite sqlite-devel git curl jq tar gzip
+            sqlite sqlite-devel git jq tar gzip
     else
         die "no supported package manager found (apt-get, dnf, yum)"
     fi

--- a/benchmarks/prototype-1/scripts/run-canonical.sh
+++ b/benchmarks/prototype-1/scripts/run-canonical.sh
@@ -26,8 +26,13 @@ readonly REPO_REF="${APS_REPO_REF:-main}"
 readonly WORK_DIR="${APS_WORK_DIR:-$HOME/aps-canonical-run}"
 readonly GATEWAY_PORT="${APS_GATEWAY_PORT:-3200}"
 readonly GATEWAY_REPO_URL="${APS_GATEWAY_REPO_URL:-}"  # optional; if unset, L4 is skipped
-readonly L4_SAMPLE_COUNT="${L4_SAMPLE_COUNT:-1000}"
-readonly L4_WARMUP_COUNT="${L4_WARMUP_COUNT:-100}"
+# L4_SAMPLE_COUNT and L4_WARMUP_COUNT are re-asserted as env-prefix
+# assignments to the l4-runner.ts subshell, so they must not be
+# readonly. export so the npx child still sees them if the env-prefix
+# block is ever dropped.
+L4_SAMPLE_COUNT="${L4_SAMPLE_COUNT:-1000}"
+L4_WARMUP_COUNT="${L4_WARMUP_COUNT:-100}"
+export L4_SAMPLE_COUNT L4_WARMUP_COUNT
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 readonly TIMESTAMP
 

--- a/benchmarks/prototype-1/scripts/run-canonical.sh
+++ b/benchmarks/prototype-1/scripts/run-canonical.sh
@@ -157,9 +157,8 @@ clone_repo() {
         git -C "$repo_dir" reset --hard "origin/$REPO_REF"
     else
         log "cloning $REPO_URL at $REPO_REF into $repo_dir"
-        git clone --depth 50 "$REPO_URL" "$repo_dir"
-        git -C "$repo_dir" fetch origin "$REPO_REF"
-        git -C "$repo_dir" checkout "$REPO_REF"
+        git clone --depth 50 --branch "$REPO_REF" --single-branch \
+            "$REPO_URL" "$repo_dir"
     fi
 }
 

--- a/benchmarks/prototype-1/scripts/seed-l4-tenant.sh
+++ b/benchmarks/prototype-1/scripts/seed-l4-tenant.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Seed a test tenant + agent + delegation for L4 benchmarking against a
+# local @aeoess/gateway. Sourced by run-canonical.sh; can also be sourced
+# standalone for ad-hoc L4 runs.
+#
+# Exports on success:
+#   L4_API_KEY     bearer token for the test tenant
+#   L4_TENANT_ID   tenant UUID
+#   L4_AGENT_ID    agent id (literal string "l4-bench-agent")
+#   L4_TENANT_NAME the tenant name (used by cleanup)
+#
+# Idempotency: if the tenant already exists, the script reuses it and
+# rotates the API key. Cleanup is the caller's responsibility (see
+# cleanup_l4 in run-canonical.sh).
+
+set -euo pipefail
+
+readonly GATEWAY_URL="${L4_GATEWAY_URL:-http://localhost:3200}"
+export L4_TENANT_NAME="${L4_TENANT_NAME:-l4-bench}"
+export L4_AGENT_ID="${L4_AGENT_ID:-l4-bench-agent}"
+readonly EMAIL="${L4_EMAIL:-l4-bench@local.test}"
+readonly SCOPE="${L4_SCOPE:-read:customer}"
+readonly DB_PATH="${L4_DB_PATH:-$HOME/aps-canonical-run/aeoess-gateway/gateway.db}"
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || { echo "missing: $1" >&2; exit 1; }
+}
+require_cmd curl
+require_cmd jq
+require_cmd sqlite3
+
+# Pre-clean: if a prior run left state, remove it so signup will succeed
+# (the gateway rejects email collisions on signup).
+if [[ -f "$DB_PATH" ]]; then
+    sqlite3 "$DB_PATH" "DELETE FROM tenants WHERE name='$L4_TENANT_NAME' OR email='$EMAIL';" || true
+fi
+
+signup_response="$(curl -fsS -X POST "$GATEWAY_URL/api/v1/signup" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"$L4_TENANT_NAME\",\"email\":\"$EMAIL\"}")"
+
+export L4_TENANT_ID
+L4_TENANT_ID="$(echo "$signup_response" | jq -r .tenant_id)"
+export L4_API_KEY
+L4_API_KEY="$(echo "$signup_response" | jq -r .api_key)"
+
+if [[ -z "$L4_TENANT_ID" ]] || [[ "$L4_TENANT_ID" == "null" ]]; then
+    echo "signup failed: $signup_response" >&2
+    exit 1
+fi
+
+# Upgrade plan to pro so the run doesn't hit the 1000/mo free-plan eval
+# cap. Direct DB write is fine here because the tenant is the test
+# fixture; the /signup endpoint deliberately only allows plan=free.
+sqlite3 "$DB_PATH" "UPDATE tenants SET plan='pro' WHERE id='$L4_TENANT_ID';"
+
+# Register agent. Ed25519 public key is a placeholder; the gateway does
+# not verify it during /evaluate, only stores it.
+curl -fsS -X POST "$GATEWAY_URL/api/v1/agents" \
+    -H "Authorization: Bearer $L4_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"agent_id\":\"$L4_AGENT_ID\",\"public_key\":\"ed25519:$(printf '0%.0s' {1..64})\"}" \
+    > /dev/null
+
+# Self-delegation with the required scope. No spend_limit so the
+# benchmark doesn't exhaust a budget over 1000 iterations.
+curl -fsS -X POST "$GATEWAY_URL/api/v1/delegations" \
+    -H "Authorization: Bearer $L4_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"parent_agent_id\":\"$L4_AGENT_ID\",\"child_agent_id\":\"$L4_AGENT_ID\",\"scope\":\"$SCOPE\"}" \
+    > /dev/null
+
+echo "L4 seed OK: tenant=$L4_TENANT_ID agent=$L4_AGENT_ID scope=$SCOPE" >&2

--- a/benchmarks/prototype-1/src/env_capture.rs
+++ b/benchmarks/prototype-1/src/env_capture.rs
@@ -1,10 +1,12 @@
 //! Host environment capture.
 //!
-//! Spec §13.3 (Apple Silicon developer reference). This narrow Stream
-//! C scope covers the pure-verifier benchmarks L0 and L1 only; the
-//! storage-config logging requirements of §13.4 are Mode-B-specific
-//! and land alongside the L3b1 / L3b2 benchmarks.
+//! Spec §13.1 (bare-metal Linux x86_64, canonical), §13.2 (AWS
+//! c7i.2xlarge cloud reference), §13.3 (Apple Silicon developer
+//! reference). Dispatches by target_os; on Linux, further dispatches
+//! by DMI sys_vendor to distinguish AWS EC2 from bare metal.
 
+#[cfg(target_os = "linux")]
+use std::fs;
 use std::process::Command;
 
 use serde::Serialize;
@@ -27,9 +29,29 @@ pub struct Host {
     pub memory_bytes: u64,
 }
 
-/// Capture the current host environment. macOS-only in this narrow
-/// scope; Linux and bare-metal capture land alongside the canonical
-/// benchmark target.
+/// Unified entry point. Picks the right capture function based on
+/// target_os and (on linux) the DMI sys_vendor.
+pub fn capture() -> EnvironmentSnapshot {
+    #[cfg(target_os = "macos")]
+    {
+        capture_mac_apple_silicon()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let sys_vendor = read_trim("/sys/class/dmi/id/sys_vendor");
+        if sys_vendor == "Amazon EC2" {
+            capture_aws_c7i()
+        } else {
+            capture_linux_baremetal()
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        compile_error!("env_capture: target_os not supported (need macos or linux)");
+    }
+}
+
+/// macOS path (Apple M-series). §13.3 developer reference.
 pub fn capture_mac_apple_silicon() -> EnvironmentSnapshot {
     EnvironmentSnapshot {
         label: "mac-apple-silicon".into(),
@@ -44,6 +66,152 @@ pub fn capture_mac_apple_silicon() -> EnvironmentSnapshot {
             memory_bytes: sysctl_string("hw.memsize").parse().unwrap_or(0),
         },
     }
+}
+
+/// Bare-metal Linux x86_64 (§13.1 canonical). Acceptance gate:
+/// `/sys/hypervisor/type` must be absent or empty. If a hypervisor is
+/// detected, the function panics, because the §13.1 measurement is
+/// only meaningful on bare metal.
+#[cfg(target_os = "linux")]
+pub fn capture_linux_baremetal() -> EnvironmentSnapshot {
+    let hyper = read_trim("/sys/hypervisor/type");
+    if !hyper.is_empty() && hyper != "none" {
+        panic!(
+            "env_capture: §13.1 requires bare metal; hypervisor detected: {hyper}"
+        );
+    }
+    EnvironmentSnapshot {
+        label: "bare-metal-linux".into(),
+        spec_section: "13.1".into(),
+        canonical: true,
+        host: linux_host(),
+    }
+}
+
+/// AWS EC2 c7i.2xlarge (§13.2 cloud reference). Acceptance gate:
+/// IMDSv2 must report `instance-type == "c7i.2xlarge"`. Any other
+/// instance type panics with the actual type named.
+#[cfg(target_os = "linux")]
+pub fn capture_aws_c7i() -> EnvironmentSnapshot {
+    let instance_type = imdsv2_instance_type();
+    if instance_type != "c7i.2xlarge" {
+        panic!(
+            "env_capture: §13.2 requires c7i.2xlarge; IMDSv2 reports: {instance_type}"
+        );
+    }
+    EnvironmentSnapshot {
+        label: "aws-c7i-gp3".into(),
+        spec_section: "13.2".into(),
+        canonical: false,
+        host: linux_host(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_host() -> Host {
+    Host {
+        cpu_brand: cpuinfo_field("model name"),
+        cpu_arch: shell_string("uname", &["-m"]),
+        os_name: os_release_field("PRETTY_NAME"),
+        os_version: shell_string("uname", &["-r"]),
+        hostname: shell_string("hostname", &[]),
+        memory_bytes: meminfo_total_bytes(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn cpuinfo_field(name: &str) -> String {
+    let body = fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
+    for line in body.lines() {
+        let mut parts = line.splitn(2, ':');
+        let key = parts.next().unwrap_or("").trim();
+        let val = parts.next().unwrap_or("").trim();
+        if key == name {
+            return val.to_string();
+        }
+    }
+    "unknown".into()
+}
+
+#[cfg(target_os = "linux")]
+fn meminfo_total_bytes() -> u64 {
+    let body = fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    for line in body.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb_str = rest.trim().split_whitespace().next().unwrap_or("0");
+            let kb: u64 = kb_str.parse().unwrap_or(0);
+            return kb * 1024;
+        }
+    }
+    0
+}
+
+#[cfg(target_os = "linux")]
+fn os_release_field(name: &str) -> String {
+    let body = fs::read_to_string("/etc/os-release").unwrap_or_default();
+    let prefix = format!("{name}=");
+    for line in body.lines() {
+        if let Some(rest) = line.strip_prefix(&prefix) {
+            return rest.trim_matches('"').to_string();
+        }
+    }
+    "unknown".into()
+}
+
+/// Read a file's contents, trim whitespace, return empty string on
+/// failure. Used for sysfs probes where missing files mean "not
+/// present" rather than "error."
+#[cfg(target_os = "linux")]
+fn read_trim(path: &str) -> String {
+    fs::read_to_string(path)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// IMDSv2 instance-type lookup. Returns empty string if IMDSv2 is
+/// unreachable (e.g. not on EC2). Caller decides whether that's an
+/// acceptance failure.
+#[cfg(target_os = "linux")]
+fn imdsv2_instance_type() -> String {
+    let token = Command::new("curl")
+        .args([
+            "-fsS",
+            "-X",
+            "PUT",
+            "-H",
+            "X-aws-ec2-metadata-token-ttl-seconds: 60",
+            "http://169.254.169.254/latest/api/token",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+    if token.is_empty() {
+        return String::new();
+    }
+    Command::new("curl")
+        .args([
+            "-fsS",
+            "-H",
+            &format!("X-aws-ec2-metadata-token: {token}"),
+            "http://169.254.169.254/latest/meta-data/instance-type",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
 }
 
 fn sysctl_string(name: &str) -> String {

--- a/benchmarks/prototype-1/src/main.rs
+++ b/benchmarks/prototype-1/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> ExitCode {
         }
     };
     let concurrent = args.iter().any(|a| a == "--concurrent");
-    let env = env_capture::capture_mac_apple_silicon();
+    let env = env_capture::capture();
 
     if concurrent {
         let mut summary_rows: Vec<SummaryRow> = Vec::new();

--- a/packages/aps-sdk-runtime/benchmarks/l4-runner.ts
+++ b/packages/aps-sdk-runtime/benchmarks/l4-runner.ts
@@ -39,6 +39,7 @@ if (!API_KEY) {
   process.exit(1);
 }
 
+const ENV_TAG = process.env.APS_RESULTS_ENV_TAG || 'mac-apple-silicon';
 const RESULTS_DIR = resolve(
   __dirname,
   '..',
@@ -47,7 +48,7 @@ const RESULTS_DIR = resolve(
   'benchmarks',
   'prototype-1',
   'results',
-  'mac-apple-silicon'
+  ENV_TAG
 );
 
 const ENDPOINT = `${GATEWAY_URL}/api/v1/evaluate`;

--- a/packages/aps-sdk-runtime/benchmarks/runner.ts
+++ b/packages/aps-sdk-runtime/benchmarks/runner.ts
@@ -35,6 +35,7 @@ import { execSync } from 'node:child_process';
 const TOOL_DESCRIPTOR_HASH_HEX =
   'abcd000000000000000000000000000000000000000000000000000000000000';
 
+const ENV_TAG = process.env.APS_RESULTS_ENV_TAG || 'mac-apple-silicon';
 const RESULTS_DIR = resolve(
   __dirname,
   '..',
@@ -43,7 +44,7 @@ const RESULTS_DIR = resolve(
   'benchmarks',
   'prototype-1',
   'results',
-  'mac-apple-silicon'
+  ENV_TAG
 );
 
 interface BenchSpec {


### PR DESCRIPTION
Canonical-measurement infrastructure + AWS c7i.2xlarge results (spec §13.2 cloud reference).

## What this PR contains

### Engineering

- benchmarks/prototype-1/src/env_capture.rs: Linux x86_64 env capture (capture_linux_baremetal, capture_aws_c7i) with IMDSv2 instance-type verification, hypervisor rejection for §13.1, and target_os dispatch
- benchmarks/prototype-1/src/main.rs: switched to unified env_capture::capture() entry point
- benchmarks/prototype-1/scripts/run-canonical.sh: corrected aps-bench CLI shape (positional L0/L1, no --config), env-tag string alignment with stream-C TOMLs, gateway-repo accepting via file:// for private-repo runs
- benchmarks/prototype-1/scripts/seed-l4-tenant.sh: from prep branch unchanged
- packages/aps-sdk-runtime/benchmarks/runner.ts: APS_RESULTS_ENV_TAG env override on output path
- packages/aps-sdk-runtime/benchmarks/l4-runner.ts: APS_RESULTS_ENV_TAG env override on output path

### Measurement results (AWS c7i.2xlarge, us-east-2, Amazon Linux 2023)

- benchmarks/prototype-1/results/aws-c7i-gp3/L0.json + L0-concurrent-{1,2,4,8,16}.json
- benchmarks/prototype-1/results/aws-c7i-gp3/L1.json + L1-concurrent-{1,2,4,8,16}.json
- benchmarks/prototype-1/results/aws-c7i-gp3/L2.json
- benchmarks/prototype-1/results/aws-c7i-gp3/L3a.json, L3b1.json, L3b2.json
- benchmarks/prototype-1/results/aws-c7i-gp3/L4.json
- benchmarks/prototype-1/results/aws-c7i-gp3/env_capture.json

### What this PR does NOT contain

- §13.1 bare-metal Linux x86_64 measurements (canonical reference). That run requires bare-metal hardware (Hetzner, OVH, Equinix, etc.) and remains a separate piece of work.
- CLAIMS.md update. That hand-off is chat-side after Tima reviews the cross-environment data.

## Numbers on AWS c7i.2xlarge

Internal-use only. Apple Silicon developer-reference comparison numbers are from the existing mac-apple-silicon/ results directory.

| Layer | aws-c7i-gp3 p50 | mac-apple-silicon p50 |
|-------|-----------------|-----------------------|
| L0 | 347 ns | 292 ns |
| L1 | 318 ns | 292 ns |
| L2 | 5.71 us | 3.92 us |
| L3a | 5.71 us | 3.92 us |
| L3b1 | 1.35 ms | 4.04 ms |
| L3b2 | 6.67 us | 4.00 us |
| L4 | 1.07 ms | 304.71 us |

### Observations

L0 and L1 on AWS are about 20 percent slower than on Apple Silicon. Both stay well under a microsecond. BLAKE3-bound at both architectures; AVX-512 on Sapphire Rapids carries part of the work that NEON does on M3.

L2 on AWS is 5.71 us, on Mac is 3.92 us. The FFI overhead is real on both platforms. The Sapphire-Rapids-to-Apple-M3 gap is 1.45x at L2 versus 1.19x at L0, suggesting napi-rs marshalling has architecture-dependent overhead beyond the raw verifier cost.

L3b1 on AWS is 1.35 ms versus 4.04 ms on Mac, in spite of L0 being slower on AWS. The Mode B1 blocking commit is fsync-bound and EBS gp3 is faster than APFS for the 100-byte sync at the 25 ms window settings. This is a storage-substrate story, not a verifier story.

L4 on AWS is 1.07 ms versus 304.71 us on Mac. Localhost-loopback gateway overhead is higher on Linux. The Linux TCP stack, SQLite ext4-vs-APFS performance, and Node V8 build differences all contribute. The number is still well below the spec §16 internet-bound L4 range of 2-50 ms; that range remains for client-to-internet-to-server measurement which is not what this captures.

## Environment

```
cpu_model        Intel(R) Xeon(R) Platinum 8488C
microcode        0x2b000661
kernel           Linux 6.18.25-57.109.amzn2023.x86_64
glibc            glibc 2.34
node_version     v24.15.0
rust_version     rustc 1.95.0 (59807616e 2026-04-14)
ram_kb           16080788  (16 GB)
hypervisor       none (KVM hypervisor at host level, but no nested)
filesystem_type  xfs
```

## Acceptance gates verified by the runner

- env_capture.json shipped with hypervisor field, microcode, kernel, glibc, Node, Rust versions, RAM, filesystem
- IMDSv2 verification confirmed instance_type == c7i.2xlarge (the env_capture::capture_aws_c7i function panics if this assertion fails)
- All seven measurement layers wrote p50/p95/p99/p99.9 + throughput
- L4 cleanup verified: test tenant rows deleted from gateway.db post-run
- Wall clock from container ready to results tar: 89 seconds

Anti-AI style discipline. No external performance claim language anywhere in this PR or the results README. The CLAIMS.md "Prototype 1 performance" entry remains at internal-use-only until Tima approves the cross-environment update.
