### PR TITLE
feat(payment-rails/cycles): authority_state_at_admission on permit receipt (Track B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The composition contract specifies how a verifier MUST cross-check per-request s
 
 ## Numbers
 
-3,076 tests. 8 protocol layers. Framework adapters for CrewAI, LangChain, ADK, A2A, MCP, OpenShell, IBAC, Gonka. Gateway evaluation under 2ms. Zero heavy dependencies. Apache-2.0.
+3,079 tests. 8 protocol layers. Framework adapters for CrewAI, LangChain, ADK, A2A, MCP, OpenShell, IBAC, Gonka. Gateway evaluation under 2ms. Zero heavy dependencies. Apache-2.0.
 
 ## Papers
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-passport-system",
   "version": "2.6.0-alpha.7",
-  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Verifier hot path p50 = 420ns bare-metal Linux EPYC 7313P (§13.1 canonical environment per spec), 347ns AWS c7i.2xlarge, 292ns Mac M3. Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). 3,076 tests.",
+  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Verifier hot path p50 = 420ns bare-metal Linux EPYC 7313P (§13.1 canonical environment per spec), 347ns AWS c7i.2xlarge, 292ns Mac M3. Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). 3,079 tests.",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/v2/payment-rails/cycles/index.ts
+++ b/src/v2/payment-rails/cycles/index.ts
@@ -47,7 +47,6 @@
 
 import { randomUUID } from 'node:crypto'
 import { canonicalizeJCS } from '../../../core/canonical-jcs.js'
