### PR TITLE
feat(payment-rails/cycles): verify CyclesEvidence envelope Ed25519 signature (#43 (a))

### DIFF
--- a/src/v2/payment-rails/cycles/index.ts
+++ b/src/v2/payment-rails/cycles/index.ts
@@ -45,9 +45,11 @@
 //   derivation") → EVIDENCE_SIGNATURE_INVALID on failure. A passing result
 //   reports `evidence_authenticity`: 'signature_valid' (bytes verify against
 //   signer_did) or 'pinned_issuer' (that PLUS expected_signer pinning the
-//   receipt issuer = full authenticity for the pinned case). Dynamic
-//   signer-AUTHORITY resolution for the unpinned case — (b) — is the v0.2
-//   work tracked at runcycles/cycles-protocol#103, not done here.
+//   APS receipt issuer — envelope authenticity then holds TRANSITIVELY, to
+//   the extent the pinned issuer is trusted to bind only legitimate
+//   envelopes; not a proof of signer_did's own authority). Resolving
+//   signer-AUTHORITY directly — (b) — is the v0.2 work tracked at
+//   runcycles/cycles-protocol#103, not done here.
 //
 // Out of scope for this commit (TODO follow-up):
 //   - (b) envelope signer-authority resolution (did:cycles / JWKS /
@@ -561,8 +563,9 @@ function _checkEvidenceJoin(
  * Build the passing result, tagging envelope authenticity (APS#43) when an
  * envelope was supplied. Reaching here with `options.evidence` set means the
  * join check passed, i.e. the envelope's signature verified ((a) held), so
- * the tag is 'pinned_issuer' when the receipt issuer is pinned via
- * `expected_signer` (full authenticity for the pinned case) and
+ * the tag is 'pinned_issuer' when the APS receipt issuer is pinned via
+ * `expected_signer` (envelope authenticity then holds transitively through
+ * the trusted issuer — not a direct proof of signer_did authority) and
  * 'signature_valid' otherwise. Omitted entirely when no envelope was passed.
  */
 function _validResult(options: VerifyCyclesOptions): CyclesVerifyResult {

--- a/src/v2/payment-rails/cycles/index.ts
+++ b/src/v2/payment-rails/cycles/index.ts
@@ -38,7 +38,20 @@
 //   cycles_evidence.cycles_evidence_id_sha256 → EVIDENCE_REF_HASH_MISMATCH
 //   on either failure. Omit the envelope for signature-only verification.
 //
+// Envelope authenticity — APS#43 (a):
+//   With the same VerifyCyclesOptions.evidence, verify also checks the
+//   envelope's OWN Ed25519 signature against its signer_did (signature
+//   emptied, evidence_id populated — cycles-evidence-v0.1 "Signature
+//   derivation") → EVIDENCE_SIGNATURE_INVALID on failure. A passing result
+//   reports `evidence_authenticity`: 'signature_valid' (bytes verify against
+//   signer_did) or 'pinned_issuer' (that PLUS expected_signer pinning the
+//   receipt issuer = full authenticity for the pinned case). Dynamic
+//   signer-AUTHORITY resolution for the unpinned case — (b) — is the v0.2
+//   work tracked at runcycles/cycles-protocol#103, not done here.
+//
 // Out of scope for this commit (TODO follow-up):
+//   - (b) envelope signer-authority resolution (did:cycles / JWKS /
+//     rotation), gated on runcycles/cycles-protocol#103.
 //   - preAuthorizeCyclesReserve gateway hook into PaymentRail interface
 //     (gateway-flow placement — held for the AEOESS gateway-flow ADR,
 //     aeoess/agent-passport-system#25).
@@ -467,20 +480,33 @@ type AnyCyclesSigned = CyclesPermitReceipt | CyclesReleaseReceipt | CyclesDenial
  *   (b) the receipt's `cycles_evidence.cycles_evidence_id_sha256`
  *                                          — the receipt binds to THIS envelope.
  *
- * Returns a failing result on mismatch, or `null` when the check passes
- * or is skipped (no envelope supplied → signature-only verification).
+ * Returns a failing result on mismatch, or `null` when the checks pass
+ * or are skipped (no envelope supplied → signature-only verification).
  *
- * Scope: verifies the receipt↔envelope HASH binding and envelope self-
- * consistency. It does NOT verify the envelope's OWN Ed25519 signature
- * against the Cycles signer key — cycles-evidence-v0.1 defers Cycles
- * signer-key resolution (did:cycles / JWKS) to v0.2, so envelope-
- * authenticity verification lands then. The APS receipt's own signature
- * (verified separately below) attests that APS vouched for this binding.
+ * Two checks, both gated on a supplied envelope:
  *
- * Cross-system byte-match note: APS `canonicalizeJCS` reproduces the
- * `evidence_id` of every cycles-protocol reference fixture, so the empty-
- * string-sentinel rule here is the SAME canonicalization the Cycles server
- * used to derive the hash. Field omission would produce different bytes.
+ *   1. HASH BINDING + self-consistency (recompute empties BOTH `evidence_id`
+ *      and `signature`): the receipt binds to THIS envelope and the envelope
+ *      is internally consistent. Mismatch → EVIDENCE_REF_HASH_MISMATCH.
+ *
+ *   2. ENVELOPE SIGNATURE (APS#43 (a)): the envelope's OWN Ed25519
+ *      `signature` verifies against the key named in `signer_did`. The
+ *      signed bytes use a DIFFERENT canonicalization — `signature` emptied
+ *      but `evidence_id` POPULATED — per cycles-evidence-v0.1's normative
+ *      "Signature derivation". Failure → EVIDENCE_SIGNATURE_INVALID.
+ *
+ * Scope boundary (the (a)/(b) split): check 2 proves the bytes were signed
+ * by the key in `signer_did` — it does NOT prove that key is the legitimate
+ * Cycles signer rather than an attacker key inside a self-consistent forgery.
+ * That is signer-*authority* resolution (did:cycles / JWKS / rotation), the
+ * v0.2 (b) work tracked at runcycles/cycles-protocol#103. The manual form of
+ * (b) is pinning the receipt issuer via `options.expected_signer`; the
+ * verify result reports which guarantee held via `evidence_authenticity`.
+ *
+ * Cross-system byte-match note: APS `canonicalizeJCS` reproduces both the
+ * `evidence_id` AND the signed bytes of every cycles-protocol reference
+ * fixture, so the empty-string-sentinel rules here are the SAME
+ * canonicalizations the Cycles server used. Field omission would differ.
  */
 function _checkEvidenceJoin(
   obj: AnyCyclesSigned,
@@ -506,7 +532,45 @@ function _checkEvidenceJoin(
       detail: `receipt cycles_evidence_id_sha256 ${obj.cycles_evidence.cycles_evidence_id_sha256} != envelope ${recomputed}`,
     }
   }
+
+  // (a) Envelope authenticity: verify the envelope's own Ed25519 signature
+  // against signer_did. Canonical bytes = envelope with `signature` emptied
+  // and `evidence_id` left populated (the post-hash, pre-signature form).
+  // Fail closed when either field is absent — a supplied envelope without a
+  // verifiable self-signature is not authenticatable. (A `did:`-method
+  // signer_did is not resolvable here in v0.1; that is the (b) path.)
+  const signerDid = env.signer_did
+  if (typeof signerDid !== 'string' || signerDid.length === 0) {
+    return { valid: false, reason: 'EVIDENCE_SIGNATURE_INVALID', detail: 'envelope missing signer_did' }
+  }
+  if (typeof env.signature !== 'string' || env.signature.length === 0) {
+    return { valid: false, reason: 'EVIDENCE_SIGNATURE_INVALID', detail: 'envelope missing signature' }
+  }
+  const envSigBytes = canonicalizeJCS({ ...env, signature: '' })
+  if (!edVerify(envSigBytes, env.signature, signerDid)) {
+    return {
+      valid: false,
+      reason: 'EVIDENCE_SIGNATURE_INVALID',
+      detail: 'envelope Ed25519 signature does not verify against signer_did',
+    }
+  }
   return null
+}
+
+/**
+ * Build the passing result, tagging envelope authenticity (APS#43) when an
+ * envelope was supplied. Reaching here with `options.evidence` set means the
+ * join check passed, i.e. the envelope's signature verified ((a) held), so
+ * the tag is 'pinned_issuer' when the receipt issuer is pinned via
+ * `expected_signer` (full authenticity for the pinned case) and
+ * 'signature_valid' otherwise. Omitted entirely when no envelope was passed.
+ */
+function _validResult(options: VerifyCyclesOptions): CyclesVerifyResult {
+  if (!options.evidence) return { valid: true }
+  return {
+    valid: true,
+    evidence_authenticity: options.expected_signer ? 'pinned_issuer' : 'signature_valid',
+  }
 }
 
 function _verifyReceiptCore(
@@ -577,7 +641,7 @@ function _verifyReceiptCore(
   if (!edVerify(sigBytes, signature, obj.signer)) {
     return { valid: false, reason: 'SIGNATURE_INVALID', detail: 'Ed25519 verify failed' }
   }
-  return { valid: true }
+  return _validResult(options)
 }
 
 async function _verifyReceiptWithDID(
@@ -613,7 +677,7 @@ async function _verifyReceiptWithDID(
   if (!edVerify(sigBytes, signature, pubHex)) {
     return { valid: false, reason: 'SIGNATURE_INVALID', detail: 'Ed25519 verify failed' }
   }
-  return { valid: true }
+  return _validResult(options)
 }
 
 // ── External-evidence resolution: claimed vs resolved (W2-A2) ─────

--- a/src/v2/payment-rails/cycles/types.ts
+++ b/src/v2/payment-rails/cycles/types.ts
@@ -282,14 +282,38 @@ export type CyclesVerifyReason =
   | 'SIGNATURE_INVALID'
   | 'EXPIRED'
   | 'EVIDENCE_REF_HASH_MISMATCH'
+  /** The supplied CyclesEvidence envelope's OWN Ed25519 signature does not
+   *  verify against the key in its `signer_did` (or `signer_did`/`signature`
+   *  is absent). APS#43 (a): envelope signature validity. Distinct from
+   *  EVIDENCE_REF_HASH_MISMATCH, which is the receipt↔envelope hash binding. */
+  | 'EVIDENCE_SIGNATURE_INVALID'
   | 'DID_RESOLVER_MISSING'
   | 'DID_URI_INVALID'
   | 'DID_DOC_NOT_FOUND'
   | 'DID_KEY_NOT_IN_DOC'
   | 'DID_KEY_RETIRED'
 
+/**
+ * Which envelope-authenticity guarantee a passing verify actually checked,
+ * surfaced when `options.evidence` is supplied (APS#43, the (a)/(b) split).
+ * Present ONLY on a `valid: true` result that carried an envelope.
+ *
+ *  - 'signature_valid' : the envelope's own Ed25519 `signature` verifies
+ *      against the key named in its `signer_did`. This is (a). It proves
+ *      the bytes were signed by *that* key — NOT that the key is the
+ *      legitimate Cycles signer. A forger can embed their own key and
+ *      self-sign a consistent envelope, so signature_valid alone is not
+ *      authenticity.
+ *  - 'pinned_issuer'   : signature_valid AND the caller pinned the receipt
+ *      issuer via `expected_signer` (enforced separately). The pin supplies
+ *      the trust anchor (the manual form of (b)), so for the pinned-issuer
+ *      case this IS full authenticity. Dynamic signer-authority resolution
+ *      for the unpinned case is (b), gated on runcycles/cycles-protocol#103.
+ */
+export type EvidenceAuthenticity = 'signature_valid' | 'pinned_issuer'
+
 export type CyclesVerifyResult =
-  | { valid: true }
+  | { valid: true; evidence_authenticity?: EvidenceAuthenticity }
   | { valid: false; reason: CyclesVerifyReason; detail?: string }
 
 // ── Sign-function input shapes (mirror the mpp/x402 pattern) ──────
@@ -365,8 +389,17 @@ export interface CyclesEvidenceEnvelopeInput {
    *  with `evidence_id` and `signature` both set to the empty string.
    *  Per runcycles/cycles-protocol drafts/cycles-evidence-v0.1.yaml. */
   evidence_id: string
-  /** Ed25519 signature hex; emptied (not omitted) during the recompute. */
+  /** Ed25519 signature hex over the JCS-canonical envelope with `signature`
+   *  emptied and `evidence_id` POPULATED (distinct from the content-hash
+   *  recipe, which empties both). Emptied (not omitted) during the recompute;
+   *  verified as-is against `signer_did` for the APS#43 (a) authenticity
+   *  check. Per runcycles/cycles-protocol drafts/cycles-evidence-v0.1.yaml. */
   signature: string
+  /** The Cycles signer key the envelope `signature` is verified against.
+   *  v0.1 form is a bare Ed25519 hex pubkey (self-describing); a future
+   *  `did:cycles` / JWKS resolvable form is the v0.2 (b) work tracked at
+   *  runcycles/cycles-protocol#103. */
+  signer_did: string
   [key: string]: unknown
 }
 

--- a/src/v2/payment-rails/cycles/types.ts
+++ b/src/v2/payment-rails/cycles/types.ts
@@ -305,10 +305,15 @@ export type CyclesVerifyReason =
  *      self-sign a consistent envelope, so signature_valid alone is not
  *      authenticity.
  *  - 'pinned_issuer'   : signature_valid AND the caller pinned the receipt
- *      issuer via `expected_signer` (enforced separately). The pin supplies
- *      the trust anchor (the manual form of (b)), so for the pinned-issuer
- *      case this IS full authenticity. Dynamic signer-authority resolution
- *      for the unpinned case is (b), gated on runcycles/cycles-protocol#103.
+ *      issuer via `expected_signer` (enforced separately). NOTE the pin is on
+ *      the APS *receipt* signer (`obj.signer`), not the envelope's
+ *      `signer_did`. Envelope authenticity is therefore TRANSITIVE: it holds
+ *      only insofar as you trust the pinned receipt issuer to have bound this
+ *      receipt solely to a legitimate Cycles envelope. This is the manual
+ *      form of (b) — a trust assumption about the pinned issuer, not a
+ *      cryptographic proof of `signer_did`'s authority. Resolving that
+ *      authority directly (so the unpinned case is also covered) is (b),
+ *      gated on runcycles/cycles-protocol#103.
  */
 export type EvidenceAuthenticity = 'signature_valid' | 'pinned_issuer'
 

--- a/tests/v2/payment-rails/cycles.test.ts
+++ b/tests/v2/payment-rails/cycles.test.ts
@@ -4,7 +4,9 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { generateKeyPair } from '../../../src/crypto/keys.js'
+import { generateKeyPair, publicKeyFromPrivate, sign } from '../../../src/crypto/keys.js'
+import { canonicalizeJCS } from '../../../src/core/canonical-jcs.js'
+import { sha256Hex } from '../../../src/v2/payment-rails/canonicalize.js'
 import {
   mapCyclesDenialToFoundation,
   RAIL_BUDGET_RESERVATION_DENIAL_CLAIM_TYPE,
@@ -563,7 +565,12 @@ test('join-integrity: permit receipt + matching envelope → valid', () => {
   const { privateKey } = generateKeyPair()
   const env = loadEnvelope('02-reserve-allow.json')
   const receipt = permitBoundTo(env, privateKey)
-  assert.deepEqual(verifyCyclesPermitReceipt(receipt, { evidence: env }), { valid: true })
+  // Envelope supplied → join + envelope-signature both checked; the passing
+  // result tags the unpinned authenticity state (APS#43 (a)).
+  assert.deepEqual(verifyCyclesPermitReceipt(receipt, { evidence: env }), {
+    valid: true,
+    evidence_authenticity: 'signature_valid',
+  })
 })
 
 test('join-integrity: envelope omitted → check skipped, signature-only verify still passes', () => {
@@ -622,7 +629,10 @@ test('join-integrity: applies on the denial path too (shared core verifier)', ()
     },
     privateKey,
   )
-  assert.deepEqual(verifyCyclesDenial(denial, { evidence: env }), { valid: true })
+  assert.deepEqual(verifyCyclesDenial(denial, { evidence: env }), {
+    valid: true,
+    evidence_authenticity: 'signature_valid',
+  })
   // And a mismatched binding is caught on the denial path.
   const wrong = verifyCyclesDenial(denial, {
     evidence: { ...env, server_id: 'https://evil.example.com/v1' },
@@ -665,4 +675,100 @@ test('join-integrity: receipt hash correct but uppercase → EVIDENCE_REF_HASH_M
   const result = verifyCyclesPermitReceipt(receipt, { evidence: env })
   assert.equal(result.valid, false)
   if (!result.valid) assert.equal(result.reason, 'EVIDENCE_REF_HASH_MISMATCH')
+})
+
+// ── Envelope authenticity: APS#43 (a) — envelope Ed25519 signature ─
+// Beyond the hash binding, a supplied envelope's OWN signature is verified
+// against its signer_did (signature emptied, evidence_id populated — the
+// cycles-evidence-v0.1 "Signature derivation" canonicalization, distinct
+// from the content-hash recipe). A passing verify tags evidence_authenticity:
+// 'signature_valid' (bytes verify against signer_did) or 'pinned_issuer'
+// (that PLUS expected_signer pinning the receipt issuer = full authenticity
+// for the pinned case). Dynamic signer-AUTHORITY resolution is (b), gated on
+// runcycles/cycles-protocol#103 and intentionally NOT done here.
+
+/** Re-derive a fully self-consistent envelope signed by `privateKey`:
+ *  re-points signer_did to that key, recomputes evidence_id, and re-signs.
+ *  Models an envelope an arbitrary key produced (used for the (a)/(b)
+ *  boundary test). */
+function resignEnvelope(
+  env: CyclesEvidenceEnvelopeInput,
+  privateKey: string,
+): CyclesEvidenceEnvelopeInput {
+  const signer_did = publicKeyFromPrivate(privateKey)
+  const evidence_id = sha256Hex(
+    canonicalizeJCS({ ...env, signer_did, evidence_id: '', signature: '' }),
+  )
+  const signature = sign(
+    canonicalizeJCS({ ...env, signer_did, evidence_id, signature: '' }),
+    privateKey,
+  )
+  return { ...env, signer_did, evidence_id, signature }
+}
+
+test('envelope-authenticity: valid signature + pinned receipt issuer → pinned_issuer', () => {
+  const { privateKey } = generateKeyPair()
+  const env = loadEnvelope('02-reserve-allow.json')
+  const receipt = permitBoundTo(env, privateKey)
+  // expected_signer pins the receipt issuer (the trust anchor / manual (b)).
+  const result = verifyCyclesPermitReceipt(receipt, {
+    evidence: env,
+    expected_signer: publicKeyFromPrivate(privateKey),
+  })
+  assert.deepEqual(result, { valid: true, evidence_authenticity: 'pinned_issuer' })
+})
+
+test('envelope-authenticity: hash-consistent envelope with a bad signature → EVIDENCE_SIGNATURE_INVALID', () => {
+  const { privateKey } = generateKeyPair()
+  const env = loadEnvelope('02-reserve-allow.json')
+  const receipt = permitBoundTo(env, privateKey)
+  // Zero the signature. The hash recompute empties `signature`, so the
+  // binding/self-consistency check still PASSES — only the (a) signature
+  // check catches it. This is the core (a) guarantee.
+  const forged = { ...env, signature: '0'.repeat(128) }
+  const result = verifyCyclesPermitReceipt(receipt, { evidence: forged })
+  assert.equal(result.valid, false)
+  if (!result.valid) assert.equal(result.reason, 'EVIDENCE_SIGNATURE_INVALID')
+})
+
+test('envelope-authenticity: (a)/(b) boundary — attacker self-signs, signature_valid still holds (NOT authenticity)', () => {
+  const { privateKey: issuerKey } = generateKeyPair()
+  const { privateKey: attackerKey } = generateKeyPair()
+  const env = loadEnvelope('02-reserve-allow.json')
+  // Attacker re-signs the envelope with THEIR OWN key and embeds their own
+  // pubkey as signer_did — a fully self-consistent forgery.
+  const forged = resignEnvelope(env, attackerKey)
+  const receipt = permitBoundTo(forged, issuerKey)
+  // (a) alone passes: the bytes verify against the embedded signer_did. This
+  // is exactly why signature_valid is NOT authenticity — it is the (b) gap
+  // that did:cycles / JWKS resolution (cycles-protocol#103) closes.
+  assert.deepEqual(verifyCyclesPermitReceipt(receipt, { evidence: forged }), {
+    valid: true,
+    evidence_authenticity: 'signature_valid',
+  })
+})
+
+test('envelope-authenticity: self-consistent envelope missing signer_did → EVIDENCE_SIGNATURE_INVALID', () => {
+  const { privateKey } = generateKeyPair()
+  const env = loadEnvelope('02-reserve-allow.json')
+  // Drop signer_did and recompute evidence_id over the reduced shape, so the
+  // hash binding still passes and the missing-signer_did guard is what fires.
+  const { signer_did: _omit, ...noDid } = env
+  const evidence_id = sha256Hex(canonicalizeJCS({ ...noDid, evidence_id: '', signature: '' }))
+  const consistent = { ...noDid, evidence_id } as unknown as CyclesEvidenceEnvelopeInput
+  const receipt = permitBoundTo(consistent, privateKey)
+  const result = verifyCyclesPermitReceipt(receipt, { evidence: consistent })
+  assert.equal(result.valid, false)
+  if (!result.valid) assert.equal(result.reason, 'EVIDENCE_SIGNATURE_INVALID')
+})
+
+test('envelope-authenticity: empty signature (hash-consistent) → EVIDENCE_SIGNATURE_INVALID', () => {
+  const { privateKey } = generateKeyPair()
+  const env = loadEnvelope('02-reserve-allow.json')
+  const receipt = permitBoundTo(env, privateKey)
+  // `signature` is emptied during the hash recompute, so an empty signature
+  // leaves the binding intact — the empty-signature guard is what fires.
+  const result = verifyCyclesPermitReceipt(receipt, { evidence: { ...env, signature: '' } })
+  assert.equal(result.valid, false)
+  if (!result.valid) assert.equal(result.reason, 'EVIDENCE_SIGNATURE_INVALID')
 })


### PR DESCRIPTION
Implements the **(a)** half of the envelope-authenticity split agreed in #43: verify the supplied `CyclesEvidence` envelope's **own** Ed25519 signature against the key in `signer_did`, and surface which guarantee actually held. @aeoess

## What

- `_checkEvidenceJoin`, after the existing receipt↔envelope **hash binding** (#42), now verifies the envelope's own signature against `signer_did` using the `cycles-evidence-v0.1` normative **"Signature derivation"** canonicalization — `signature` emptied, `evidence_id` **populated** (distinct from the content-hash recipe, which empties both). Failure → new reason **`EVIDENCE_SIGNATURE_INVALID`**. Fail-closed when `signer_did`/`signature` is absent.
- A passing verify reports **`evidence_authenticity`**, keeping the split explicit rather than collapsing to a single `valid: true`:
  - `'signature_valid'` — the bytes verify against the named `signer_did`;
  - `'pinned_issuer'` — that **plus** `expected_signer` pinning the receipt issuer (the manual trust anchor) = full authenticity for the pinned-issuer case.
  - Present only when `options.evidence` was supplied.
- `CyclesEvidenceEnvelopeInput` gains `signer_did`.
- Hung off the existing `resolveEvidenceRef` / `recomputeEvidenceContentHash` surface, next to the `options.evidence` path, as we discussed.

## Scope boundary — (a) vs (b)

This proves the bytes were signed by the key in `signer_did` — **not** that the key is the legitimate Cycles signer (a forger can embed their own key and self-sign a consistent envelope; the boundary test below demonstrates exactly this). Dynamic signer-**authority** resolution (did:cycles / JWKS / rotation) is **(b)**, gated on `runcycles/cycles-protocol#103`, and intentionally not done here.

## Backward compatible

Omitting `options.evidence` preserves today's signature-only behavior; the success shape only adds an optional field.

## Tests

5 new cases + 2 updated assertions: `pinned_issuer`; bad signature (hash-consistent) → `EVIDENCE_SIGNATURE_INVALID`; the (a)/(b) boundary (attacker self-signs, `signature_valid` still holds — *not* authenticity); missing `signer_did`; empty signature. `cycles.test.ts` 34/34, `tsc --noEmit` clean. Verified empirically that all 4 `cycles-protocol` reference fixtures' envelope signatures verify against `signer_did` under this canonicalization.

Refs #43, #42, runcycles/cycles-protocol#103.
