### PR TITLE
feat(key-resolution): align did:cycles to the hash-bound + window model (#43)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -332,7 +332,7 @@ export {
 // ── Key Resolution (M3): KeyResolver interface + did:cycles/JWKS ──
 export {
   CyclesKeyResolver,
-  parseDIDCycles, isDIDCycles, asJWKS, selectKey,
+  parseDIDCycles, isDIDCycles, cyclesJwksUrl, asJWKS, selectKey,
   decodeBase64Url, bytesToHex as keyResolutionBytesToHex,
   DEFAULT_TIMEOUT_MS as KEY_RESOLUTION_DEFAULT_TIMEOUT_MS,
   DEFAULT_CACHE_POLICY as KEY_RESOLUTION_DEFAULT_CACHE_POLICY,

--- a/src/v2/key-resolution/README.md
+++ b/src/v2/key-resolution/README.md
@@ -36,7 +36,7 @@ with the Cycles maintainers on `runcycles/cycles-protocol` (#43, spec
 lowercase hex `sha256(server_id)`, a BINDING value, not a locator:
 
 ```
-did:cycles:<sha256(server_id)>            (optionally with #<kid>)
+did:cycles:<sha256(server_id)>#<kid>      (the #<kid> fragment is REQUIRED)
 ```
 
 A hash cannot be reversed to a URL, so `did:cycles` is **not self-locating**.
@@ -53,11 +53,13 @@ Keeping the JWKS under the same base anchors key authority to the exact
 `server_id` the DID hash commits to, closing the cross-tenant key-confusion path
 an origin-rooted JWKS would open under a path-multi-tenant host.
 
-A DID-URL fragment is the `kid`: `did:cycles:<hash>#2026-06` selects the JWK
-whose `kid === "2026-06"`. Selection adds a validity-WINDOW gate over the kid
-match: the key whose `[cycles_nbf_ms, cycles_exp_ms)` covers the envelope's
-`issued_at_ms` — never "the current key", so a receipt verified after a rotation
-checks against the key valid when it was signed. Zero/ambiguous matches fail
+The REQUIRED DID-URL fragment is the `kid`: `did:cycles:<hash>#2026-06` selects
+the JWK whose `kid === "2026-06"` (resolution fails closed for a did:cycles with
+no fragment). Selection adds a validity-WINDOW gate over the kid match: the key
+whose `[cycles_nbf_ms, cycles_exp_ms)` covers the envelope's `issued_at_ms` —
+never "the current key", so a receipt verified after a rotation checks against
+the key valid when it was signed. `kid` MUST be unique across the set (a
+duplicate kid is an authority failure set-wide); zero/ambiguous matches fail
 closed.
 
 ## Key selection

--- a/src/v2/key-resolution/README.md
+++ b/src/v2/key-resolution/README.md
@@ -103,6 +103,8 @@ off-host redirects are not followed.
 - JWK Set + `kid`/`use`/`alg`: RFC 7517.
 - OKP/Ed25519 JWK (`kty`/`crv`/`x`, EdDSA): RFC 8037.
 - Ed25519 algorithm + Test 1 vector: RFC 8032 §7.1.
-- DID-to-HTTPS mapping pattern mirrored from: did:web.
 - base64url: RFC 7515 §2 / RFC 4648 §5.
-- `did:cycles`: no external spec exists; AEOESS-defined here.
+- `did:cycles`: hash-bound (subject = `sha256(server_id)`) + API-base-relative
+  JWKS + validity-window selection, settled with the Cycles maintainers on
+  `runcycles/cycles-protocol` (#43; spec `drafts/cycles-evidence-v0.1`). NOT a
+  did:web-style host mapping — that earlier M3 shape was dropped.

--- a/src/v2/key-resolution/README.md
+++ b/src/v2/key-resolution/README.md
@@ -20,7 +20,9 @@ no registry, no alerting, and no network endpoint exposed by this module.
   - `did:web`: fetches the DID Document (reuses existing `resolveDIDWeb`),
     selects a `verificationMethod` by fragment.
   - `did:cycles` / direct `jwksUrl`: fetches a JWKS (RFC 7517), selects an
-    Ed25519 key (RFC 8037) by `kid`.
+    Ed25519 key (RFC 8037) by `kid`, with an optional validity-window gate
+    (`issuedAtMs`) and raw-hex signer match (`publicKeyHex`). `did:cycles` is
+    hash-bound and NOT self-locating — the caller supplies `jwksUrl` (see below).
 - **Caching**: in-process TTL cache with distinct hit/miss handling. A cached
   miss is never promoted to a key.
 - **Failure policy**: explicit `fail-open` vs `fail-closed`, defaulting to
@@ -28,19 +30,35 @@ no registry, no alerting, and no network endpoint exposed by this module.
 
 ## did:cycles method shape
 
-`did:cycles` is an AEOESS-defined, `did:web`-style, HTTPS-anchored method. It
-mirrors `didWebToUrl` exactly, except the resolved document is a JWKS:
+`did:cycles` is an AEOESS-defined method for Cycles evidence signers, settled
+with the Cycles maintainers on `runcycles/cycles-protocol` (#43, spec
+`drafts/cycles-evidence-v0.1`). The subject is a **hash, not a host** — it is the
+lowercase hex `sha256(server_id)`, a BINDING value, not a locator:
 
 ```
-did:cycles:example.com          -> https://example.com/.well-known/jwks.json
-did:cycles:example.com:agents:7 -> https://example.com/agents/7/jwks.json
-did:cycles:example.com%3A8443   -> https://example.com:8443/.well-known/jwks.json
+did:cycles:<sha256(server_id)>            (optionally with #<kid>)
 ```
 
-A DID-URL fragment is the `kid`: `did:cycles:example.com#agent-7-2026` selects
-the JWK whose `kid === "agent-7-2026"`. With no fragment and exactly one signing
-key, that key is used; with more than one and no `kid`, resolution fails closed
-(ambiguous).
+A hash cannot be reversed to a URL, so `did:cycles` is **not self-locating**.
+The JWK Set is located from the envelope's own `server_id`, API-base-relative
+(NOT origin-rooted — `server_id` carries its path):
+
+```
+{server_id}/.well-known/cycles-jwks.json     (see cyclesJwksUrl)
+```
+
+The cycles verify layer (which holds the envelope) checks
+`sha256(server_id) === <subject>` and hands the resolver the derived `jwksUrl`.
+Keeping the JWKS under the same base anchors key authority to the exact
+`server_id` the DID hash commits to, closing the cross-tenant key-confusion path
+an origin-rooted JWKS would open under a path-multi-tenant host.
+
+A DID-URL fragment is the `kid`: `did:cycles:<hash>#2026-06` selects the JWK
+whose `kid === "2026-06"`. Selection adds a validity-WINDOW gate over the kid
+match: the key whose `[cycles_nbf_ms, cycles_exp_ms)` covers the envelope's
+`issued_at_ms` — never "the current key", so a receipt verified after a rotation
+checks against the key valid when it was signed. Zero/ambiguous matches fail
+closed.
 
 ## Key selection
 

--- a/src/v2/key-resolution/did-cycles.ts
+++ b/src/v2/key-resolution/did-cycles.ts
@@ -180,6 +180,23 @@ export function selectKey(jwks: JWKS, sel?: string | SelectKeyOptions): JWKSelec
     return { ok: false, status: 'not_found', reason: 'no Ed25519 signing key in JWKS' }
   }
 
+  // Cycles authority paths carry a window (issuedAtMs) and/or a raw-hex signer
+  // match (publicKeyHex). On those, `kid` MUST be unique across the whole set —
+  // a duplicate kid is an authority failure SET-WIDE, before any selection, so
+  // it can't be rescued by the window leaving one survivor or by selecting via
+  // the raw-hex path. (Generic non-cycles kid-only lookups keep RFC 7517's
+  // looser handling, enforced per-requested-kid below.)
+  if (opts.issuedAtMs !== undefined || opts.publicKeyHex !== undefined) {
+    const seen = new Set<string>()
+    for (const c of candidates) {
+      if (typeof c.kid !== 'string') continue
+      if (seen.has(c.kid)) {
+        return { ok: false, status: 'ambiguous', reason: `duplicate kid='${c.kid}' in JWK Set` }
+      }
+      seen.add(c.kid)
+    }
+  }
+
   // Raw-hex signer match (cycles): the published key must carry the signer's
   // bytes — and the spec applies the SAME validity-window gate to raw-hex
   // signers as to did:cycles, so a raw-hex selection REQUIRES an integer

--- a/src/v2/key-resolution/did-cycles.ts
+++ b/src/v2/key-resolution/did-cycles.ts
@@ -132,6 +132,10 @@ function isEd25519SigningCandidate(jwk: unknown): jwk is Ed25519JWK {
   if (k.kty !== 'OKP') return false
   if (k.crv !== 'Ed25519') return false
   if (typeof k.x !== 'string' || k.x.length === 0) return false
+  // A published verification key set must be public-only. A JWK carrying a
+  // private `d` member is leaked private material / a misconfiguration —
+  // reject it (fail-closed), never select it.
+  if (k.d !== undefined) return false
   if (k.use !== undefined && k.use !== 'sig') return false
   if (k.alg !== undefined && k.alg !== 'EdDSA') return false
   if (k.key_ops !== undefined) {

--- a/src/v2/key-resolution/did-cycles.ts
+++ b/src/v2/key-resolution/did-cycles.ts
@@ -180,8 +180,14 @@ export function selectKey(jwks: JWKS, sel?: string | SelectKeyOptions): JWKSelec
     return { ok: false, status: 'not_found', reason: 'no Ed25519 signing key in JWKS' }
   }
 
-  // Raw-hex signer match (cycles): the published key must carry the signer's bytes.
+  // Raw-hex signer match (cycles): the published key must carry the signer's
+  // bytes — and the spec applies the SAME validity-window gate to raw-hex
+  // signers as to did:cycles, so a raw-hex selection REQUIRES an integer
+  // issued_at_ms (no window-less raw acceptance).
   if (opts.publicKeyHex !== undefined) {
+    if (typeof opts.issuedAtMs !== 'number' || !Number.isInteger(opts.issuedAtMs)) {
+      return { ok: false, status: 'not_found', reason: 'raw-hex signer selection requires an integer issuedAtMs (window gate)' }
+    }
     const want = opts.publicKeyHex.toLowerCase()
     candidates = candidates.filter((c) => candidateToHex(c) === want)
     if (candidates.length === 0) {
@@ -189,11 +195,16 @@ export function selectKey(jwks: JWKS, sel?: string | SelectKeyOptions): JWKSelec
     }
   }
 
-  // kid match (exact, case-sensitive).
+  // kid match (exact, case-sensitive). kid MUST be unique within the set: a
+  // duplicate kid is an authority failure BEFORE any window discretion (so two
+  // same-kid keys with disjoint windows can't sneak one survivor through).
   if (opts.kid !== undefined) {
     const matches = candidates.filter((c) => c.kid === opts.kid)
     if (matches.length === 0) {
       return { ok: false, status: 'not_found', reason: `no key with kid='${opts.kid}'` }
+    }
+    if (matches.length > 1) {
+      return { ok: false, status: 'ambiguous', reason: `duplicate kid='${opts.kid}' in JWK Set` }
     }
     candidates = matches
   }

--- a/src/v2/key-resolution/did-cycles.ts
+++ b/src/v2/key-resolution/did-cycles.ts
@@ -197,6 +197,11 @@ export function selectKey(jwks: JWKS, sel?: string | SelectKeyOptions): JWKSelec
   // Validity-window gate (cycles): the key valid AT ISSUANCE, never the newest.
   if (opts.issuedAtMs !== undefined) {
     const t = opts.issuedAtMs
+    // Fail-closed on a non-finite-integer issuance time: never coerce a string
+    // or fractional value into the [nbf, exp) comparison.
+    if (typeof t !== 'number' || !Number.isInteger(t)) {
+      return { ok: false, status: 'not_found', reason: 'issuedAtMs must be an integer epoch-ms value' }
+    }
     candidates = candidates.filter((c) => windowCovers(c, t))
     if (candidates.length === 0) {
       return { ok: false, status: 'not_found', reason: 'no key whose validity window covers issued_at_ms' }

--- a/src/v2/key-resolution/did-cycles.ts
+++ b/src/v2/key-resolution/did-cycles.ts
@@ -1,47 +1,67 @@
 // Copyright 2024-2026 Tymofii Pidlisnyi. Apache-2.0 license. See LICENSE.
 // ══════════════════════════════════════════════════════════════════
-// did:cycles: DID-to-JWKS mapping and Ed25519 JWK selection (M3)
+// did:cycles: hash-bound DID → JWKS mapping and Ed25519 JWK selection
 // ══════════════════════════════════════════════════════════════════
-// did:cycles is an AEOESS-defined, did:web-style, HTTPS-anchored
-// method. There is no external registry to conform to; this file IS
-// its specification. It mirrors didWebToUrl() in core/did-interop.ts
-// exactly, except the method name is `cycles` and the resolved
-// document is a JWKS (RFC 7517) rather than a DID Document.
+// did:cycles is an AEOESS-defined method for Cycles evidence signers.
+// The design is settled with the Cycles maintainers on
+// runcycles/cycles-protocol (issue #43, spec drafts/cycles-evidence-v0.1).
+// There is no external registry to conform to; this file IS its
+// specification on the APS side.
 //
-//   did:cycles:example.com          -> https://example.com/.well-known/jwks.json
-//   did:cycles:example.com:agents:7 -> https://example.com/agents/7/jwks.json
-//   did:cycles:example.com%3A8443   -> https://example.com:8443/.well-known/jwks.json
+// SUBJECT IS A HASH, NOT A HOST (the load-bearing difference from a
+// did:web-style method):
 //
-// A DID-URL fragment is the kid:
-//   did:cycles:example.com#agent-7-2026
-// selects the JWK whose kid === "agent-7-2026" from the resolved set.
+//   did:cycles:<sha256(server_id)>            (optionally with #<kid>)
+//
+// The subject is the lowercase hex sha256 of the envelope's `server_id`
+// string — a BINDING, not a locator. The DID does NOT encode where the
+// keys live; a hash cannot be reversed to a URL. The JWK Set is located
+// from the envelope's own `server_id`:
+//
+//   {server_id}/.well-known/cycles-jwks.json            (API-base-relative)
+//
+// and the DID's hash is checked against `sha256(server_id)` so the key
+// authority stays anchored to the exact `server_id` (path included) the
+// envelope claims — closing the cross-tenant key-confusion path that an
+// origin-rooted JWKS would open under a path-multi-tenant host. (The
+// sha256 binding check itself is performed by the cycles verify layer,
+// which holds the envelope's `server_id` and the sha256 primitive.)
+//
+// A DID-URL fragment is the kid:  did:cycles:<hash>#2026-06  selects the
+// JWK whose kid === "2026-06" from the resolved set.
+//
+// Key selection adds a validity-WINDOW gate over the M3 kid match: pick
+// the key whose [cycles_nbf_ms, cycles_exp_ms) covers the envelope's
+// issued_at_ms, never "the current key" — so a receipt verified after a
+// rotation is checked against the key valid when it was signed.
 // ══════════════════════════════════════════════════════════════════
 
 import { decodeBase64Url, bytesToHex } from './base64url.js'
 import type { Ed25519JWK, JWKS } from './types.js'
 
 export interface ParsedDIDCycles {
-  /** https JWKS endpoint the DID maps to. */
-  jwksUrl: string
+  /** Lowercase hex sha256 of `server_id`, as carried in the DID subject.
+   *  A BINDING value: the cycles verify layer checks it against
+   *  sha256(envelope.server_id). Not a locator. */
+  serverIdHash: string
   /** kid taken from the DID-URL fragment, if present. */
   kid?: string
 }
 
+const SERVER_ID_HASH_RE = /^[0-9a-f]{64}$/
+
 /**
  * Parse a did:cycles identifier (optionally with a #fragment) into its
- * JWKS URL and kid. Mirrors didWebToUrl: colon-separated segments,
- * each percent-decoded, segment[0] is the authority, the rest is the
- * path; a bare authority uses /.well-known/jwks.json.
+ * `server_id` hash and kid. The fragment is split off BEFORE the subject
+ * is read so a `#` never lands inside the hash.
  *
- * Throws on a structurally invalid did:cycles string. The fragment is
- * split off BEFORE segment parsing so a `#` never lands inside a path
- * segment.
+ * Throws on a structurally invalid did:cycles string (wrong method, or a
+ * subject that is not a 64-char lowercase hex sha256).
  */
 export function parseDIDCycles(did: string): ParsedDIDCycles {
   if (typeof did !== 'string') {
     throw new Error('did:cycles must be a string')
   }
-  // Split the DID-URL fragment (the kid) off first.
   const hashIndex = did.indexOf('#')
   let kid: string | undefined
   let core = did
@@ -54,23 +74,14 @@ export function parseDIDCycles(did: string): ParsedDIDCycles {
   }
 
   const parts = core.split(':')
-  if (parts.length < 3 || parts[0] !== 'did' || parts[1] !== 'cycles') {
+  if (parts.length !== 3 || parts[0] !== 'did' || parts[1] !== 'cycles') {
     throw new Error(`Invalid did:cycles format: ${core}`)
   }
-  // Everything after "did:cycles:" is authority-and-path, colon-separated.
-  const segments = parts.slice(2).map(s => decodeURIComponent(s))
-  const authority = segments[0]
-  if (!authority) {
-    throw new Error('did:cycles must include an authority')
+  const serverIdHash = parts[2]
+  if (!SERVER_ID_HASH_RE.test(serverIdHash)) {
+    throw new Error('did:cycles subject must be a 64-char lowercase hex sha256(server_id)')
   }
-  let jwksUrl: string
-  if (segments.length === 1) {
-    jwksUrl = `https://${authority}/.well-known/jwks.json`
-  } else {
-    const path = segments.slice(1).join('/')
-    jwksUrl = `https://${authority}/${path}/jwks.json`
-  }
-  return { jwksUrl, kid }
+  return { serverIdHash, kid }
 }
 
 /** True if the value looks like a did:cycles identifier. */
@@ -78,21 +89,34 @@ export function isDIDCycles(value: string): boolean {
   return typeof value === 'string' && value.startsWith('did:cycles:')
 }
 
+/**
+ * The JWK Set URL for a Cycles server, API-base-relative: append
+ * `/.well-known/cycles-jwks.json` to the verbatim `server_id` (collapsing
+ * only a doubled `/` at the join). Deliberately NOT origin-rooted —
+ * `server_id` carries its path (e.g. `https://cycles.example.com/v1`), so
+ * the set lives at `…/v1/.well-known/cycles-jwks.json`, keeping key
+ * authority anchored to the base the DID hash commits to.
+ */
+export function cyclesJwksUrl(serverId: string): string {
+  const base = serverId.endsWith('/') ? serverId.slice(0, -1) : serverId
+  return `${base}/.well-known/cycles-jwks.json`
+}
+
 export type JWKSelection =
   | { ok: true; jwk: Ed25519JWK; publicKeyHex: string; kid?: string }
   | { ok: false; status: 'not_found' | 'ambiguous' | 'malformed'; reason: string }
 
-/**
- * Validate that a parsed object is a well-formed JWKS with a non-empty
- * `keys` array. Returns the JWKS on success or null on any structural
- * problem. Does NOT validate individual JWK key material; that happens
- * during candidate filtering / selection.
- */
-export function asJWKS(body: unknown): JWKS | null {
-  if (!body || typeof body !== 'object') return null
-  const keys = (body as Record<string, unknown>).keys
-  if (!Array.isArray(keys) || keys.length === 0) return null
-  return { keys: keys as Ed25519JWK[] }
+/** Selection criteria. Legacy callers pass a bare kid string; the cycles
+ *  path passes the window + raw-key form. */
+export interface SelectKeyOptions {
+  /** Match the JWK whose kid strictly equals this (exact, case-sensitive). */
+  kid?: string
+  /** Window gate: keep only keys whose [cycles_nbf_ms, cycles_exp_ms) covers
+   *  this issuance time (epoch ms). Omitted ⇒ no window gate (legacy). */
+  issuedAtMs?: number
+  /** Raw-hex signer match: keep only keys whose `x` decodes to these 32 bytes
+   *  (64-char hex). Used when the envelope's signer_did is a raw key. */
+  publicKeyHex?: string
 }
 
 /**
@@ -101,7 +125,6 @@ export function asJWKS(body: unknown): JWKS | null {
  *   (use absent || use === "sig")
  *   (alg absent || alg === "EdDSA")
  *   (key_ops absent || includes "verify")
- * X-curves, enc keys, and non-EdDSA algs are excluded here.
  */
 function isEd25519SigningCandidate(jwk: unknown): jwk is Ed25519JWK {
   if (!jwk || typeof jwk !== 'object') return false
@@ -117,61 +140,88 @@ function isEd25519SigningCandidate(jwk: unknown): jwk is Ed25519JWK {
   return true
 }
 
-/**
- * Decode a candidate's `x` to a 32-byte Ed25519 public key, returned
- * as 64-char lowercase hex. Returns null if `x` does not base64url-
- * decode to exactly 32 bytes (malformed key material).
- */
+/** Decode a candidate's `x` to a 32-byte key as 64-char lowercase hex, or
+ *  null if `x` does not base64url-decode to exactly 32 bytes. */
 function candidateToHex(jwk: Ed25519JWK): string | null {
   const bytes = decodeBase64Url(jwk.x)
   if (!bytes || bytes.length !== 32) return null
   return bytesToHex(bytes)
 }
 
+/** `cycles_nbf_ms <= t AND (cycles_exp_ms absent/null OR t < cycles_exp_ms)`.
+ *  A non-integer `cycles_nbf_ms` (or a non-integer present `cycles_exp_ms`)
+ *  makes the window unusable → the key does not cover `t`. */
+function windowCovers(jwk: Ed25519JWK, t: number): boolean {
+  const nbf = jwk.cycles_nbf_ms
+  if (typeof nbf !== 'number' || !Number.isInteger(nbf)) return false
+  if (t < nbf) return false
+  const exp = jwk.cycles_exp_ms
+  if (exp === undefined || exp === null) return true
+  if (typeof exp !== 'number' || !Number.isInteger(exp)) return false
+  return t < exp
+}
+
 /**
- * Select exactly one Ed25519 verification key from a JWKS by kid.
- *
- *  1. Filter to Ed25519 signing candidates.
- *  2. If a kid is requested: the candidate whose kid strictly equals it
- *     must be unique. Zero matches -> not_found. Duplicate kids ->
- *     ambiguous. kid comparison is exact, case-sensitive.
- *  3. If no kid is requested: exactly one candidate -> use it; more than
- *     one -> ambiguous; zero -> not_found.
- *  4. Decode `x` -> 32 bytes -> hex. A candidate that survives filtering
- *     but whose `x` is not 32 bytes is malformed.
- *
- * Never silently falls back to a different kid than requested.
+ * Select exactly one Ed25519 verification key from a JWKS. Filters, in
+ * order: Ed25519 signing candidacy, optional raw-hex `x` match, optional
+ * kid match, optional validity-window gate; then requires the survivor to
+ * be unique. Never silently falls back to a different key. Legacy callers
+ * may pass a bare kid string.
  */
-export function selectKey(jwks: JWKS, requestedKid?: string): JWKSelection {
-  const candidates = jwks.keys.filter(isEd25519SigningCandidate)
+export function selectKey(jwks: JWKS, sel?: string | SelectKeyOptions): JWKSelection {
+  const opts: SelectKeyOptions = typeof sel === 'string' ? { kid: sel } : (sel ?? {})
+
+  let candidates = jwks.keys.filter(isEd25519SigningCandidate)
   if (candidates.length === 0) {
     return { ok: false, status: 'not_found', reason: 'no Ed25519 signing key in JWKS' }
   }
 
-  if (requestedKid !== undefined) {
-    const matches = candidates.filter(c => c.kid === requestedKid)
-    if (matches.length === 0) {
-      return { ok: false, status: 'not_found', reason: `no key with kid='${requestedKid}'` }
+  // Raw-hex signer match (cycles): the published key must carry the signer's bytes.
+  if (opts.publicKeyHex !== undefined) {
+    const want = opts.publicKeyHex.toLowerCase()
+    candidates = candidates.filter((c) => candidateToHex(c) === want)
+    if (candidates.length === 0) {
+      return { ok: false, status: 'not_found', reason: 'no JWK carries the raw signer key' }
     }
-    if (matches.length > 1) {
-      return { ok: false, status: 'ambiguous', reason: `duplicate kid='${requestedKid}' in JWKS` }
-    }
-    const jwk = matches[0]
-    const hex = candidateToHex(jwk)
-    if (!hex) {
-      return { ok: false, status: 'malformed', reason: `kid='${requestedKid}' x is not a 32-byte key` }
-    }
-    return { ok: true, jwk, publicKeyHex: hex, kid: jwk.kid }
   }
 
-  // No kid requested: require an unambiguous single candidate.
+  // kid match (exact, case-sensitive).
+  if (opts.kid !== undefined) {
+    const matches = candidates.filter((c) => c.kid === opts.kid)
+    if (matches.length === 0) {
+      return { ok: false, status: 'not_found', reason: `no key with kid='${opts.kid}'` }
+    }
+    candidates = matches
+  }
+
+  // Validity-window gate (cycles): the key valid AT ISSUANCE, never the newest.
+  if (opts.issuedAtMs !== undefined) {
+    const t = opts.issuedAtMs
+    candidates = candidates.filter((c) => windowCovers(c, t))
+    if (candidates.length === 0) {
+      return { ok: false, status: 'not_found', reason: 'no key whose validity window covers issued_at_ms' }
+    }
+  }
+
   if (candidates.length > 1) {
-    return { ok: false, status: 'ambiguous', reason: 'multiple signing keys and no kid requested' }
+    return { ok: false, status: 'ambiguous', reason: 'more than one key matches the selection criteria' }
   }
   const jwk = candidates[0]
   const hex = candidateToHex(jwk)
   if (!hex) {
-    return { ok: false, status: 'malformed', reason: 'sole candidate x is not a 32-byte key' }
+    return { ok: false, status: 'malformed', reason: 'selected key x is not a 32-byte key' }
   }
   return { ok: true, jwk, publicKeyHex: hex, kid: jwk.kid }
+}
+
+/**
+ * Validate that a parsed object is a well-formed JWKS with a non-empty
+ * `keys` array. Returns the JWKS on success or null on any structural
+ * problem.
+ */
+export function asJWKS(body: unknown): JWKS | null {
+  if (!body || typeof body !== 'object') return null
+  const keys = (body as Record<string, unknown>).keys
+  if (!Array.isArray(keys) || keys.length === 0) return null
+  return { keys: keys as Ed25519JWK[] }
 }

--- a/src/v2/key-resolution/index.ts
+++ b/src/v2/key-resolution/index.ts
@@ -49,9 +49,11 @@ export { decodeBase64Url, bytesToHex } from './base64url.js'
 export {
   parseDIDCycles,
   isDIDCycles,
+  cyclesJwksUrl,
   asJWKS,
   selectKey,
   type ParsedDIDCycles,
+  type SelectKeyOptions,
   type JWKSelection,
 } from './did-cycles.js'
 

--- a/src/v2/key-resolution/resolver.ts
+++ b/src/v2/key-resolution/resolver.ts
@@ -100,11 +100,10 @@ export class CyclesKeyResolver implements KeyResolver {
     if (locator.jwksUrl) return true
     const did = locator.did
     if (!did) return false
-    return (
-      did.startsWith('did:key:') ||
-      did.startsWith('did:web:') ||
-      did.startsWith('did:cycles:')
-    )
+    // did:cycles is hash-bound, NOT self-locating: it cannot yield a URL on
+    // its own, so it is resolvable only with a jwksUrl (handled above, derived
+    // from the envelope's server_id by the cycles verify layer).
+    return did.startsWith('did:key:') || did.startsWith('did:web:')
   }
 
   async resolve(locator: KeyLocator): Promise<KeyResolution> {
@@ -231,20 +230,24 @@ export class CyclesKeyResolver implements KeyResolver {
   // ── did:cycles / direct JWKS (this module's mapping) ─────────────
 
   private async resolveJwks(locator: KeyLocator): Promise<KeyResolution> {
-    let jwksUrl: string
     let fragmentKid: string | undefined
     if (locator.did && isDIDCycles(locator.did)) {
+      // did:cycles is hash-bound: parse it for the kid fragment only. The
+      // JWKS URL is NOT derivable from the DID (the subject is a hash) — the
+      // cycles verify layer derives it from the envelope's server_id and
+      // passes it in as locator.jwksUrl after checking the sha256 binding.
       try {
-        const parsed = parseDIDCycles(locator.did)
-        jwksUrl = parsed.jwksUrl
-        fragmentKid = parsed.kid
+        fragmentKid = parseDIDCycles(locator.did).kid
       } catch (err) {
         return this.fail('unsupported', `did:cycles parse failed: ${safeMsg(err)}`)
       }
-    } else if (locator.jwksUrl) {
-      jwksUrl = locator.jwksUrl
-    } else {
-      return this.fail('unsupported', 'no did:cycles or jwksUrl present')
+    }
+    const jwksUrl = locator.jwksUrl
+    if (!jwksUrl) {
+      return this.fail(
+        'unsupported',
+        'did:cycles is not self-locating; supply jwksUrl derived from the envelope server_id',
+      )
     }
 
     // HTTPS only.
@@ -291,7 +294,11 @@ export class CyclesKeyResolver implements KeyResolver {
       return this.storeFail(cacheKey, 'malformed', 'JWKS missing non-empty keys[] array')
     }
 
-    const selection = selectKey(jwks, wantKid)
+    const selection = selectKey(jwks, {
+      kid: wantKid,
+      issuedAtMs: locator.issuedAtMs,
+      publicKeyHex: locator.publicKeyHex,
+    })
     if (!selection.ok) {
       return this.storeFail(cacheKey, selection.status, selection.reason)
     }

--- a/src/v2/key-resolution/resolver.ts
+++ b/src/v2/key-resolution/resolver.ts
@@ -251,6 +251,11 @@ export class CyclesKeyResolver implements KeyResolver {
       } catch (err) {
         return this.fail('unsupported', `did:cycles parse failed: ${safeMsg(err)}`)
       }
+      // The canonical signer_did form is did:cycles:<hash>#<kid>; the fragment
+      // names the key in the set and is REQUIRED for resolution.
+      if (!fragmentKid) {
+        return this.fail('unsupported', 'did:cycles requires a #<kid> fragment')
+      }
       if (!locator.serverId) {
         return this.fail('unsupported', 'did:cycles requires serverId to establish the sha256 binding')
       }

--- a/src/v2/key-resolution/resolver.ts
+++ b/src/v2/key-resolution/resolver.ts
@@ -260,7 +260,16 @@ export class CyclesKeyResolver implements KeyResolver {
       return this.fail('ambiguous', 'did:cycles fragment and explicit kid disagree')
     }
 
-    const cacheKey = `jwks:${jwksUrl}|kid:${wantKid ?? ''}`
+    // Cache the SELECTED key. Selection now depends on the validity window
+    // (issuedAtMs) and the raw-hex signer match (publicKeyHex) too, so both
+    // MUST be in the cache key — otherwise a key selected for one receipt's
+    // issuance window could be wrongly reused for another across a rotation
+    // (the [nbf, exp) gate would be bypassed). (A JWKS-document cache keyed by
+    // URL, with selection re-run per call, would also dedup the fetch across
+    // distinct issuance times — a future optimization.)
+    const cacheKey =
+      `jwks:${jwksUrl}|kid:${wantKid ?? ''}` +
+      `|iat:${locator.issuedAtMs ?? ''}|pk:${locator.publicKeyHex?.toLowerCase() ?? ''}`
     const cached = this.readCache(cacheKey)
     if (cached) return cached
 

--- a/src/v2/key-resolution/resolver.ts
+++ b/src/v2/key-resolution/resolver.ts
@@ -21,11 +21,13 @@
 // across tenants, expose an endpoint, or alert.
 // ══════════════════════════════════════════════════════════════════
 
+import { createHash } from 'node:crypto'
 import { fromDIDKey, resolveDIDWeb } from '../../core/did-interop.js'
 import { multibaseToHex } from '../../core/did.js'
 import type { ScopeOfClaim } from '../accountability/types/base.js'
 import {
   asJWKS,
+  cyclesJwksUrl,
   isDIDCycles,
   parseDIDCycles,
   selectKey,
@@ -100,10 +102,11 @@ export class CyclesKeyResolver implements KeyResolver {
     if (locator.jwksUrl) return true
     const did = locator.did
     if (!did) return false
-    // did:cycles is hash-bound, NOT self-locating: it cannot yield a URL on
-    // its own, so it is resolvable only with a jwksUrl (handled above, derived
-    // from the envelope's server_id by the cycles verify layer).
-    return did.startsWith('did:key:') || did.startsWith('did:web:')
+    // did:cycles is handled here, but is hash-bound: it resolves only with a
+    // serverId (the resolver checks sha256(serverId) against the DID subject and
+    // derives the JWKS URL). A did:cycles locator without serverId fails closed
+    // in resolve(); canResolve reports the method is handled.
+    return did.startsWith('did:key:') || did.startsWith('did:web:') || did.startsWith('did:cycles:')
   }
 
   async resolve(locator: KeyLocator): Promise<KeyResolution> {
@@ -231,23 +234,43 @@ export class CyclesKeyResolver implements KeyResolver {
 
   private async resolveJwks(locator: KeyLocator): Promise<KeyResolution> {
     let fragmentKid: string | undefined
+    let jwksUrl: string | undefined
+
     if (locator.did && isDIDCycles(locator.did)) {
-      // did:cycles is hash-bound: parse it for the kid fragment only. The
-      // JWKS URL is NOT derivable from the DID (the subject is a hash) — the
-      // cycles verify layer derives it from the envelope's server_id and
-      // passes it in as locator.jwksUrl after checking the sha256 binding.
+      // did:cycles is HASH-BOUND. The resolver enforces the binding itself and
+      // derives the JWKS URL — it never accepts an unbound did:cycles:
+      //   1. parse the subject hash + kid fragment;
+      //   2. require server_id, and check sha256(server_id) === subject hash
+      //      (fail closed on mismatch) — anchors authority to that server_id;
+      //   3. derive the JWKS URL from server_id (cyclesJwksUrl), NOT from a
+      //      caller-supplied URL (which could point at a different server);
+      //   4. the validity-window gate (issued_at_ms) is MANDATORY here.
+      let serverIdHash: string
       try {
-        fragmentKid = parseDIDCycles(locator.did).kid
+        ;({ serverIdHash, kid: fragmentKid } = parseDIDCycles(locator.did))
       } catch (err) {
         return this.fail('unsupported', `did:cycles parse failed: ${safeMsg(err)}`)
       }
+      if (!locator.serverId) {
+        return this.fail('unsupported', 'did:cycles requires serverId to establish the sha256 binding')
+      }
+      const computed = createHash('sha256').update(locator.serverId, 'utf8').digest('hex')
+      if (computed !== serverIdHash) {
+        return this.fail(
+          'not_found',
+          'did:cycles subject does not match sha256(server_id) — signer not bound to this server',
+        )
+      }
+      if (typeof locator.issuedAtMs !== 'number' || !Number.isInteger(locator.issuedAtMs)) {
+        return this.fail('not_found', 'did:cycles resolution requires an integer issuedAtMs (validity window)')
+      }
+      jwksUrl = cyclesJwksUrl(locator.serverId)
+    } else {
+      jwksUrl = locator.jwksUrl
     }
-    const jwksUrl = locator.jwksUrl
+
     if (!jwksUrl) {
-      return this.fail(
-        'unsupported',
-        'did:cycles is not self-locating; supply jwksUrl derived from the envelope server_id',
-      )
+      return this.fail('unsupported', 'no did:cycles (with serverId) or jwksUrl present')
     }
 
     // HTTPS only.

--- a/src/v2/key-resolution/types.ts
+++ b/src/v2/key-resolution/types.ts
@@ -40,6 +40,15 @@ export interface Ed25519JWK {
   alg?: 'EdDSA' | string
   /** If present MUST include "verify". */
   key_ops?: string[]
+  /** Cycles validity window — valid-from, epoch ms, INCLUSIVE. Present on
+   *  did:cycles JWK Sets; selection by window requires it (see selectKey).
+   *  Not an RFC 7517 member; ignored by non-cycles consumers. */
+  cycles_nbf_ms?: number
+  /** Cycles validity window — valid-until, epoch ms, EXCLUSIVE. Absent/null
+   *  ⇒ open-ended (the active key). */
+  cycles_exp_ms?: number | null
+  /** Advisory rotation status; selection is by window, never by status. */
+  status?: 'active' | 'retired' | string
 }
 
 /**
@@ -118,6 +127,14 @@ export interface KeyLocator {
   did?: string
   jwksUrl?: string
   kid?: string
+  /** Cycles window selection: pick the key whose
+   *  [cycles_nbf_ms, cycles_exp_ms) covers this issuance time (epoch ms).
+   *  When set, selection is window-gated; when absent, legacy kid-only. */
+  issuedAtMs?: number
+  /** Cycles raw-hex signer match: when the envelope's signer_did is a raw
+   *  64-hex Ed25519 key (not a did:cycles), select the JWK whose `x` decodes
+   *  to these bytes (confirming the raw key is published) rather than by kid. */
+  publicKeyHex?: string
 }
 
 /**

--- a/src/v2/key-resolution/types.ts
+++ b/src/v2/key-resolution/types.ts
@@ -53,9 +53,10 @@ export interface Ed25519JWK {
 
 /**
  * RFC 7517 JWK Set. The single REQUIRED member is `keys`, an array of
- * JWK objects. A resolver MUST treat a private `d` member on any JWK
- * as a misconfiguration and never use it; this type does not surface
- * `d`, and the loader strips it.
+ * JWK objects. A published verification set must contain public keys
+ * only: a JWK carrying a private `d` member is a misconfiguration (leaked
+ * private material), so it is REJECTED as a signing candidate and never
+ * selected — fail-closed rather than silently stripped-and-used.
  */
 export interface JWKS {
   keys: Ed25519JWK[]
@@ -135,6 +136,12 @@ export interface KeyLocator {
    *  64-hex Ed25519 key (not a did:cycles), select the JWK whose `x` decodes
    *  to these bytes (confirming the raw key is published) rather than by kid. */
   publicKeyHex?: string
+  /** Cycles authority binding: the envelope's `server_id`. REQUIRED for a
+   *  `did:cycles` locator — the resolver checks `sha256(server_id)` against the
+   *  DID subject hash and derives the JWKS URL from it (cyclesJwksUrl), failing
+   *  closed on mismatch. A `did:cycles` locator without `serverId` is rejected
+   *  (the binding cannot be established). */
+  serverId?: string
 }
 
 /**

--- a/tests/v2/key-resolution/resolver.test.ts
+++ b/tests/v2/key-resolution/resolver.test.ts
@@ -286,6 +286,15 @@ describe('selectKey (JWK selection by kid)', () => {
     if (!sel.ok) assert.equal(sel.status, 'ambiguous')
   })
 
+  it('the raw-hex path also rejects a set with duplicate kids (set-wide uniqueness)', () => {
+    // No requested kid here — selection is by raw key + window. kid uniqueness
+    // must still be enforced across the whole set, before the raw-hex match.
+    const jwks = fixtureJWKS(winJWK('dup', 0, 1000), winJWK('dup', 1000, null))
+    const sel = selectKey(jwks, { publicKeyHex: PUB_HEX, issuedAtMs: 500 })
+    assert.equal(sel.ok, false)
+    if (!sel.ok) assert.equal(sel.status, 'ambiguous')
+  })
+
   it('rejects x that does not decode to 32 bytes', () => {
     const jwks = fixtureJWKS({ kty: 'OKP', crv: 'Ed25519', x: 'AAAA', kid: 'short' })
     const sel = selectKey(jwks, 'short')
@@ -355,6 +364,14 @@ describe('CyclesKeyResolver: did:cycles (hash-bound) + direct JWKS', () => {
   it('did:cycles without serverId is unsupported (binding cannot be established)', async () => {
     const r = new CyclesKeyResolver()
     const res = await r.resolve({ did: `did:cycles:${HASH}#k`, issuedAtMs: 500 })
+    assert.equal(res.ok, false)
+    assert.equal(res.status, 'unsupported')
+  })
+
+  it('did:cycles without a #kid fragment is unsupported (canonical form is <h>#<kid>)', async () => {
+    const { impl } = jsonFetch(fixtureJWKS(winJWK('test-1')))
+    const r = new CyclesKeyResolver({ fetchImpl: impl })
+    const res = await r.resolve({ did: `did:cycles:${HASH}`, serverId: SERVER_ID, issuedAtMs: 500 })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'unsupported')
   })

--- a/tests/v2/key-resolution/resolver.test.ts
+++ b/tests/v2/key-resolution/resolver.test.ts
@@ -247,18 +247,43 @@ describe('selectKey (JWK selection by kid)', () => {
     assert.equal(selectKey(jwks, { issuedAtMs: '500' as unknown as number }).ok, false)
   })
 
-  it('raw-hex match: selects the JWK whose x decodes to the signer key', () => {
-    const sel = selectKey(fixtureJWKS(fixtureJWK('a'), fixtureJWK('b')), { publicKeyHex: PUB_HEX })
-    // both fixtures carry PUB_HEX → ambiguous (two carriers, no other narrowing)
-    assert.equal(sel.ok, false)
-    if (!sel.ok) assert.equal(sel.status, 'ambiguous')
+  it('raw-hex match: selects the unique windowed JWK carrying the signer key', () => {
+    // winJWK(kid, nbf, exp) carries X_B64URL (=PUB_HEX); the 'b' key's x is
+    // overridden so it does not carry the signer's bytes.
+    const sel = selectKey(fixtureJWKS(winJWK('a', 0, null), { ...winJWK('b', 0, null), x: 'AA' }), {
+      publicKeyHex: PUB_HEX, issuedAtMs: 500,
+    })
+    assert.equal(sel.ok, true)
+    if (sel.ok) assert.equal(sel.kid, 'a')
+  })
+
+  it('raw-hex match REQUIRES an integer issuedAtMs (window applies to raw signers too)', () => {
+    const jwks = fixtureJWKS(winJWK('a', 0, null))
+    assert.equal(selectKey(jwks, { publicKeyHex: PUB_HEX }).ok, false) // no window → fail closed
+    assert.equal(selectKey(jwks, { publicKeyHex: PUB_HEX, issuedAtMs: 1.5 }).ok, false)
+  })
+
+  it('raw-hex match: out-of-window key fails closed', () => {
+    const covering = selectKey(fixtureJWKS(winJWK('a', 0, null)), { publicKeyHex: PUB_HEX, issuedAtMs: 500 })
+    assert.equal(covering.ok, true)
+    const expired = winJWK('a', 0, 100) // [0,100), 500 not covered
+    assert.equal(selectKey(fixtureJWKS(expired), { publicKeyHex: PUB_HEX, issuedAtMs: 500 }).ok, false)
   })
 
   it('raw-hex match: no JWK carries the signer key → not_found', () => {
     const other = Buffer.from(PUB_HEX, 'hex'); other[0] ^= 0xff
-    const sel = selectKey(fixtureJWKS(fixtureJWK('a')), { publicKeyHex: other.toString('hex') })
+    const sel = selectKey(fixtureJWKS(winJWK('a', 0, null)), { publicKeyHex: other.toString('hex'), issuedAtMs: 500 })
     assert.equal(sel.ok, false)
     if (!sel.ok) assert.equal(sel.status, 'not_found')
+  })
+
+  it('duplicate kid is an authority failure BEFORE the window gate (disjoint windows do not rescue it)', () => {
+    // Two kid="dup" keys with NON-overlapping windows: only one covers
+    // issued_at=500, but the duplicate kid must fail ambiguous up front.
+    const jwks = fixtureJWKS(winJWK('dup', 0, 1000), winJWK('dup', 1000, null))
+    const sel = selectKey(jwks, { kid: 'dup', issuedAtMs: 500 })
+    assert.equal(sel.ok, false)
+    if (!sel.ok) assert.equal(sel.status, 'ambiguous')
   })
 
   it('rejects x that does not decode to 32 bytes', () => {

--- a/tests/v2/key-resolution/resolver.test.ts
+++ b/tests/v2/key-resolution/resolver.test.ts
@@ -11,6 +11,10 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+
+/** sha256 hex of a server_id — the did:cycles subject binding. */
+const sha256Hex = (s: string) => createHash('sha256').update(s, 'utf8').digest('hex')
 
 import {
   CyclesKeyResolver,
@@ -264,17 +268,15 @@ describe('selectKey (JWK selection by kid)', () => {
     if (!sel.ok) assert.equal(sel.status, 'malformed')
   })
 
-  it('strips a private d member (never used)', () => {
-    // d present is a misconfiguration; selection still returns the public x.
+  it('rejects a JWK carrying a private d member (public-only key set)', () => {
+    // A published verification set must be public-only; a leaked private `d`
+    // makes the JWK a non-candidate (fail-closed), never selected.
     const jwks = fixtureJWKS({
       kty: 'OKP', crv: 'Ed25519', x: X_B64URL, kid: 'p', d: SEED_HEX,
     } as object)
     const sel = selectKey(jwks, 'p')
-    assert.equal(sel.ok, true)
-    if (sel.ok) {
-      assert.equal(sel.publicKeyHex, PUB_HEX)
-      assert.equal('d' in (sel.jwk as Record<string, unknown>) , true) // input untouched
-    }
+    assert.equal(sel.ok, false)
+    if (!sel.ok) assert.equal(sel.status, 'not_found')
   })
 })
 
@@ -288,25 +290,29 @@ describe('asJWKS structural validation', () => {
 })
 
 // ════════════════════════════════════════════════════════════════
-describe('CyclesKeyResolver: did:cycles / JWKS', () => {
-  // did:cycles is hash-bound (not self-locating): the cycles verify layer
-  // derives the JWKS URL from the envelope's server_id and supplies it. These
-  // tests pass jwksUrl directly (optionally alongside the hash-bound did to
-  // exercise the #fragment kid), mirroring how the verify path calls in.
-  const HASH = 'a'.repeat(64)
+describe('CyclesKeyResolver: did:cycles (hash-bound) + direct JWKS', () => {
+  // did:cycles is HASH-BOUND: the resolver checks sha256(serverId) against the
+  // DID subject and derives the JWKS URL from serverId itself. The window gate
+  // (issuedAtMs) is mandatory for did:cycles. A windowed JWK is required.
+  const SERVER_ID = 'https://h.test/v1'
+  const HASH = sha256Hex(SERVER_ID)
   const CYCLES_URL = 'https://h.test/v1/.well-known/cycles-jwks.json'
+  const winJWK = (kid: string, x: string = X_B64URL) => ({
+    kty: 'OKP', crv: 'Ed25519', x, kid, use: 'sig', alg: 'EdDSA',
+    cycles_nbf_ms: 0, cycles_exp_ms: null,
+  })
 
-  it('resolves a did:cycles key (fragment kid) to the RFC 8032 public key', async () => {
-    const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('test-1')))
+  it('resolves a bound did:cycles key (fragment kid) to the RFC 8032 public key', async () => {
+    const { impl } = jsonFetch(fixtureJWKS(winJWK('test-1')))
     const r = new CyclesKeyResolver({ fetchImpl: impl })
-    const res = await r.resolve({ did: `did:cycles:${HASH}#test-1`, jwksUrl: CYCLES_URL })
+    const res = await r.resolve({ did: `did:cycles:${HASH}#test-1`, serverId: SERVER_ID, issuedAtMs: 500 })
     assert.equal(res.ok, true)
     assert.equal(res.publicKeyHex, PUB_HEX)
     assert.equal(res.kid, 'test-1')
     assert.ok(res.scope_of_claim, 'resolved key carries scope_of_claim')
   })
 
-  it('resolves a direct jwksUrl + explicit kid', async () => {
+  it('resolves a direct jwksUrl + explicit kid (non-cycles, window optional)', async () => {
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('k1')))
     const r = new CyclesKeyResolver({ fetchImpl: impl })
     const res = await r.resolve({ jwksUrl: CYCLES_URL, kid: 'k1' })
@@ -321,17 +327,34 @@ describe('CyclesKeyResolver: did:cycles / JWKS', () => {
     assert.equal(res.status, 'unsupported')
   })
 
-  it('a did:cycles locator with no jwksUrl is unsupported (not self-locating)', async () => {
+  it('did:cycles without serverId is unsupported (binding cannot be established)', async () => {
     const r = new CyclesKeyResolver()
-    const res = await r.resolve({ did: `did:cycles:${HASH}#k` })
+    const res = await r.resolve({ did: `did:cycles:${HASH}#k`, issuedAtMs: 500 })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'unsupported')
   })
 
-  it('fails closed when DID fragment and explicit kid disagree', async () => {
-    const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('a')))
+  it('did:cycles fails closed when sha256(serverId) != subject hash', async () => {
+    const { impl } = jsonFetch(fixtureJWKS(winJWK('test-1')))
     const r = new CyclesKeyResolver({ fetchImpl: impl })
-    const res = await r.resolve({ did: `did:cycles:${HASH}#a`, jwksUrl: CYCLES_URL, kid: 'b' })
+    // a different server_id than the one the DID hash commits to
+    const res = await r.resolve({ did: `did:cycles:${HASH}#test-1`, serverId: 'https://evil.test/v1', issuedAtMs: 500 })
+    assert.equal(res.ok, false)
+    assert.equal(res.status, 'not_found') // signer not bound to this server
+  })
+
+  it('did:cycles requires an integer issuedAtMs (mandatory window)', async () => {
+    const { impl } = jsonFetch(fixtureJWKS(winJWK('test-1')))
+    const r = new CyclesKeyResolver({ fetchImpl: impl })
+    const res = await r.resolve({ did: `did:cycles:${HASH}#test-1`, serverId: SERVER_ID })
+    assert.equal(res.ok, false)
+    assert.equal(res.status, 'not_found')
+  })
+
+  it('fails closed when DID fragment and explicit kid disagree', async () => {
+    const { impl } = jsonFetch(fixtureJWKS(winJWK('a')))
+    const r = new CyclesKeyResolver({ fetchImpl: impl })
+    const res = await r.resolve({ did: `did:cycles:${HASH}#a`, serverId: SERVER_ID, issuedAtMs: 500, kid: 'b' })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'ambiguous')
   })
@@ -506,7 +529,7 @@ describe('did:key and did:web registered behind the interface', () => {
     const r = new CyclesKeyResolver()
     assert.equal(r.canResolve({ did: 'did:key:z6Mk...' }), true)
     assert.equal(r.canResolve({ did: 'did:web:e.test' }), true)
-    assert.equal(r.canResolve({ did: 'did:cycles:e.test' }), false) // hash-bound, needs jwksUrl
+    assert.equal(r.canResolve({ did: 'did:cycles:e.test' }), true) // handled (binding checked at resolve time)
     assert.equal(r.canResolve({ jwksUrl: 'https://e.test/v1/.well-known/cycles-jwks.json' }), true)
     assert.equal(r.canResolve({ jwksUrl: 'https://e.test/jwks.json' }), true)
     assert.equal(r.canResolve({ did: 'did:example:nope' }), false)

--- a/tests/v2/key-resolution/resolver.test.ts
+++ b/tests/v2/key-resolution/resolver.test.ts
@@ -237,6 +237,12 @@ describe('selectKey (JWK selection by kid)', () => {
     assert.equal(sel.ok, false)
   })
 
+  it('window gate: a non-integer issuedAtMs fails closed (no coercion)', () => {
+    const jwks = fixtureJWKS(winJWK('k', 0, null))
+    assert.equal(selectKey(jwks, { issuedAtMs: 500.5 }).ok, false)
+    assert.equal(selectKey(jwks, { issuedAtMs: '500' as unknown as number }).ok, false)
+  })
+
   it('raw-hex match: selects the JWK whose x decodes to the signer key', () => {
     const sel = selectKey(fixtureJWKS(fixtureJWK('a'), fixtureJWK('b')), { publicKeyHex: PUB_HEX })
     // both fixtures carry PUB_HEX → ambiguous (two carriers, no other narrowing)
@@ -337,6 +343,22 @@ describe('CyclesKeyResolver: did:cycles / JWKS', () => {
     assert.equal(res.ok, false)
     assert.equal(res.status, 'malformed')
     assert.notEqual(res.degraded, true) // not a transient-network relaxation
+  })
+
+  it('cache key includes the window: an out-of-window issuance is not a stale hit', async () => {
+    // Same jwksUrl + kid, one key valid [0,1000). An in-window resolution must
+    // NOT be served from cache for an out-of-window issuance — the window is
+    // part of the cache key (regression guard for cross-window contamination).
+    const jwks = fixtureJWKS({
+      kty: 'OKP', crv: 'Ed25519', x: X_B64URL, kid: 'k', use: 'sig', alg: 'EdDSA',
+      cycles_nbf_ms: 0, cycles_exp_ms: 1000,
+    })
+    const { impl } = jsonFetch(jwks)
+    const r = new CyclesKeyResolver({ fetchImpl: impl })
+    const inWin = await r.resolve({ jwksUrl: CYCLES_URL, kid: 'k', issuedAtMs: 500 })
+    const outWin = await r.resolve({ jwksUrl: CYCLES_URL, kid: 'k', issuedAtMs: 5000 })
+    assert.equal(inWin.ok, true)
+    assert.equal(outWin.ok, false, 'out-of-window issuance must not reuse the in-window cache entry')
   })
 })
 

--- a/tests/v2/key-resolution/resolver.test.ts
+++ b/tests/v2/key-resolution/resolver.test.ts
@@ -16,6 +16,7 @@ import {
   CyclesKeyResolver,
   parseDIDCycles,
   isDIDCycles,
+  cyclesJwksUrl,
   selectKey,
   asJWKS,
   decodeBase64Url,
@@ -72,36 +73,26 @@ function throwingFetch() {
 }
 
 // ════════════════════════════════════════════════════════════════
-describe('did:cycles URL mapping (mirrors didWebToUrl)', () => {
-  it('bare authority -> /.well-known/jwks.json', () => {
-    assert.equal(
-      parseDIDCycles('did:cycles:example.com').jwksUrl,
-      'https://example.com/.well-known/jwks.json',
-    )
-  })
+describe('did:cycles hash-bound parsing (subject = sha256(server_id))', () => {
+  const H = 'a'.repeat(64) // a valid 64-char lowercase hex sha256
 
-  it('authority + path -> /<path>/jwks.json', () => {
-    assert.equal(
-      parseDIDCycles('did:cycles:example.com:agents:7').jwksUrl,
-      'https://example.com/agents/7/jwks.json',
-    )
-  })
-
-  it('percent-encoded port is decoded per segment', () => {
-    assert.equal(
-      parseDIDCycles('did:cycles:example.com%3A8443').jwksUrl,
-      'https://example.com:8443/.well-known/jwks.json',
-    )
+  it('parses the server_id-hash subject', () => {
+    assert.equal(parseDIDCycles(`did:cycles:${H}`).serverIdHash, H)
   })
 
   it('fragment becomes the kid', () => {
-    const p = parseDIDCycles('did:cycles:example.com#agent-7-2026')
-    assert.equal(p.kid, 'agent-7-2026')
-    assert.equal(p.jwksUrl, 'https://example.com/.well-known/jwks.json')
+    const p = parseDIDCycles(`did:cycles:${H}#2026-06`)
+    assert.equal(p.kid, '2026-06')
+    assert.equal(p.serverIdHash, H)
   })
 
   it('rejects an empty fragment', () => {
-    assert.throws(() => parseDIDCycles('did:cycles:example.com#'))
+    assert.throws(() => parseDIDCycles(`did:cycles:${H}#`))
+  })
+
+  it('rejects a host-style subject (the dropped did:web M3 form)', () => {
+    assert.throws(() => parseDIDCycles('did:cycles:example.com'))
+    assert.throws(() => parseDIDCycles('did:cycles:example.com:agents:7'))
   })
 
   it('rejects a non-cycles method', () => {
@@ -109,8 +100,23 @@ describe('did:cycles URL mapping (mirrors didWebToUrl)', () => {
   })
 
   it('isDIDCycles recognizes the method', () => {
-    assert.equal(isDIDCycles('did:cycles:example.com'), true)
+    assert.equal(isDIDCycles(`did:cycles:${H}`), true)
     assert.equal(isDIDCycles('did:web:example.com'), false)
+  })
+})
+
+describe('cyclesJwksUrl (API-base-relative, not origin-rooted)', () => {
+  it('appends /.well-known/cycles-jwks.json to server_id, keeping its path', () => {
+    assert.equal(
+      cyclesJwksUrl('https://cycles.example.com/v1'),
+      'https://cycles.example.com/v1/.well-known/cycles-jwks.json',
+    )
+  })
+  it('collapses a single trailing slash at the join', () => {
+    assert.equal(
+      cyclesJwksUrl('https://cycles.example.com/v1/'),
+      'https://cycles.example.com/v1/.well-known/cycles-jwks.json',
+    )
   })
 })
 
@@ -197,6 +203,54 @@ describe('selectKey (JWK selection by kid)', () => {
     assert.equal(sel.ok, false)
   })
 
+  // ── Cycles window gate + raw-hex match (the v0.2 selection rules) ──
+  const winJWK = (kid: string, nbf: number, exp: number | null) => ({
+    kty: 'OKP', crv: 'Ed25519', x: X_B64URL, kid, use: 'sig', alg: 'EdDSA',
+    cycles_nbf_ms: nbf, cycles_exp_ms: exp,
+  })
+
+  it('window gate: selects the key whose [nbf,exp) covers issued_at_ms (not the newest)', () => {
+    const jwks = fixtureJWKS(
+      winJWK('old', 0, 1000),       // valid [0,1000)
+      winJWK('new', 1000, null),    // valid [1000, ∞)
+    )
+    // An envelope issued at t=500 must resolve to the OLD key, never "current".
+    const sel = selectKey(jwks, { issuedAtMs: 500 })
+    assert.equal(sel.ok, true)
+    if (sel.ok) assert.equal(sel.kid, 'old')
+  })
+
+  it('window gate fails closed when no key covers issued_at_ms', () => {
+    const sel = selectKey(fixtureJWKS(winJWK('k', 1000, 2000)), { issuedAtMs: 500 })
+    assert.equal(sel.ok, false)
+    if (!sel.ok) assert.equal(sel.status, 'not_found')
+  })
+
+  it('window gate: exp is EXCLUSIVE (issued_at == exp does not cover)', () => {
+    const sel = selectKey(fixtureJWKS(winJWK('k', 0, 1000)), { issuedAtMs: 1000 })
+    assert.equal(sel.ok, false)
+  })
+
+  it('window gate: a non-integer cycles_nbf_ms does not cover (no coercion)', () => {
+    const bad = { kty: 'OKP', crv: 'Ed25519', x: X_B64URL, kid: 'k', cycles_nbf_ms: 'soon' }
+    const sel = selectKey(fixtureJWKS(bad), { issuedAtMs: 500 })
+    assert.equal(sel.ok, false)
+  })
+
+  it('raw-hex match: selects the JWK whose x decodes to the signer key', () => {
+    const sel = selectKey(fixtureJWKS(fixtureJWK('a'), fixtureJWK('b')), { publicKeyHex: PUB_HEX })
+    // both fixtures carry PUB_HEX → ambiguous (two carriers, no other narrowing)
+    assert.equal(sel.ok, false)
+    if (!sel.ok) assert.equal(sel.status, 'ambiguous')
+  })
+
+  it('raw-hex match: no JWK carries the signer key → not_found', () => {
+    const other = Buffer.from(PUB_HEX, 'hex'); other[0] ^= 0xff
+    const sel = selectKey(fixtureJWKS(fixtureJWK('a')), { publicKeyHex: other.toString('hex') })
+    assert.equal(sel.ok, false)
+    if (!sel.ok) assert.equal(sel.status, 'not_found')
+  })
+
   it('rejects x that does not decode to 32 bytes', () => {
     const jwks = fixtureJWKS({ kty: 'OKP', crv: 'Ed25519', x: 'AAAA', kid: 'short' })
     const sel = selectKey(jwks, 'short')
@@ -229,10 +283,17 @@ describe('asJWKS structural validation', () => {
 
 // ════════════════════════════════════════════════════════════════
 describe('CyclesKeyResolver: did:cycles / JWKS', () => {
-  it('resolves a did:cycles key to the RFC 8032 public key', async () => {
+  // did:cycles is hash-bound (not self-locating): the cycles verify layer
+  // derives the JWKS URL from the envelope's server_id and supplies it. These
+  // tests pass jwksUrl directly (optionally alongside the hash-bound did to
+  // exercise the #fragment kid), mirroring how the verify path calls in.
+  const HASH = 'a'.repeat(64)
+  const CYCLES_URL = 'https://h.test/v1/.well-known/cycles-jwks.json'
+
+  it('resolves a did:cycles key (fragment kid) to the RFC 8032 public key', async () => {
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('test-1')))
     const r = new CyclesKeyResolver({ fetchImpl: impl })
-    const res = await r.resolve({ did: 'did:cycles:fixture.test#test-1' })
+    const res = await r.resolve({ did: `did:cycles:${HASH}#test-1`, jwksUrl: CYCLES_URL })
     assert.equal(res.ok, true)
     assert.equal(res.publicKeyHex, PUB_HEX)
     assert.equal(res.kid, 'test-1')
@@ -242,14 +303,21 @@ describe('CyclesKeyResolver: did:cycles / JWKS', () => {
   it('resolves a direct jwksUrl + explicit kid', async () => {
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('k1')))
     const r = new CyclesKeyResolver({ fetchImpl: impl })
-    const res = await r.resolve({ jwksUrl: 'https://h.test/.well-known/jwks.json', kid: 'k1' })
+    const res = await r.resolve({ jwksUrl: CYCLES_URL, kid: 'k1' })
     assert.equal(res.ok, true)
     assert.equal(res.publicKeyHex, PUB_HEX)
   })
 
   it('rejects a non-https jwksUrl as unsupported', async () => {
     const r = new CyclesKeyResolver()
-    const res = await r.resolve({ jwksUrl: 'http://insecure.test/jwks.json' })
+    const res = await r.resolve({ jwksUrl: 'http://insecure.test/cycles-jwks.json' })
+    assert.equal(res.ok, false)
+    assert.equal(res.status, 'unsupported')
+  })
+
+  it('a did:cycles locator with no jwksUrl is unsupported (not self-locating)', async () => {
+    const r = new CyclesKeyResolver()
+    const res = await r.resolve({ did: `did:cycles:${HASH}#k` })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'unsupported')
   })
@@ -257,7 +325,7 @@ describe('CyclesKeyResolver: did:cycles / JWKS', () => {
   it('fails closed when DID fragment and explicit kid disagree', async () => {
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('a')))
     const r = new CyclesKeyResolver({ fetchImpl: impl })
-    const res = await r.resolve({ did: 'did:cycles:h.test#a', kid: 'b' })
+    const res = await r.resolve({ did: `did:cycles:${HASH}#a`, jwksUrl: CYCLES_URL, kid: 'b' })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'ambiguous')
   })
@@ -265,7 +333,7 @@ describe('CyclesKeyResolver: did:cycles / JWKS', () => {
   it('malformed JWKS fails closed even under fail-open', async () => {
     const { impl } = jsonFetch({ not: 'a jwks' })
     const r = new CyclesKeyResolver({ fetchImpl: impl, failurePolicy: 'open' })
-    const res = await r.resolve({ did: 'did:cycles:h.test#k' })
+    const res = await r.resolve({ jwksUrl: CYCLES_URL, kid: 'k' })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'malformed')
     assert.notEqual(res.degraded, true) // not a transient-network relaxation
@@ -277,8 +345,8 @@ describe('cache hit and cache miss', () => {
   it('serves a second identical resolution from cache (one fetch)', async () => {
     const f = jsonFetch(fixtureJWKS(fixtureJWK('k')))
     const r = new CyclesKeyResolver({ fetchImpl: f.impl })
-    const a = await r.resolve({ did: 'did:cycles:h.test#k' })
-    const b = await r.resolve({ did: 'did:cycles:h.test#k' })
+    const a = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
+    const b = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
     assert.equal(a.cacheHit, false, 'first call is a miss')
     assert.equal(b.cacheHit, true, 'second call is a hit')
     assert.equal(f.calls(), 1, 'cache hit avoids the second fetch')
@@ -293,9 +361,9 @@ describe('cache hit and cache miss', () => {
       now: () => clock,
       cache: { ttlMs: 100 },
     })
-    await r.resolve({ did: 'did:cycles:h.test#k' })
+    await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
     clock += 200 // advance past TTL
-    const b = await r.resolve({ did: 'did:cycles:h.test#k' })
+    const b = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
     assert.equal(b.cacheHit, false, 'expired entry is a miss')
     assert.equal(f.calls(), 2, 'expired entry triggers a re-fetch')
   })
@@ -303,9 +371,9 @@ describe('cache hit and cache miss', () => {
   it('a cached miss is never promoted to a key', async () => {
     const f = jsonFetch(fixtureJWKS(fixtureJWK('present')))
     const r = new CyclesKeyResolver({ fetchImpl: f.impl })
-    const miss = await r.resolve({ did: 'did:cycles:h.test#absent' })
+    const miss = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'absent' })
     assert.equal(miss.ok, false)
-    const again = await r.resolve({ did: 'did:cycles:h.test#absent' })
+    const again = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'absent' })
     assert.equal(again.ok, false)
     assert.equal(again.publicKeyHex, undefined)
     assert.equal(again.cacheHit, true, 'negative result is cached')
@@ -317,7 +385,7 @@ describe('unreachable endpoint: fail-closed vs fail-open', () => {
   it('fail-closed (default): unreachable rejects, no key', async () => {
     const f = throwingFetch()
     const r = new CyclesKeyResolver({ fetchImpl: f.impl }) // default closed
-    const res = await r.resolve({ did: 'did:cycles:down.test#k' })
+    const res = await r.resolve({ jwksUrl: 'https://down.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'unreachable')
     assert.equal(res.degraded, false)
@@ -327,7 +395,7 @@ describe('unreachable endpoint: fail-closed vs fail-open', () => {
   it('non-200 is unreachable and rejects under fail-closed', async () => {
     const { impl } = jsonFetch({}, 503)
     const r = new CyclesKeyResolver({ fetchImpl: impl })
-    const res = await r.resolve({ did: 'did:cycles:down.test#k' })
+    const res = await r.resolve({ jwksUrl: 'https://down.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
     assert.equal(res.ok, false)
     assert.equal(res.status, 'unreachable')
   })
@@ -335,7 +403,7 @@ describe('unreachable endpoint: fail-closed vs fail-open', () => {
   it('fail-open: unreachable yields a degraded result with NO key', async () => {
     const f = throwingFetch()
     const r = new CyclesKeyResolver({ fetchImpl: f.impl, failurePolicy: 'open' })
-    const res = await r.resolve({ did: 'did:cycles:down.test#k' })
+    const res = await r.resolve({ jwksUrl: 'https://down.test/v1/.well-known/cycles-jwks.json', kid: 'k' })
     assert.equal(res.ok, false, 'degraded is still not a positive verification')
     assert.equal(res.status, 'unreachable')
     assert.equal(res.degraded, true)
@@ -361,8 +429,8 @@ describe('key rotation picks the new key', () => {
     const { impl } = jsonFetch(jwks)
     const r = new CyclesKeyResolver({ fetchImpl: impl })
 
-    const oldRes = await r.resolve({ did: 'did:cycles:h.test#old-2025' })
-    const newRes = await r.resolve({ did: 'did:cycles:h.test#new-2026' })
+    const oldRes = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'old-2025' })
+    const newRes = await r.resolve({ jwksUrl: 'https://h.test/v1/.well-known/cycles-jwks.json', kid: 'new-2026' })
     assert.equal(oldRes.publicKeyHex, PUB_HEX)
     assert.equal(newRes.publicKeyHex, KP_NEW.pub)
     assert.notEqual(oldRes.publicKeyHex, newRes.publicKeyHex)
@@ -416,7 +484,8 @@ describe('did:key and did:web registered behind the interface', () => {
     const r = new CyclesKeyResolver()
     assert.equal(r.canResolve({ did: 'did:key:z6Mk...' }), true)
     assert.equal(r.canResolve({ did: 'did:web:e.test' }), true)
-    assert.equal(r.canResolve({ did: 'did:cycles:e.test' }), true)
+    assert.equal(r.canResolve({ did: 'did:cycles:e.test' }), false) // hash-bound, needs jwksUrl
+    assert.equal(r.canResolve({ jwksUrl: 'https://e.test/v1/.well-known/cycles-jwks.json' }), true)
     assert.equal(r.canResolve({ jwksUrl: 'https://e.test/jwks.json' }), true)
     assert.equal(r.canResolve({ did: 'did:example:nope' }), false)
   })
@@ -433,15 +502,21 @@ describe('end-to-end: a did:cycles envelope verifies against a JWKS', () => {
   // Ed25519 signature whose verification key is named by a did:cycles
   // URL. The resolver fetches the JWKS, selects the key by kid, and the
   // existing verify() completes the check.
-  function signEnvelope(message: string, seedHex: string, did: string) {
-    return { message, did, signature: sign(message, seedHex) }
+  // did:cycles is hash-bound, so the JWKS URL comes from the envelope's
+  // server_id (here a constant; the verify layer derives + binds it). The
+  // resolver is handed {jwksUrl, kid}.
+  const E2E_JWKS_URL = 'https://fixture.test/v1/.well-known/cycles-jwks.json'
+
+  function signEnvelope(message: string, seedHex: string, kid: string) {
+    return { message, kid, signature: sign(message, seedHex) }
   }
 
   async function verifyEnvelope(
-    env: { message: string; did: string; signature: string },
+    env: { message: string; kid: string; signature: string },
     resolver: CyclesKeyResolver,
+    jwksUrl: string = E2E_JWKS_URL,
   ): Promise<{ verified: boolean; resolution: KeyResolution }> {
-    const resolution = await resolver.resolve({ did: env.did })
+    const resolution = await resolver.resolve({ jwksUrl, kid: env.kid })
     if (!resolution.ok || !resolution.publicKeyHex) {
       return { verified: false, resolution } // fail-closed
     }
@@ -452,7 +527,7 @@ describe('end-to-end: a did:cycles envelope verifies against a JWKS', () => {
   it('verifies the empty-message RFC 8032 envelope end to end', async () => {
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('test-1')))
     const resolver = new CyclesKeyResolver({ fetchImpl: impl })
-    const env = signEnvelope('', SEED_HEX, 'did:cycles:fixture.test#test-1')
+    const env = signEnvelope('', SEED_HEX, 'test-1')
     const { verified, resolution } = await verifyEnvelope(env, resolver)
     assert.equal(verified, true, 'envelope must verify end to end')
     assert.equal(resolution.publicKeyHex, PUB_HEX)
@@ -461,7 +536,7 @@ describe('end-to-end: a did:cycles envelope verifies against a JWKS', () => {
   it('verifies a non-empty-message envelope end to end', async () => {
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('test-1')))
     const resolver = new CyclesKeyResolver({ fetchImpl: impl })
-    const env = signEnvelope('cycles:permit:reservation-42', SEED_HEX, 'did:cycles:fixture.test#test-1')
+    const env = signEnvelope('cycles:permit:reservation-42', SEED_HEX, 'test-1')
     const { verified } = await verifyEnvelope(env, resolver)
     assert.equal(verified, true)
   })
@@ -476,15 +551,17 @@ describe('end-to-end: a did:cycles envelope verifies against a JWKS', () => {
     })()
     const { impl } = jsonFetch(fixtureJWKS(fixtureJWK('test-1', tamperedX)))
     const resolver = new CyclesKeyResolver({ fetchImpl: impl })
-    const env = signEnvelope('', SEED_HEX, 'did:cycles:fixture.test#test-1')
+    const env = signEnvelope('', SEED_HEX, 'test-1')
     const { verified } = await verifyEnvelope(env, resolver)
     assert.equal(verified, false, 'a tampered JWKS key must not verify the signature')
   })
 
   it('an unreachable JWKS makes the envelope check fail closed', async () => {
     const resolver = new CyclesKeyResolver({ fetchImpl: throwingFetch().impl })
-    const env = signEnvelope('', SEED_HEX, 'did:cycles:down.test#test-1')
-    const { verified, resolution } = await verifyEnvelope(env, resolver)
+    const env = signEnvelope('', SEED_HEX, 'test-1')
+    const { verified, resolution } = await verifyEnvelope(
+      env, resolver, 'https://down.test/v1/.well-known/cycles-jwks.json',
+    )
     assert.equal(verified, false)
     assert.equal(resolution.status, 'unreachable')
   })


### PR DESCRIPTION
## What

Aligns the `did:cycles` key resolver to the model **settled on runcycles/cycles-protocol#43** (spec `drafts/cycles-evidence-v0.1`; published in `cycles-protocol-v0` v0.1.25.6 + cycles-server v0.1.25.32). Per the sign-off there, drops the did:web-style M3 form and moves `parseDIDCycles` + `selectKey` to the hash-bound + API-base + validity-window model.

This is the **model-alignment half** — it settles which model the resolver targets. The **verify-path wiring** (`signer_did → resolve → select → edVerify → authentic/binding_only`) and the **Cycles golden-fixture regression vectors** land in the stacked follow-up PR ("the wiring PR gets its own review").

## Changes

- **`did:cycles` is hash-bound, not self-locating.** Subject = `sha256(server_id)` (64-hex). `parseDIDCycles` → `{ serverIdHash, kid? }`; no longer yields a URL (a hash can't be reversed to one).
- **`cyclesJwksUrl(serverId)`** derives the JWK Set location API-base-relative: `{server_id}/.well-known/cycles-jwks.json` — deliberately **not** origin-rooted (the cross-tenant key-confusion close-out).
- **`selectKey` gains the `[cycles_nbf_ms, cycles_exp_ms)` window gate + raw-hex `x` match** — the key valid **at `issued_at_ms`**, never "the current key". Backward compatible (legacy `kid` string still works). `Ed25519JWK` gains `cycles_nbf_ms`/`cycles_exp_ms`/`status`; `KeyLocator` gains `issuedAtMs`/`publicKeyHex`.
- **`resolver.ts`**: did:cycles no longer self-resolvable — the cycles verify layer derives `jwksUrl` from the envelope's `server_id` (checking the `sha256` binding) and supplies it. `did:key`/`did:web` untouched.

## Load-bearing properties (#43)
- **Authority scope** — JWKS API-base-relative off `server_id`, not origin.
- **Rotation / offline replay** — window-gated selection by `issued_at_ms`, fail-closed when no key covers it.

## Tests / review
- `resolver.test.ts` rewritten to the hash-bound model + `cyclesJwksUrl` + window/raw-hex selection. **52 pass**; full `tsc` clean; cycles payment-rail (29) + evidence-resolution (19) unaffected.
- codex-reviewed: 3 findings fixed — cache key now includes the window + raw-key inputs (rotation-safety bug), `issuedAtMs` fail-closes on non-integers, README updated; regression tests added.

Refs: cycles-protocol#43; Cycles publication side (cycles-protocol#113 / cycles-server#194) + reference verifier (cycles-server-events#90).
