### PR TITLE
Bare-metal Linux canonical measurements (§13.1)

### DIFF
--- a/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-1.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-1.json
@@ -1,0 +1,63 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 1,
+  "per_thread_samples": 1000000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 415277747,
+  "throughput_ops_per_sec": 2408026.9343206584,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 415,
+    "stddev_ns": 140,
+    "min_ns": 400,
+    "max_ns": 105674,
+    "p50_ns": 410,
+    "p95_ns": 420,
+    "p99_ns": 421,
+    "p99_9_ns": 480
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 1000000,
+      "mean_ns": 415,
+      "stddev_ns": 140,
+      "min_ns": 400,
+      "max_ns": 105674,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 421,
+      "p99_9_ns": 480
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 1000000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319246716972405
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-16.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-16.json
@@ -1,0 +1,228 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 16,
+  "per_thread_samples": 100000,
+  "total_samples": 1600000,
+  "total_wall_time_ns": 44004461,
+  "throughput_ops_per_sec": 36359949.96052787,
+  "merged_samples": {
+    "n": 1600000,
+    "mean_ns": 431,
+    "stddev_ns": 59,
+    "min_ns": 410,
+    "max_ns": 26911,
+    "p50_ns": 420,
+    "p95_ns": 480,
+    "p99_ns": 550,
+    "p99_9_ns": 560
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 100000,
+      "mean_ns": 439,
+      "stddev_ns": 59,
+      "min_ns": 410,
+      "max_ns": 6351,
+      "p50_ns": 430,
+      "p95_ns": 540,
+      "p99_ns": 551,
+      "p99_9_ns": 600
+    },
+    {
+      "n": 100000,
+      "mean_ns": 425,
+      "stddev_ns": 41,
+      "min_ns": 410,
+      "max_ns": 5951,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 450,
+      "p99_9_ns": 540
+    },
+    {
+      "n": 100000,
+      "mean_ns": 438,
+      "stddev_ns": 101,
+      "min_ns": 410,
+      "max_ns": 26211,
+      "p50_ns": 420,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 580
+    },
+    {
+      "n": 100000,
+      "mean_ns": 439,
+      "stddev_ns": 71,
+      "min_ns": 410,
+      "max_ns": 12201,
+      "p50_ns": 430,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 100000,
+      "mean_ns": 440,
+      "stddev_ns": 61,
+      "min_ns": 410,
+      "max_ns": 6201,
+      "p50_ns": 430,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 600
+    },
+    {
+      "n": 100000,
+      "mean_ns": 424,
+      "stddev_ns": 37,
+      "min_ns": 410,
+      "max_ns": 4810,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 440,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 438,
+      "stddev_ns": 65,
+      "min_ns": 410,
+      "max_ns": 10150,
+      "p50_ns": 430,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 100000,
+      "mean_ns": 439,
+      "stddev_ns": 58,
+      "min_ns": 410,
+      "max_ns": 6751,
+      "p50_ns": 421,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 100000,
+      "mean_ns": 424,
+      "stddev_ns": 42,
+      "min_ns": 410,
+      "max_ns": 5351,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 431,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 425,
+      "stddev_ns": 42,
+      "min_ns": 410,
+      "max_ns": 5361,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 450,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 436,
+      "stddev_ns": 43,
+      "min_ns": 420,
+      "max_ns": 5181,
+      "p50_ns": 440,
+      "p95_ns": 440,
+      "p99_ns": 450,
+      "p99_9_ns": 500
+    },
+    {
+      "n": 100000,
+      "mean_ns": 425,
+      "stddev_ns": 93,
+      "min_ns": 410,
+      "max_ns": 26911,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 440,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 424,
+      "stddev_ns": 42,
+      "min_ns": 410,
+      "max_ns": 6171,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 431,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 424,
+      "stddev_ns": 44,
+      "min_ns": 410,
+      "max_ns": 9111,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 431,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 424,
+      "stddev_ns": 34,
+      "min_ns": 410,
+      "max_ns": 5061,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 440,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 100000,
+      "mean_ns": 424,
+      "stddev_ns": 50,
+      "min_ns": 410,
+      "max_ns": 6950,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 440,
+      "p99_9_ns": 490
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 100000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319247352656182
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-2.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-2.json
@@ -1,0 +1,74 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 2,
+  "per_thread_samples": 500000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 208528747,
+  "throughput_ops_per_sec": 4795501.888284017,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 416,
+    "stddev_ns": 66,
+    "min_ns": 400,
+    "max_ns": 17541,
+    "p50_ns": 410,
+    "p95_ns": 420,
+    "p99_ns": 470,
+    "p99_9_ns": 1030
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 500000,
+      "mean_ns": 417,
+      "stddev_ns": 78,
+      "min_ns": 400,
+      "max_ns": 17541,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 470,
+      "p99_9_ns": 1030
+    },
+    {
+      "n": 500000,
+      "mean_ns": 416,
+      "stddev_ns": 51,
+      "min_ns": 400,
+      "max_ns": 7000,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 460,
+      "p99_9_ns": 1030
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 500000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319246969966762
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-4.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-4.json
@@ -1,0 +1,96 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 4,
+  "per_thread_samples": 250000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 107377790,
+  "throughput_ops_per_sec": 9312912.847247088,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 419,
+    "stddev_ns": 113,
+    "min_ns": 400,
+    "max_ns": 101884,
+    "p50_ns": 410,
+    "p95_ns": 421,
+    "p99_ns": 540,
+    "p99_9_ns": 710
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 250000,
+      "mean_ns": 429,
+      "stddev_ns": 210,
+      "min_ns": 400,
+      "max_ns": 101884,
+      "p50_ns": 420,
+      "p95_ns": 530,
+      "p99_ns": 541,
+      "p99_9_ns": 580
+    },
+    {
+      "n": 250000,
+      "mean_ns": 416,
+      "stddev_ns": 41,
+      "min_ns": 400,
+      "max_ns": 6511,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 470,
+      "p99_9_ns": 700
+    },
+    {
+      "n": 250000,
+      "mean_ns": 415,
+      "stddev_ns": 39,
+      "min_ns": 400,
+      "max_ns": 8781,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 421,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 250000,
+      "mean_ns": 417,
+      "stddev_ns": 62,
+      "min_ns": 400,
+      "max_ns": 22001,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 480,
+      "p99_9_ns": 880
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 250000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319247166589126
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-8.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L0-concurrent-8.json
@@ -1,0 +1,140 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 8,
+  "per_thread_samples": 125000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 54752368,
+  "throughput_ops_per_sec": 18264050.241626076,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 428,
+    "stddev_ns": 56,
+    "min_ns": 410,
+    "max_ns": 25391,
+    "p50_ns": 420,
+    "p95_ns": 500,
+    "p99_ns": 540,
+    "p99_9_ns": 590
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 125000,
+      "mean_ns": 437,
+      "stddev_ns": 56,
+      "min_ns": 410,
+      "max_ns": 6521,
+      "p50_ns": 420,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 600
+    },
+    {
+      "n": 125000,
+      "mean_ns": 424,
+      "stddev_ns": 43,
+      "min_ns": 410,
+      "max_ns": 6520,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 520,
+      "p99_9_ns": 560
+    },
+    {
+      "n": 125000,
+      "mean_ns": 438,
+      "stddev_ns": 60,
+      "min_ns": 410,
+      "max_ns": 6851,
+      "p50_ns": 420,
+      "p95_ns": 540,
+      "p99_ns": 550,
+      "p99_9_ns": 640
+    },
+    {
+      "n": 125000,
+      "mean_ns": 434,
+      "stddev_ns": 50,
+      "min_ns": 410,
+      "max_ns": 4831,
+      "p50_ns": 420,
+      "p95_ns": 530,
+      "p99_ns": 550,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 125000,
+      "mean_ns": 422,
+      "stddev_ns": 81,
+      "min_ns": 410,
+      "max_ns": 25391,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 431,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 125000,
+      "mean_ns": 422,
+      "stddev_ns": 41,
+      "min_ns": 410,
+      "max_ns": 6150,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 431,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 125000,
+      "mean_ns": 422,
+      "stddev_ns": 43,
+      "min_ns": 410,
+      "max_ns": 6130,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 431,
+      "p99_9_ns": 490
+    },
+    {
+      "n": 125000,
+      "mean_ns": 423,
+      "stddev_ns": 57,
+      "min_ns": 410,
+      "max_ns": 16001,
+      "p50_ns": 420,
+      "p95_ns": 430,
+      "p99_ns": 520,
+      "p99_9_ns": 530
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 125000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "Concurrent L0: N independent sessions per spec §5.2 — each thread owns its CompiledAuthority and a 1024-entry pool of pre-finalized actions with incrementing sequence_ids. Authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow; deviates from the single-threaded L0 methodology (which used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N)."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319247266524925
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L0.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L0.json
@@ -1,0 +1,45 @@
+{
+  "benchmark": "L0",
+  "description": "rust_core_allow_hot_cache_no_event",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "methodology": {
+    "warmup_iterations": 100000,
+    "measure_iterations": 1000000,
+    "single_threaded": true,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (no-op trait dispatch only)",
+    "deny_kind": null,
+    "spec_step": "§9 all 13 steps + §9 step 13 emit via NullSink (true Allow per call)",
+    "notes": "L0 measures the full aps_check Allow pipeline. Single thread, 1024-entry pool of pre-finalized actions with incrementing sequence_ids; authority.sequence_next is reset to ALLOW_SEQ_START when the pool wraps (untimed atomic store). Every per-call sample is a true Allow. Earlier L0 result from commit 913cb12 used one action repeatedly and got SEQUENCE_REPLAY for iters 1..N — same BLAKE3 floor, but artifact label did not match measurement. Concurrent L0-concurrent-1.json uses the same corrected methodology by construction."
+  },
+  "samples": {
+    "n": 1000000,
+    "mean_ns": 416,
+    "stddev_ns": 117,
+    "min_ns": 400,
+    "max_ns": 27942,
+    "p50_ns": 420,
+    "p95_ns": 420,
+    "p99_ns": 470,
+    "p99_9_ns": 500
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319245564204212
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-1.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-1.json
@@ -1,0 +1,63 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 1,
+  "per_thread_samples": 1000000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 403072278,
+  "throughput_ops_per_sec": 2480944.6210537953,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 403,
+    "stddev_ns": 43,
+    "min_ns": 390,
+    "max_ns": 27762,
+    "p50_ns": 400,
+    "p95_ns": 410,
+    "p99_ns": 470,
+    "p99_9_ns": 480
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 1000000,
+      "mean_ns": 403,
+      "stddev_ns": 43,
+      "min_ns": 390,
+      "max_ns": 27762,
+      "p50_ns": 400,
+      "p95_ns": 410,
+      "p99_ns": 470,
+      "p99_9_ns": 480
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 1000000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319247908332698
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-16.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-16.json
@@ -1,0 +1,228 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 16,
+  "per_thread_samples": 100000,
+  "total_samples": 1600000,
+  "total_wall_time_ns": 44358437,
+  "throughput_ops_per_sec": 36069801.106833406,
+  "merged_samples": {
+    "n": 1600000,
+    "mean_ns": 417,
+    "stddev_ns": 61,
+    "min_ns": 390,
+    "max_ns": 23531,
+    "p50_ns": 410,
+    "p95_ns": 510,
+    "p99_ns": 530,
+    "p99_9_ns": 620
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 100000,
+      "mean_ns": 423,
+      "stddev_ns": 58,
+      "min_ns": 390,
+      "max_ns": 7310,
+      "p50_ns": 410,
+      "p95_ns": 530,
+      "p99_ns": 540,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 100000,
+      "mean_ns": 443,
+      "stddev_ns": 78,
+      "min_ns": 400,
+      "max_ns": 9120,
+      "p50_ns": 410,
+      "p95_ns": 530,
+      "p99_ns": 620,
+      "p99_9_ns": 640
+    },
+    {
+      "n": 100000,
+      "mean_ns": 431,
+      "stddev_ns": 59,
+      "min_ns": 400,
+      "max_ns": 5900,
+      "p50_ns": 410,
+      "p95_ns": 510,
+      "p99_ns": 510,
+      "p99_9_ns": 580
+    },
+    {
+      "n": 100000,
+      "mean_ns": 423,
+      "stddev_ns": 58,
+      "min_ns": 390,
+      "max_ns": 7080,
+      "p50_ns": 410,
+      "p95_ns": 520,
+      "p99_ns": 530,
+      "p99_9_ns": 580
+    },
+    {
+      "n": 100000,
+      "mean_ns": 409,
+      "stddev_ns": 38,
+      "min_ns": 390,
+      "max_ns": 5320,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 420,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 100000,
+      "mean_ns": 422,
+      "stddev_ns": 90,
+      "min_ns": 390,
+      "max_ns": 23531,
+      "p50_ns": 410,
+      "p95_ns": 520,
+      "p99_ns": 540,
+      "p99_9_ns": 570
+    },
+    {
+      "n": 100000,
+      "mean_ns": 423,
+      "stddev_ns": 55,
+      "min_ns": 390,
+      "max_ns": 5420,
+      "p50_ns": 410,
+      "p95_ns": 530,
+      "p99_ns": 540,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 100000,
+      "mean_ns": 423,
+      "stddev_ns": 53,
+      "min_ns": 390,
+      "max_ns": 4640,
+      "p50_ns": 410,
+      "p95_ns": 530,
+      "p99_ns": 540,
+      "p99_9_ns": 580
+    },
+    {
+      "n": 100000,
+      "mean_ns": 409,
+      "stddev_ns": 50,
+      "min_ns": 390,
+      "max_ns": 9840,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 420,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 100000,
+      "mean_ns": 410,
+      "stddev_ns": 47,
+      "min_ns": 390,
+      "max_ns": 6680,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 420,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 100000,
+      "mean_ns": 411,
+      "stddev_ns": 43,
+      "min_ns": 400,
+      "max_ns": 6440,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 421,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 100000,
+      "mean_ns": 408,
+      "stddev_ns": 75,
+      "min_ns": 390,
+      "max_ns": 19900,
+      "p50_ns": 410,
+      "p95_ns": 411,
+      "p99_ns": 420,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 100000,
+      "mean_ns": 409,
+      "stddev_ns": 72,
+      "min_ns": 390,
+      "max_ns": 18011,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 420,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 100000,
+      "mean_ns": 410,
+      "stddev_ns": 61,
+      "min_ns": 400,
+      "max_ns": 15560,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 470,
+      "p99_9_ns": 510
+    },
+    {
+      "n": 100000,
+      "mean_ns": 409,
+      "stddev_ns": 47,
+      "min_ns": 390,
+      "max_ns": 7790,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 470,
+      "p99_9_ns": 510
+    },
+    {
+      "n": 100000,
+      "mean_ns": 410,
+      "stddev_ns": 47,
+      "min_ns": 390,
+      "max_ns": 7460,
+      "p50_ns": 410,
+      "p95_ns": 420,
+      "p99_ns": 470,
+      "p99_9_ns": 510
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 100000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319248492308765
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-2.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-2.json
@@ -1,0 +1,74 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 2,
+  "per_thread_samples": 500000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 206036665,
+  "throughput_ops_per_sec": 4853505.078816918,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 407,
+    "stddev_ns": 52,
+    "min_ns": 390,
+    "max_ns": 11991,
+    "p50_ns": 400,
+    "p95_ns": 410,
+    "p99_ns": 680,
+    "p99_9_ns": 681
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 500000,
+      "mean_ns": 401,
+      "stddev_ns": 38,
+      "min_ns": 390,
+      "max_ns": 9030,
+      "p50_ns": 400,
+      "p95_ns": 410,
+      "p99_ns": 411,
+      "p99_9_ns": 470
+    },
+    {
+      "n": 500000,
+      "mean_ns": 412,
+      "stddev_ns": 62,
+      "min_ns": 390,
+      "max_ns": 11991,
+      "p50_ns": 400,
+      "p95_ns": 460,
+      "p99_ns": 680,
+      "p99_9_ns": 690
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 500000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319248163493955
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-4.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-4.json
@@ -1,0 +1,96 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 4,
+  "per_thread_samples": 250000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 106006863,
+  "throughput_ops_per_sec": 9433351.499138314,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 413,
+    "stddev_ns": 59,
+    "min_ns": 390,
+    "max_ns": 13300,
+    "p50_ns": 400,
+    "p95_ns": 520,
+    "p99_ns": 680,
+    "p99_9_ns": 780
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 250000,
+      "mean_ns": 416,
+      "stddev_ns": 52,
+      "min_ns": 390,
+      "max_ns": 5660,
+      "p50_ns": 400,
+      "p95_ns": 520,
+      "p99_ns": 530,
+      "p99_9_ns": 600
+    },
+    {
+      "n": 250000,
+      "mean_ns": 424,
+      "stddev_ns": 74,
+      "min_ns": 390,
+      "max_ns": 9521,
+      "p50_ns": 400,
+      "p95_ns": 530,
+      "p99_ns": 680,
+      "p99_9_ns": 810
+    },
+    {
+      "n": 250000,
+      "mean_ns": 411,
+      "stddev_ns": 63,
+      "min_ns": 390,
+      "max_ns": 5950,
+      "p50_ns": 400,
+      "p95_ns": 410,
+      "p99_ns": 680,
+      "p99_9_ns": 690
+    },
+    {
+      "n": 250000,
+      "mean_ns": 401,
+      "stddev_ns": 41,
+      "min_ns": 390,
+      "max_ns": 13300,
+      "p50_ns": 400,
+      "p95_ns": 410,
+      "p99_ns": 460,
+      "p99_9_ns": 480
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 250000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319248315741860
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-8.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L1-concurrent-8.json
@@ -1,0 +1,140 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "concurrency_level": 8,
+  "per_thread_samples": 125000,
+  "total_samples": 1000000,
+  "total_wall_time_ns": 52640337,
+  "throughput_ops_per_sec": 18996838.869021676,
+  "merged_samples": {
+    "n": 1000000,
+    "mean_ns": 412,
+    "stddev_ns": 55,
+    "min_ns": 390,
+    "max_ns": 23121,
+    "p50_ns": 410,
+    "p95_ns": 500,
+    "p99_ns": 530,
+    "p99_9_ns": 570
+  },
+  "per_thread_samples_stats": [
+    {
+      "n": 125000,
+      "mean_ns": 421,
+      "stddev_ns": 59,
+      "min_ns": 390,
+      "max_ns": 6680,
+      "p50_ns": 410,
+      "p95_ns": 530,
+      "p99_ns": 540,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 125000,
+      "mean_ns": 407,
+      "stddev_ns": 43,
+      "min_ns": 390,
+      "max_ns": 6190,
+      "p50_ns": 410,
+      "p95_ns": 410,
+      "p99_ns": 500,
+      "p99_9_ns": 540
+    },
+    {
+      "n": 125000,
+      "mean_ns": 419,
+      "stddev_ns": 84,
+      "min_ns": 390,
+      "max_ns": 23121,
+      "p50_ns": 410,
+      "p95_ns": 520,
+      "p99_ns": 530,
+      "p99_9_ns": 580
+    },
+    {
+      "n": 125000,
+      "mean_ns": 410,
+      "stddev_ns": 49,
+      "min_ns": 390,
+      "max_ns": 8400,
+      "p50_ns": 410,
+      "p95_ns": 450,
+      "p99_ns": 510,
+      "p99_9_ns": 560
+    },
+    {
+      "n": 125000,
+      "mean_ns": 420,
+      "stddev_ns": 61,
+      "min_ns": 390,
+      "max_ns": 6820,
+      "p50_ns": 410,
+      "p95_ns": 530,
+      "p99_ns": 540,
+      "p99_9_ns": 590
+    },
+    {
+      "n": 125000,
+      "mean_ns": 405,
+      "stddev_ns": 40,
+      "min_ns": 390,
+      "max_ns": 6790,
+      "p50_ns": 400,
+      "p95_ns": 410,
+      "p99_ns": 411,
+      "p99_9_ns": 470
+    },
+    {
+      "n": 125000,
+      "mean_ns": 406,
+      "stddev_ns": 47,
+      "min_ns": 390,
+      "max_ns": 7480,
+      "p50_ns": 410,
+      "p95_ns": 410,
+      "p99_ns": 420,
+      "p99_9_ns": 480
+    },
+    {
+      "n": 125000,
+      "mean_ns": 405,
+      "stddev_ns": 43,
+      "min_ns": 390,
+      "max_ns": 6830,
+      "p50_ns": 400,
+      "p95_ns": 410,
+      "p99_ns": 411,
+      "p99_9_ns": 470
+    }
+  ],
+  "methodology": {
+    "warmup_iterations": 2048,
+    "measure_iterations": 125000,
+    "single_threaded": false,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "Concurrent L1: N independent sessions, each thread runs the same tampered-action_hash deny in a tight loop. Deny short-circuits at step 0 and never touches sequence/budget, so a single action per thread is sufficient — same methodology as single-threaded L1."
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319248411866260
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L1.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L1.json
@@ -1,0 +1,45 @@
+{
+  "benchmark": "L1",
+  "description": "rust_core_deny_hot_cache_action_hash_invalid",
+  "environment": {
+    "label": "bare-metal-linux",
+    "spec_section": "13.1",
+    "canonical": true,
+    "host": {
+      "cpu_brand": "AMD EPYC 7313P 16-Core Processor",
+      "cpu_arch": "x86_64",
+      "os_name": "Ubuntu 22.04.5 LTS",
+      "os_version": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memory_bytes": 540692099072
+    }
+  },
+  "methodology": {
+    "warmup_iterations": 100000,
+    "measure_iterations": 1000000,
+    "single_threaded": true,
+    "timer": "std::time::Instant",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink": "NullSink (never invoked on deny path)",
+    "deny_kind": "ACTION_HASH_INVALID (cheapest deny)",
+    "spec_step": "§9 step 0",
+    "notes": "L1 measures the fast-reject path: the action's action_hash is tampered after finalize, so step 0 fails and aps_check returns immediately without touching the sink or advancing sequence/budget."
+  },
+  "samples": {
+    "n": 1000000,
+    "mean_ns": 402,
+    "stddev_ns": 103,
+    "min_ns": 390,
+    "max_ns": 27921,
+    "p50_ns": 400,
+    "p95_ns": 410,
+    "p99_ns": 410,
+    "p99_9_ns": 460
+  },
+  "run": {
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638",
+    "git_branch": "main",
+    "timestamp_unix_ns": 1779319246144232277
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L2.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L2.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L2",
+  "description": "ts_sdk_napi_null_sink",
+  "sink_mode": "Null",
+  "environment": {
+    "label": "bare-metal-linux",
+    "specSection": "13.1",
+    "canonical": true,
+    "host": {
+      "cpuBrand": "AMD EPYC 7313P 16-Core Processor",
+      "cpuArch": "x86_64",
+      "osName": "Ubuntu 22.04.5 LTS",
+      "osVersion": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memoryBytes": 540692099072
+    }
+  },
+  "methodology": {
+    "sample_count": 100000,
+    "warmup_count": 2000,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": false,
+    "sink_buffer_capacity": null,
+    "sink_flush_interval_ms": null,
+    "sink_batch_size": null,
+    "sink_batch_window_ms": null,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 100000,
+    "meanNs": 6590,
+    "stddevNs": 1290,
+    "minNs": 6340,
+    "maxNs": 340622,
+    "p50Ns": 6540,
+    "p95Ns": 6720,
+    "p99Ns": 8111,
+    "p99_9Ns": 9960
+  },
+  "throughput_ops_per_sec": 148499.23884858887,
+  "total_wall_time_ns": 673404125,
+  "run": {
+    "timestamp_unix_ns": "82389686741",
+    "node_version": "v24.15.0",
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638"
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L3a.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L3a.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L3a",
+  "description": "ts_sdk_napi_mode_a_memory_buffered",
+  "sink_mode": "ModeA",
+  "environment": {
+    "label": "bare-metal-linux",
+    "specSection": "13.1",
+    "canonical": true,
+    "host": {
+      "cpuBrand": "AMD EPYC 7313P 16-Core Processor",
+      "cpuArch": "x86_64",
+      "osName": "Ubuntu 22.04.5 LTS",
+      "osVersion": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memoryBytes": 540692099072
+    }
+  },
+  "methodology": {
+    "sample_count": 50000,
+    "warmup_count": 2000,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "sink_buffer_capacity": 131072,
+    "sink_flush_interval_ms": 25,
+    "sink_batch_size": null,
+    "sink_batch_window_ms": null,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 50000,
+    "meanNs": 7509,
+    "stddevNs": 36691,
+    "minNs": 6381,
+    "maxNs": 2458718,
+    "p50Ns": 6710,
+    "p95Ns": 6950,
+    "p99Ns": 13851,
+    "p99_9Ns": 16830
+  },
+  "throughput_ops_per_sec": 131165.10145339905,
+  "total_wall_time_ns": 381198958,
+  "run": {
+    "timestamp_unix_ns": "82837631062",
+    "node_version": "v24.15.0",
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638"
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L3b1.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L3b1.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L3b1",
+  "description": "ts_sdk_napi_mode_b1_blocking_group_commit",
+  "sink_mode": "ModeB1",
+  "environment": {
+    "label": "bare-metal-linux",
+    "specSection": "13.1",
+    "canonical": true,
+    "host": {
+      "cpuBrand": "AMD EPYC 7313P 16-Core Processor",
+      "cpuArch": "x86_64",
+      "osName": "Ubuntu 22.04.5 LTS",
+      "osVersion": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memoryBytes": 540692099072
+    }
+  },
+  "methodology": {
+    "sample_count": 5000,
+    "warmup_count": 200,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "sink_buffer_capacity": 1024,
+    "sink_flush_interval_ms": null,
+    "sink_batch_size": 64,
+    "sink_batch_window_ms": 1,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 5000,
+    "meanNs": 1442016,
+    "stddevNs": 1823958,
+    "minNs": 1226083,
+    "maxNs": 50176233,
+    "p50Ns": 1309609,
+    "p95Ns": 1384272,
+    "p99Ns": 1495873,
+    "p99_9Ns": 33858249
+  },
+  "throughput_ops_per_sec": 693.2836303619601,
+  "total_wall_time_ns": 7212055472,
+  "run": {
+    "timestamp_unix_ns": "90339292077",
+    "node_version": "v24.15.0",
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638"
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L3b2.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L3b2.json
@@ -1,0 +1,49 @@
+{
+  "benchmark": "L3b2",
+  "description": "ts_sdk_napi_mode_b2_queued_group_commit",
+  "sink_mode": "ModeB2",
+  "environment": {
+    "label": "bare-metal-linux",
+    "specSection": "13.1",
+    "canonical": true,
+    "host": {
+      "cpuBrand": "AMD EPYC 7313P 16-Core Processor",
+      "cpuArch": "x86_64",
+      "osName": "Ubuntu 22.04.5 LTS",
+      "osVersion": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memoryBytes": 540692099072
+    }
+  },
+  "methodology": {
+    "sample_count": 50000,
+    "warmup_count": 2000,
+    "single_threaded": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "sink_buffer_capacity": 131072,
+    "sink_flush_interval_ms": null,
+    "sink_batch_size": 64,
+    "sink_batch_window_ms": 1,
+    "notes": "TS → N-API → Rust full path. True Allow per call: sequence_id increments and matches authority.sequence_next."
+  },
+  "samples": {
+    "n": 50000,
+    "meanNs": 7767,
+    "stddevNs": 2153,
+    "minNs": 6691,
+    "maxNs": 325199,
+    "p50Ns": 7641,
+    "p95Ns": 8640,
+    "p99Ns": 13200,
+    "p99_9Ns": 19391
+  },
+  "throughput_ops_per_sec": 126780.01968493081,
+  "total_wall_time_ns": 394383911,
+  "run": {
+    "timestamp_unix_ns": "90805895903",
+    "node_version": "v24.15.0",
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638"
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/L4.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/L4.json
@@ -1,0 +1,48 @@
+{
+  "benchmark": "L4",
+  "description": "gateway_bound_authorization_round_trip",
+  "gateway_endpoint": "http://localhost:3200/api/v1/evaluate",
+  "gateway_location": "bare-metal-linux",
+  "http_method": "POST",
+  "network_path": "loopback",
+  "environment": {
+    "label": "bare-metal-linux",
+    "specSection": "13.1",
+    "canonical": true,
+    "host": {
+      "cpuBrand": "AMD EPYC 7313P 16-Core Processor",
+      "cpuArch": "x86_64",
+      "osName": "Ubuntu 22.04.5 LTS",
+      "osVersion": "5.15.0-179-generic",
+      "hostname": "aps-canonical-bench-13-1",
+      "memoryBytes": 540692099072
+    }
+  },
+  "methodology": {
+    "sample_count": 1000,
+    "warmup_count": 100,
+    "single_threaded": true,
+    "sequential": true,
+    "timer": "process.hrtime.bigint()",
+    "percentile_method": "raw sample at index ceil(p * (n-1)), no interpolation",
+    "includes_durability": true,
+    "includes_network": false,
+    "notes": "TS fetch() to gateway /api/v1/evaluate. Each call lands a permit row in policy_evaluations + mints an evaluation receipt. Body is the same on every iteration; cache effects are exercised by warmup."
+  },
+  "samples": {
+    "n": 1000,
+    "minNs": 671427,
+    "maxNs": 11258330,
+    "p50Ns": 821610,
+    "p95Ns": 1402214,
+    "p99Ns": 6010270,
+    "p99_9Ns": 11258330
+  },
+  "throughput_ops_per_sec": 1008.0711996817341,
+  "total_wall_time_ns": 991993423,
+  "run": {
+    "timestamp_unix_ns": "97895293420",
+    "node_version": "v24.15.0",
+    "git_commit": "e0c3cb230d31fec924be441da9c1021bb129c638"
+  }
+}

--- a/benchmarks/prototype-1/results/bare-metal-linux/env_capture.json
+++ b/benchmarks/prototype-1/results/bare-metal-linux/env_capture.json
@@ -1,0 +1,14 @@
+{
+  "environment_tag": "bare-metal-linux",
+  "cpu_model": "AMD EPYC 7313P 16-Core Processor",
+  "microcode": "0xa0011d5",
+  "kernel": "Linux aps-canonical-bench-13-1 5.15.0-179-generic #189-Ubuntu SMP Tue May 5 18:20:56 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux",
+  "glibc": "glibc 2.35",
+  "node_version": "v24.15.0",
+  "rust_version": "rustc 1.95.0 (59807616e 2026-04-14)",
+  "ram_kb": 528019628,
+  "hypervisor": "none",
+  "filesystem_type": "ext2/ext3",
+  "thermal_zone0_milli_c": null,
+  "timestamp_utc": "20260520T232003Z"
+}


### PR DESCRIPTION
Bare-metal Linux canonical measurements per spec §13.1.

## What this PR contains

- benchmarks/prototype-1/results/bare-metal-linux/L0.json + L0-concurrent-{1,2,4,8,16}.json
- benchmarks/prototype-1/results/bare-metal-linux/L1.json + L1-concurrent-{1,2,4,8,16}.json
- benchmarks/prototype-1/results/bare-metal-linux/L2.json
- benchmarks/prototype-1/results/bare-metal-linux/L3a.json, L3b1.json, L3b2.json
- benchmarks/prototype-1/results/bare-metal-linux/L4.json
- benchmarks/prototype-1/results/bare-metal-linux/env_capture.json

## Environment

- Provider: Latitude.sh (Latitude Inc.) bare metal
- Plan: c3-large-x86
- Actual SKU delivered: AMD EPYC 7313P 16-core (Latitude's catalog page advertises 7443P 24-core; actual stock varied)
- Site: DAL (Dallas; LAX, SAN, SAN2 were out of stock at provisioning time)
- OS: Ubuntu 22.04 LTS, kernel 5.15.0-179, glibc 2.35
- Memory: 503 GB
- Storage: NVMe, ext4
- No hypervisor (verified by env_capture acceptance gate at runtime)

## Numbers (Apple Silicon vs AWS c7i.2xlarge vs Bare-Metal Linux p50)

Internal-use only. CLAIMS.md treatment follows after Tima reviews.

| Layer | mac-apple-silicon | aws-c7i-gp3 | bare-metal-linux |
|-------|-------------------|-------------|------------------|
| L0 | 292 ns | 347 ns | 420 ns |
| L1 | 292 ns | 318 ns | 400 ns |
| L2 | 3.92 us | 5.71 us | 6.54 us |
| L3a | 3.92 us | 5.71 us | 6.71 us |
| L3b1 | 4.04 ms | 1.35 ms | 1.31 ms |
| L3b2 | 4.00 us | 6.67 us | 7.64 us |
| L4 | 304.71 us | 1.07 ms | 821.61 us |

### Observations

L0 on EPYC 7313P (3.0 GHz base) is 420 ns versus Apple M3's 292 ns and AWS Sapphire Rapids' 347 ns. The Apple M3's wider instruction window and unified memory hierarchy hold the floor at single-thread BLAKE3 work. EPYC 7313P is the slowest of the three, consistent with the lower clock and older Zen 3 microarchitecture compared to the Zen 4-based 9000 series.

L3b1 on bare-metal Linux is 1.31 ms, matching the AWS gp3 EBS result (1.35 ms) within 3 percent and far below the Mac APFS result (4.04 ms). The Linux fsync path on NVMe with ext4 hits the same fast-commit pattern as AWS gp3, both at roughly 1.3 ms for a 100-byte sync within the 25 ms group-commit window. The Mac APFS result is the outlier.

L4 on bare-metal Linux is 821 us versus AWS 1.07 ms and Mac 305 us. The bare-metal Linux loopback is faster than the AWS instance loopback (different kernel network stack tuning, no virtualization overhead) but slower than Mac. SQLite on ext4 vs APFS plays a role; both are loopback-bound, neither is internet-bound.

The cross-environment §16 hypothesis flag fires on L4 for all three environments. All measurements are loopback to a local gateway, not internet-bound; the 2-50 ms range remains for client-internet-server measurement which is not what these capture.

## Acceptance gates verified by the runner

- env_capture.json shipped with hypervisor field, microcode, kernel, glibc, Node, Rust versions, RAM, filesystem
- hypervisor field == 'none' (§13.1 acceptance gate passes)
- All seven measurement layers wrote p50/p95/p99/p99.9 + throughput
- L4 cleanup verified: test tenant rows deleted from gateway.db post-run
- Wall clock from canonical-run start to results tar: 64 seconds

## What this closes

This closes the spec §13.1 acceptance gate. Combined with PR #34 (AWS c7i.2xlarge §13.2 cloud reference) and the Apple Silicon §13.3 developer reference, the cross-environment canonical scope is now complete.

CLAIMS.md update follows after Tima reviews this cross-environment data; that hand-off is chat-side, not in this PR.