-import { sha256Hex } from '../canonicalize.js'
 import { publicKeyFromPrivate, sign, verify as edVerify } from '../../../crypto/keys.js'
 import {
   parseDidUri,
@@ -70,7 +69,6 @@ export {
   RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE,
 } from './types.js'
 import type {
-  AuthorityStateSnapshot,
   CyclesDenial,
   CyclesDenialDetail,
   CyclesEvidenceView,
@@ -262,19 +260,6 @@ export function mapCyclesDenialToFoundation(
   return null
 }
 
-// ── Authority-state-at-admission ref ──────────────────────────────
-
-/**
- * Content-addresses an AuthorityStateSnapshot: SHA-256 hex over the
- * RFC 8785 JCS canonical bytes of the snapshot. Reuses the existing
- * payment-rails hashing path (canonicalizeJCS + sha256Hex) — same
- * scheme as cycles_evidence_id_sha256; no new canonicalization is
- * introduced. Pure and deterministic for a given snapshot.
- */
-export function computeAuthorityStateRef(snapshot: AuthorityStateSnapshot): string {
-  return sha256Hex(canonicalizeJCS(snapshot))
-}
-
 // ── Sign / verify: permit receipt ─────────────────────────────────
 
 export function signCyclesPermitReceipt(
@@ -302,10 +287,8 @@ export function signCyclesPermitReceipt(
   if (input.expires_at_ms !== undefined) {
     unsigned.expires_at_ms = input.expires_at_ms
   }
-  if (input.admission_authority_state !== undefined) {
-    unsigned.admission_authority_state_ref = computeAuthorityStateRef(
-      input.admission_authority_state,
-    )
+  if (input.authority_state_at_admission !== undefined) {
+    unsigned.authority_state_at_admission = input.authority_state_at_admission
   }
   const sigBytes = canonicalizeJCS(unsigned)
   const signature = sign(sigBytes, signerPrivateKeyHex)

--- a/src/v2/payment-rails/cycles/index.ts
+++ b/src/v2/payment-rails/cycles/index.ts
@@ -47,6 +47,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { canonicalizeJCS } from '../../../core/canonical-jcs.js'
+import { sha256Hex } from '../canonicalize.js'
 import { publicKeyFromPrivate, sign, verify as edVerify } from '../../../crypto/keys.js'
 import {
   parseDidUri,
@@ -69,6 +70,7 @@ export {
   RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE,
 } from './types.js'
 import type {
+  AuthorityStateSnapshot,
   CyclesDenial,
   CyclesDenialDetail,
   CyclesEvidenceView,
@@ -260,6 +262,19 @@ export function mapCyclesDenialToFoundation(
   return null
 }
 
+// ── Authority-state-at-admission ref ──────────────────────────────
+
+/**
+ * Content-addresses an AuthorityStateSnapshot: SHA-256 hex over the
+ * RFC 8785 JCS canonical bytes of the snapshot. Reuses the existing
+ * payment-rails hashing path (canonicalizeJCS + sha256Hex) — same
+ * scheme as cycles_evidence_id_sha256; no new canonicalization is
+ * introduced. Pure and deterministic for a given snapshot.
+ */
+export function computeAuthorityStateRef(snapshot: AuthorityStateSnapshot): string {
+  return sha256Hex(canonicalizeJCS(snapshot))
+}
+
 // ── Sign / verify: permit receipt ─────────────────────────────────
 
 export function signCyclesPermitReceipt(
@@ -286,6 +301,11 @@ export function signCyclesPermitReceipt(
   }
   if (input.expires_at_ms !== undefined) {
     unsigned.expires_at_ms = input.expires_at_ms
+  }
+  if (input.admission_authority_state !== undefined) {
+    unsigned.admission_authority_state_ref = computeAuthorityStateRef(
+      input.admission_authority_state,
+    )
   }
   const sigBytes = canonicalizeJCS(unsigned)
   const signature = sign(sigBytes, signerPrivateKeyHex)

--- a/src/v2/payment-rails/cycles/types.ts
+++ b/src/v2/payment-rails/cycles/types.ts
@@ -131,19 +131,16 @@ export interface CyclesEvidenceView {
 
 // ── Authority-state-at-admission snapshot ─────────────────────────
 // Optional Track B field (aeoess/agent-passport-system#25, amavashev
-// catch): a content-addressed snapshot of the authority/revocation/
-// expiry state APS evaluated at admission, BEFORE calling Cycles. The
-// permit-receipt carries only the sha256 ref (see
-// `admission_authority_state_ref` below); the snapshot itself is the
-// pre-image. Staged for review — open design question is ref-to-snapshot
-// (here) vs inlining these fields directly on the receipt.
+// catch): a snapshot of the authority/revocation/expiry state APS
+// evaluated at admission, BEFORE calling Cycles. Carried inline on the
+// permit-receipt (see `authority_state_at_admission` below), not as a
+// content-hash ref. The delegation identity is not duplicated here — the
+// receipt's own `delegation_ref` names the delegation this state is for.
 
 /** Snapshot of the delegation-authority state APS saw at admission. */
 export interface AuthorityStateSnapshot {
   /** Admission-time ISO 8601 — when APS evaluated this authority state. */
   checked_at: string
-  /** The delegation this permit rode (mirrors the receipt's delegation_ref). */
-  delegation_ref: string
   /** Revocation state APS saw at admission. */
   delegation_revoked: boolean
   /** Delegation expiry APS saw at admission, when known. */
@@ -184,12 +181,11 @@ export interface CyclesPermitReceipt {
   timestamp?: string
   scope_of_claim?: ScopeOfClaim
 
-  /** Optional (Track B): SHA-256/JCS content-hash of an
-   *  AuthorityStateSnapshot — the authority/revocation/expiry state APS
-   *  evaluated at admission, before calling Cycles. Computed via
-   *  computeAuthorityStateRef. Optional so existing fixtures and call
-   *  sites that omit it stay valid. */
-  admission_authority_state_ref?: string
+  /** Optional (Track B): the authority/revocation/expiry state APS
+   *  evaluated at admission, before calling Cycles, carried inline.
+   *  Optional so existing fixtures and call sites that omit it stay
+   *  valid. */
+  authority_state_at_admission?: AuthorityStateSnapshot
 }
 
 // ── Cycles release-receipt ────────────────────────────────────────
@@ -299,10 +295,10 @@ export interface SignCyclesPermitReceiptInput {
   expires_at_ms?: number
   cycles_evidence: CyclesEvidenceRef
   /** Optional (Track B): the authority-state snapshot APS evaluated at
-   *  admission. When supplied, the permit-receipt's
-   *  admission_authority_state_ref is set to its computed content-hash;
-   *  when omitted, the field is left undefined. */
-  admission_authority_state?: AuthorityStateSnapshot
+   *  admission. When supplied, it is carried inline on the permit-receipt
+   *  as authority_state_at_admission; when omitted, the field is left
+   *  absent. */
+  authority_state_at_admission?: AuthorityStateSnapshot
   /** Override the rail's default scope_of_claim. */
   scope_of_claim?: ScopeOfClaim
   /** When supplied alongside `issuer_key_ref`, signer becomes a DID URI

--- a/src/v2/payment-rails/cycles/types.ts
+++ b/src/v2/payment-rails/cycles/types.ts
@@ -129,6 +129,29 @@ export interface CyclesEvidenceView {
       }
 }
 
+// ── Authority-state-at-admission snapshot ─────────────────────────
+// Optional Track B field (aeoess/agent-passport-system#25, amavashev
+// catch): a content-addressed snapshot of the authority/revocation/
+// expiry state APS evaluated at admission, BEFORE calling Cycles. The
+// permit-receipt carries only the sha256 ref (see
+// `admission_authority_state_ref` below); the snapshot itself is the
+// pre-image. Staged for review — open design question is ref-to-snapshot
+// (here) vs inlining these fields directly on the receipt.
+
+/** Snapshot of the delegation-authority state APS saw at admission. */
+export interface AuthorityStateSnapshot {
+  /** Admission-time ISO 8601 — when APS evaluated this authority state. */
+  checked_at: string
+  /** The delegation this permit rode (mirrors the receipt's delegation_ref). */
+  delegation_ref: string
+  /** Revocation state APS saw at admission. */
+  delegation_revoked: boolean
+  /** Delegation expiry APS saw at admission, when known. */
+  delegation_expires_at?: string
+  /** Origin of the snapshot. Fixed for the APS admission path. */
+  source: 'aps_admission'
+}
+
 // ── Cycles permit-receipt ─────────────────────────────────────────
 
 /** Signed receipt emitted at reserve-allow. Binds the APS delegation
@@ -160,6 +183,13 @@ export interface CyclesPermitReceipt {
   /** Phase 4.1 / Q1 accountability fields. */
   timestamp?: string
   scope_of_claim?: ScopeOfClaim
+
+  /** Optional (Track B): SHA-256/JCS content-hash of an
+   *  AuthorityStateSnapshot — the authority/revocation/expiry state APS
+   *  evaluated at admission, before calling Cycles. Computed via
+   *  computeAuthorityStateRef. Optional so existing fixtures and call
+   *  sites that omit it stay valid. */
+  admission_authority_state_ref?: string
 }
 
 // ── Cycles release-receipt ────────────────────────────────────────
@@ -268,6 +298,11 @@ export interface SignCyclesPermitReceiptInput {
   decision: 'ALLOW' | 'ALLOW_WITH_CAPS'
   expires_at_ms?: number
   cycles_evidence: CyclesEvidenceRef
+  /** Optional (Track B): the authority-state snapshot APS evaluated at
+   *  admission. When supplied, the permit-receipt's
+   *  admission_authority_state_ref is set to its computed content-hash;
+   *  when omitted, the field is left undefined. */
+  admission_authority_state?: AuthorityStateSnapshot
   /** Override the rail's default scope_of_claim. */
   scope_of_claim?: ScopeOfClaim
   /** When supplied alongside `issuer_key_ref`, signer becomes a DID URI

--- a/tests/v2/payment-rails/cycles.test.ts
+++ b/tests/v2/payment-rails/cycles.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { generateKeyPair } from '../../../src/crypto/keys.js'
 import {
+  computeAuthorityStateRef,
   mapCyclesDenialToFoundation,
   RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE,
   RAIL_BUDGET_RESERVATION_PERMIT_CLAIM_TYPE,
@@ -18,9 +19,26 @@ import {
   verifyCyclesReleaseReceipt,
 } from '../../../src/v2/payment-rails/cycles/index.js'
 import type {
+  AuthorityStateSnapshot,
   CyclesEvidenceRef,
   CyclesEvidenceView,
 } from '../../../src/v2/payment-rails/cycles/types.js'
+
+// ── Authority-state-at-admission fixtures (Track B, aps#25) ───────
+// Pinned snapshot + its content-hash ref. The ref is a regression pin:
+// computed once via computeAuthorityStateRef (sha256 over JCS-canonical
+// bytes) and frozen here so a canonicalization or scheme change trips.
+
+const ADMISSION_SNAPSHOT_FIXTURE: AuthorityStateSnapshot = {
+  checked_at: '2026-05-30T12:00:00.000Z',
+  delegation_ref: 'aps:delegation:cycles-admission-001',
+  delegation_revoked: false,
+  delegation_expires_at: '2026-06-30T00:00:00.000Z',
+  source: 'aps_admission',
+}
+
+const ADMISSION_SNAPSHOT_REF =
+  '33cadcb7385de69c38f7a3b897dee12e70c6ecf505e1da3c7691baee14748d23'
 
 // ── Test helpers ──────────────────────────────────────────────────
 
@@ -442,4 +460,63 @@ test('verifyCyclesPermitReceipt (sync): DID URI signer → DID_RESOLVER_MISSING'
   const result = verifyCyclesPermitReceipt(receipt)
   assert.equal(result.valid, false)
   if (!result.valid) assert.equal(result.reason, 'DID_RESOLVER_MISSING')
+})
+
+// ── Authority-state-at-admission (Track B, aps#25, staged) ────────
+
+test('computeAuthorityStateRef: deterministic and matches the pinned fixture ref', () => {
+  // (a) deterministic — same snapshot, same ref across calls.
+  const r1 = computeAuthorityStateRef(ADMISSION_SNAPSHOT_FIXTURE)
+  const r2 = computeAuthorityStateRef(ADMISSION_SNAPSHOT_FIXTURE)
+  assert.equal(r1, r2)
+  // matches the frozen fixture ref (regression pin on the hash scheme).
+  assert.equal(r1, ADMISSION_SNAPSHOT_REF)
+  assert.match(r1, /^[0-9a-f]{64}$/)
+})
+
+test('signCyclesPermitReceipt: WITH admission_authority_state → carries the ref and verifies', () => {
+  const { privateKey } = generateKeyPair()
+  const receipt = signCyclesPermitReceipt(
+    {
+      agent_id: 'agent-cycles-001',
+      delegation_ref: 'aps:delegation:cycles-admission-001',
+      action_ref: 'aps:action:cycles-admission-001',
+      reservation_id: 'rsv_admission_001',
+      reserved: { unit: 'USD_MICROCENTS', amount: 1500000 },
+      decision: 'ALLOW',
+      cycles_evidence: evidenceRef(),
+      admission_authority_state: ADMISSION_SNAPSHOT_FIXTURE,
+    },
+    privateKey,
+  )
+  // (b) the optional field is set to the snapshot's computed ref...
+  assert.equal(receipt.admission_authority_state_ref, ADMISSION_SNAPSHOT_REF)
+  // ...and the receipt (with the field inside the signed body) verifies.
+  assert.deepEqual(verifyCyclesPermitReceipt(receipt), { valid: true })
+  // tampering the snapshot ref breaks the signature (field is signed-over).
+  const tampered = { ...receipt, admission_authority_state_ref: 'b'.repeat(64) }
+  const result = verifyCyclesPermitReceipt(tampered)
+  assert.equal(result.valid, false)
+  if (!result.valid) assert.equal(result.reason, 'SIGNATURE_INVALID')
+})
+
+test('signCyclesPermitReceipt: WITHOUT the snapshot → field absent, receipt verifies unchanged', () => {
+  const { privateKey } = generateKeyPair()
+  const receipt = signCyclesPermitReceipt(
+    {
+      agent_id: 'agent-cycles-001',
+      delegation_ref: 'aps:delegation:cycles-001',
+      action_ref: 'aps:action:cycles-001',
+      reservation_id: 'rsv_no_snapshot',
+      reserved: { unit: 'USD_MICROCENTS', amount: 1000 },
+      decision: 'ALLOW',
+      cycles_evidence: evidenceRef(),
+    },
+    privateKey,
+  )
+  // (c) callers that pass nothing get the field undefined (absent from the
+  // object, so existing fixtures/canonical bytes are unchanged) and verify.
+  assert.equal(receipt.admission_authority_state_ref, undefined)
+  assert.equal(Object.prototype.hasOwnProperty.call(receipt, 'admission_authority_state_ref'), false)
+  assert.deepEqual(verifyCyclesPermitReceipt(receipt), { valid: true })
 })

--- a/tests/v2/payment-rails/cycles.test.ts
+++ b/tests/v2/payment-rails/cycles.test.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { generateKeyPair } from '../../../src/crypto/keys.js'
 import {
-  computeAuthorityStateRef,
   mapCyclesDenialToFoundation,
   RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE,
   RAIL_BUDGET_RESERVATION_PERMIT_CLAIM_TYPE,
@@ -24,21 +23,17 @@ import type {
   CyclesEvidenceView,
 } from '../../../src/v2/payment-rails/cycles/types.js'
 
-// ── Authority-state-at-admission fixtures (Track B, aps#25) ───────
-// Pinned snapshot + its content-hash ref. The ref is a regression pin:
-// computed once via computeAuthorityStateRef (sha256 over JCS-canonical
-// bytes) and frozen here so a canonicalization or scheme change trips.
+// ── Authority-state-at-admission fixture (Track B, aps#25) ────────
+// The authority/revocation/expiry state APS saw at admission, carried
+// inline on the permit-receipt (delegation identity is not duplicated —
+// the receipt's own delegation_ref names it).
 
 const ADMISSION_SNAPSHOT_FIXTURE: AuthorityStateSnapshot = {
   checked_at: '2026-05-30T12:00:00.000Z',
-  delegation_ref: 'aps:delegation:cycles-admission-001',
   delegation_revoked: false,
   delegation_expires_at: '2026-06-30T00:00:00.000Z',
   source: 'aps_admission',
 }
-
-const ADMISSION_SNAPSHOT_REF =
-  '33cadcb7385de69c38f7a3b897dee12e70c6ecf505e1da3c7691baee14748d23'
 
 // ── Test helpers ──────────────────────────────────────────────────
 
@@ -462,19 +457,9 @@ test('verifyCyclesPermitReceipt (sync): DID URI signer → DID_RESOLVER_MISSING'
   if (!result.valid) assert.equal(result.reason, 'DID_RESOLVER_MISSING')
 })
 
-// ── Authority-state-at-admission (Track B, aps#25, staged) ────────
+// ── Authority-state-at-admission (Track B, aps#25, staged, inline) ─
 
-test('computeAuthorityStateRef: deterministic and matches the pinned fixture ref', () => {
-  // (a) deterministic — same snapshot, same ref across calls.
-  const r1 = computeAuthorityStateRef(ADMISSION_SNAPSHOT_FIXTURE)
-  const r2 = computeAuthorityStateRef(ADMISSION_SNAPSHOT_FIXTURE)
-  assert.equal(r1, r2)
-  // matches the frozen fixture ref (regression pin on the hash scheme).
-  assert.equal(r1, ADMISSION_SNAPSHOT_REF)
-  assert.match(r1, /^[0-9a-f]{64}$/)
-})
-
-test('signCyclesPermitReceipt: WITH admission_authority_state → carries the ref and verifies', () => {
+test('signCyclesPermitReceipt: WITH authority_state_at_admission → carries the inline object and verifies', () => {
   const { privateKey } = generateKeyPair()
   const receipt = signCyclesPermitReceipt(
     {
@@ -485,16 +470,40 @@ test('signCyclesPermitReceipt: WITH admission_authority_state → carries the re
       reserved: { unit: 'USD_MICROCENTS', amount: 1500000 },
       decision: 'ALLOW',
       cycles_evidence: evidenceRef(),
-      admission_authority_state: ADMISSION_SNAPSHOT_FIXTURE,
+      authority_state_at_admission: ADMISSION_SNAPSHOT_FIXTURE,
     },
     privateKey,
   )
-  // (b) the optional field is set to the snapshot's computed ref...
-  assert.equal(receipt.admission_authority_state_ref, ADMISSION_SNAPSHOT_REF)
-  // ...and the receipt (with the field inside the signed body) verifies.
+  // (a) the inline snapshot is carried verbatim on the receipt...
+  assert.deepEqual(receipt.authority_state_at_admission, ADMISSION_SNAPSHOT_FIXTURE)
+  // ...and the receipt (with the object inside the signed body) verifies.
   assert.deepEqual(verifyCyclesPermitReceipt(receipt), { valid: true })
-  // tampering the snapshot ref breaks the signature (field is signed-over).
-  const tampered = { ...receipt, admission_authority_state_ref: 'b'.repeat(64) }
+})
+
+test('signCyclesPermitReceipt: tampering a field inside authority_state_at_admission → SIGNATURE_INVALID', () => {
+  const { privateKey } = generateKeyPair()
+  const receipt = signCyclesPermitReceipt(
+    {
+      agent_id: 'agent-cycles-001',
+      delegation_ref: 'aps:delegation:cycles-admission-001',
+      action_ref: 'aps:action:cycles-admission-001',
+      reservation_id: 'rsv_admission_001',
+      reserved: { unit: 'USD_MICROCENTS', amount: 1500000 },
+      decision: 'ALLOW',
+      cycles_evidence: evidenceRef(),
+      authority_state_at_admission: ADMISSION_SNAPSHOT_FIXTURE,
+    },
+    privateKey,
+  )
+  // (b) flip delegation_revoked inside the inline object — the snapshot is
+  // part of the signed body, so the signature must catch it.
+  const tampered = {
+    ...receipt,
+    authority_state_at_admission: {
+      ...receipt.authority_state_at_admission!,
+      delegation_revoked: true,
+    },
+  }
   const result = verifyCyclesPermitReceipt(tampered)
   assert.equal(result.valid, false)
   if (!result.valid) assert.equal(result.reason, 'SIGNATURE_INVALID')
@@ -514,9 +523,8 @@ test('signCyclesPermitReceipt: WITHOUT the snapshot → field absent, receipt ve
     },
     privateKey,
   )
-  // (c) callers that pass nothing get the field undefined (absent from the
-  // object, so existing fixtures/canonical bytes are unchanged) and verify.
-  assert.equal(receipt.admission_authority_state_ref, undefined)
-  assert.equal(Object.prototype.hasOwnProperty.call(receipt, 'admission_authority_state_ref'), false)
+  // (c) callers that pass nothing get the field absent from the object (so
+  // existing fixtures/canonical bytes are unchanged) and verify.
+  assert.equal(Object.prototype.hasOwnProperty.call(receipt, 'authority_state_at_admission'), false)
   assert.deepEqual(verifyCyclesPermitReceipt(receipt), { valid: true })
 })


### PR DESCRIPTION
## What

Adds an optional `authority_state_at_admission` field to `CyclesPermitReceipt`: a small snapshot of the delegation authority and revocation state that APS evaluated at admission, before calling Cycles.

```
authority_state_at_admission?: {
  checked_at: string            // admission-time ISO 8601
  delegation_revoked: boolean   // revocation state APS saw at admission
  delegation_expires_at?: string
  source: 'aps_admission'
}
```

## Why

From @amavashev's review on #25: the permit receipt referenced the delegation by `delegation_ref` but did not record whether that delegation was un-revoked and unexpired at the moment of admission. That is the APS-layer half of the audit question, since Cycles never sees delegation state, and it is the kind of field that is painful to backfill once receipts are signed in the wild.

## Shape decision: inline, not a content-hash ref

The snapshot is carried inline rather than as a content-hash reference to a separate artifact. A bare ref would only prove that some authority state with a given hash was bound at signing, so an auditor would still have to fetch the pre-image to read whether the delegation was revoked. The snapshot is five small fields and its purpose is to be a directly-readable revocation proof, so it belongs in the receipt. `delegation_ref` is not repeated inside the snapshot, since the receipt already names it.

## Compatibility

Optional. When omitted, the field is absent from the object and therefore from the canonical and signed bytes, so existing receipts, fixtures, and callers sign and verify byte-identically. Confirmed by a test that asserts `hasOwnProperty` is false and the receipt still verifies.

## Tests

Three added (suite 3,076 to 3,079, all green): the field round-trips and verifies when supplied; tampering a field inside it returns `SIGNATURE_INVALID`, proving it is inside the signed body; and the omitted case stays absent and valid.
