### PR TITLE
feat(bilateral-pair): action_ref slot in signed body + pair reconcili…

### DIFF
--- a/src/core/bilateral-receipt.ts
+++ b/src/core/bilateral-receipt.ts
@@ -59,6 +59,13 @@ export function createBilateralReceipt(opts: {
    * audience binding, since canonicalize() omits undefined keys.
    */
   aud?: import('../types/bilateral-receipt.js').BilateralReceipt['aud']
+  /**
+   * Optional native action_ref correlating the receipt to its request. When
+   * set, both co-signers sign over it. When omitted, the canonical body (and
+   * therefore both signatures) is byte-identical to a receipt without the
+   * slot, since canonicalize() omits undefined keys.
+   */
+  action_ref?: string
   // Additive optional slot. When omitted the body and signatures are unchanged
   // (canonicalize() strips undefined keys), so receipts that do not carry a
   // field-disclosure profile keep their exact prior bytes.
@@ -79,6 +86,7 @@ export function createBilateralReceipt(opts: {
     agreedAt: now,
     evidenceCommitments: opts.evidenceCommitments,
     aud: opts.aud,
+    action_ref: opts.action_ref,
     fieldDisclosureProfile: opts.fieldDisclosureProfile,
   }
 

--- a/src/types/bilateral-receipt.ts
+++ b/src/types/bilateral-receipt.ts
@@ -60,6 +60,17 @@ export interface BilateralReceipt {
    * existing receipts remain valid. Both co-signers sign over it when present.
    */
   aud?: import('../v2/audience-binding/types.js').AudienceBinding
+  /**
+   * Optional native action_ref (src/core/action-ref.ts) correlating this
+   * receipt to the request it records. When present, both co-signers sign
+   * over it and pair reconciliation (src/v2/bilateral-pair) compares the two
+   * parties' values with actionRefsMatch. Additive and versioned: a receipt
+   * that OMITS this field signs and serializes byte-for-byte as before
+   * (canonicalize strips undefined keys), so existing receipts remain valid.
+   * Legacy pairing for receipts without this slot is served by a
+   * caller-supplied expectedActionRef at reconciliation time.
+   */
+  action_ref?: string
   // Field-disclosure profile (additive, versioned slot).
   // Commits to a payload by hash + URI with a per-field disclosure policy so
   // raw sensitive payloads are never embedded. Optional: a receipt that omits

--- a/src/v2/bilateral-pair/reconcile.ts
+++ b/src/v2/bilateral-pair/reconcile.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @fileoverview reconcileBilateralPair: compare the two parties' copies of a
+ * bilateral receipt and emit a reason-coded verdict (FREEZE-VWE F2).
+ *
+ * ── PROOF BOX ──────────────────────────────────────────────────────────────
+ * What a 'reconciled' verdict PROVES, given the precondition that both copies
+ * individually passed verifyBilateralReceipt:
+ *   The two parties hold copies that agree on the request/response hashes,
+ *   the serving agent, the success claim, and (when present) the action_ref,
+ *   and each copy's audience binding names the other side per the memo
+ *   invariant.
+ *
+ * What it does NOT prove:
+ *   - It does NOT re-verify signatures; run verifyBilateralReceipt first.
+ *   - It does NOT prove the interaction happened; it proves the copies agree.
+ *   - It is NOT a gateway decision. The verdict feeds a relying party's own
+ *     policy; only the audience facet emits a ConstraintFailure, via the
+ *     existing audienceFailure builder.
+ * ───────────────────────────────────────────────────────────────────────────
+ *
+ * Detectors per SCHEMAS-DRAFT 3a, classes frozen by FREEZE-VWE F2.
+ * Audience directions per AUDIENCE-BINDING-MEMO decision 4: the counterparty
+ * receipt's aud must contain the requester (self) identifier; the
+ * requester-side receipt's aud must contain the counterparty identifier.
+ */
+
+import { checkAudience } from '../audience-binding/verify.js'
+import { audienceFailure } from '../audience-binding/reconcile.js'
+import { actionRefsMatch } from '../../core/action-ref.js'
+import type { BilateralReceipt } from '../../types/bilateral-receipt.js'
+import type { ConstraintFailure } from '../../types/gateway.js'
+import type {
+  BilateralMismatchReason,
+  BilateralPairAudienceTrace,
+  BilateralPairPolicy,
+  BilateralPairVerdict,
+} from './types.js'
+
+/**
+ * Derive the counterparty's recipient identifier from the local copy under
+ * the APS-native convention (agent DIDs are the recipient identifiers). When
+ * selfRecipientId matches neither agent id (e.g. the jwks-kid convention),
+ * returns null and the caller reports the direction as not evaluable rather
+ * than guessing.
+ */
+function deriveCounterpartyId(local: BilateralReceipt, selfRecipientId: string): string | null {
+  if (selfRecipientId === local.requestingAgentId) return local.servingAgentId
+  if (selfRecipientId === local.servingAgentId) return local.requestingAgentId
+  return null
+}
+
+/**
+ * Reconcile the relying party's copy of a bilateral receipt with the
+ * counterparty's copy (or its absence). See the fileoverview for the proof
+ * box and the precondition (signatures already verified per copy).
+ */
+export function reconcileBilateralPair(
+  local: BilateralReceipt,
+  counterparty: BilateralReceipt | null,
+  policy: BilateralPairPolicy,
+): BilateralPairVerdict {
+  const mismatches: BilateralMismatchReason[] = []
+  const detail: BilateralPairVerdict['detail'] = {}
+  const audience: BilateralPairAudienceTrace = {}
+  const constraintFailures: ConstraintFailure[] = []
+
+  const push = (reason: BilateralMismatchReason, line: string): void => {
+    if (!mismatches.includes(reason)) mismatches.push(reason)
+    if (detail[reason] === undefined) detail[reason] = line
+  }
+
+  // ── wrong_audience: both directions of the memo invariant ──
+  // Direction 1: the counterparty's copy must name self among its recipients.
+  if (counterparty !== null) {
+    const d1 = checkAudience(counterparty, {
+      recipientId: policy.selfRecipientId,
+      requireAudience: policy.requireAudience,
+    })
+    audience.counterpartyCopyToSelf = d1
+    if (d1.status === 'fail') {
+      push('wrong_audience', `counterparty copy does not admit self (${d1.reason})`)
+      const failure = audienceFailure(d1)
+      if (failure !== null) constraintFailures.push(failure)
+    }
+  }
+
+  // Direction 2: the local copy must name the counterparty among its
+  // recipients. The identifier comes from policy when supplied, else from the
+  // APS-native agent-DID convention; when neither resolves the direction is
+  // simply not evaluable (no silent pass, no invented failure).
+  const counterpartyId =
+    policy.counterpartyRecipientId ?? deriveCounterpartyId(local, policy.selfRecipientId)
+  if (counterpartyId !== null) {
+    const d2 = checkAudience(local, {
+      recipientId: counterpartyId,
+      requireAudience: policy.requireAudience,
+    })
+    audience.localCopyToCounterparty = d2
+    if (d2.status === 'fail') {
+      push('wrong_audience', `local copy does not admit the counterparty (${d2.reason})`)
+      const failure = audienceFailure(d2)
+      if (failure !== null) constraintFailures.push(failure)
+    }
+  }
+
+  // ── action_ref_mismatch: every pair of PRESENT refs must match ──
+  // Absence never mismatches: the slot is additive (F1) and expectedActionRef
+  // exists precisely so legacy slot-free receipts can still be paired.
+  const presentRefs: string[] = []
+  if (local.action_ref !== undefined) presentRefs.push(local.action_ref)
+  if (counterparty !== null && counterparty.action_ref !== undefined) {
+    presentRefs.push(counterparty.action_ref)
+  }
+  if (policy.expectedActionRef !== undefined) presentRefs.push(policy.expectedActionRef)
+  if (presentRefs.length >= 2) {
+    const first = presentRefs[0]
+    if (!presentRefs.every((r) => actionRefsMatch(first, r))) {
+      push('action_ref_mismatch', 'present action_ref values disagree across copies/policy')
+    }
+  }
+
+  // ── pairwise detectors (need both copies) ──
+  if (counterparty !== null) {
+    if (
+      local.outcome.requestHash !== counterparty.outcome.requestHash ||
+      local.outcome.responseHash !== counterparty.outcome.responseHash
+    ) {
+      push('payload_changed', 'outcome.requestHash/responseHash differ between copies')
+    }
+
+    if (local.servingAgentId !== counterparty.servingAgentId) {
+      push('recipient_changed', 'copies name different servingAgentId (re-mint)')
+    }
+
+    const localSuccess = local.outcome.status === 'success'
+    const cpSuccess = counterparty.outcome.status === 'success'
+    if (localSuccess !== cpSuccess) {
+      push('unilateral_success', 'one copy claims success, the other does not')
+    }
+  } else if (local.outcome.status === 'success') {
+    // One-sided success with no counterparty copy at all.
+    push('unilateral_success', 'local copy claims success with no counterparty copy')
+  }
+
+  const status: BilateralPairVerdict['status'] =
+    counterparty === null ? 'unilateral' : mismatches.length === 0 ? 'reconciled' : 'mismatch'
+
+  return { status, mismatches, detail, audience, constraintFailures }
+}

--- a/src/v2/bilateral-pair/types.ts
+++ b/src/v2/bilateral-pair/types.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @fileoverview Bilateral pair reconciliation types (FREEZE-VWE F2).
+ *
+ * A bilateral receipt exists as two copies, one held by each party. Both
+ * parties signed the same canonical body, so honest copies are identical.
+ * Reconciliation takes the relying party's copy plus the counterparty's copy
+ * (or its absence) and emits a reason-coded verdict in the same string-union
+ * style as AudienceReason (src/v2/audience-binding/types.ts).
+ *
+ * The five mismatch classes are frozen (FREEZE-VWE F2, SCHEMAS-DRAFT 3a).
+ * They exist ONLY in the pair verdict: no new ConstraintFacet is introduced
+ * (the facet count is a public claim). wrong_audience may additionally emit
+ * the existing 'audience' ConstraintFailure via audienceFailure.
+ *
+ * PRECONDITION: reconciliation compares two copies structurally. It does NOT
+ * re-verify signatures; callers run verifyBilateralReceipt on each copy first
+ * and only reconcile copies whose signatures verified. The detectors are
+ * defined over individually valid copies (SCHEMAS-DRAFT 3a).
+ */
+
+import type { AudienceCheckResult } from '../audience-binding/types.js'
+import type { ConstraintFailure } from '../../types/gateway.js'
+
+/** The five frozen mismatch classes (FREEZE-VWE F2). */
+export type BilateralMismatchReason =
+  | 'payload_changed'      // both copies valid but outcome.requestHash/responseHash differ
+  | 'recipient_changed'    // two validly signed copies naming different servingAgentId
+  | 'wrong_audience'       // an audience direction check failed (memo invariant)
+  | 'unilateral_success'   // success claimed on one side; counterparty absent or says failure
+  | 'action_ref_mismatch'  // present action_refs disagree (slot or caller-supplied)
+
+/**
+ * Relying-party policy for pair reconciliation. Never read from a receipt.
+ */
+export interface BilateralPairPolicy {
+  /**
+   * The relying party's own recipient identifier. Per the audience memo:
+   * APS-native parties use the agent DID; JWT/JWKS counterparties use
+   * 'jwks-kid:' + the stable JWKS kid.
+   */
+  selfRecipientId: string
+  /** When true, an audience-unbound copy fails the audience direction checks. */
+  requireAudience?: boolean
+  /**
+   * Caller-supplied expected action_ref, serving legacy pairing for receipts
+   * minted before the F1 slot existed (FREEZE-VWE F1). Compared with
+   * actionRefsMatch against any copy that carries the slot.
+   */
+  expectedActionRef?: string
+  /**
+   * Optional explicit counterparty recipient identifier for the reverse
+   * audience direction (local copy must name the counterparty). When omitted,
+   * the counterparty identifier is derived from the local copy's agent ids
+   * (the APS-native DID convention); for jwks-kid counterparties the derived
+   * form does not exist, so supply this field and the direction is otherwise
+   * reported 'unknown', never silently passed.
+   */
+  counterpartyRecipientId?: string
+}
+
+/**
+ * The audience evaluation trace, one entry per direction of the memo
+ * invariant: the counterparty's copy must name self; the local copy must name
+ * the counterparty. Entries are absent when the direction could not run
+ * (no counterparty copy; no counterparty identifier).
+ */
+export interface BilateralPairAudienceTrace {
+  /** checkAudience(counterparty copy, {recipientId: selfRecipientId, requireAudience}) */
+  counterpartyCopyToSelf?: AudienceCheckResult
+  /** checkAudience(local copy, {recipientId: counterparty identifier, requireAudience}) */
+  localCopyToCounterparty?: AudienceCheckResult
+}
+
+/** The reconciliation verdict (FREEZE-VWE F2). */
+export interface BilateralPairVerdict {
+  /**
+   * 'reconciled'  : counterparty copy present, no mismatch class detected.
+   * 'mismatch'    : counterparty copy present, one or more classes detected.
+   * 'unilateral'  : no counterparty copy was supplied; mismatches may still
+   *                 carry unilateral_success, wrong_audience, or
+   *                 action_ref_mismatch findings computable from one copy.
+   */
+  status: 'reconciled' | 'mismatch' | 'unilateral'
+  /** Detected classes, deduplicated, in detection order. */
+  mismatches: BilateralMismatchReason[]
+  /** One human-readable line per detected class (logs, never parsed). */
+  detail: Partial<Record<BilateralMismatchReason, string>>
+  /** Per-direction audience results backing any wrong_audience finding. */
+  audience: BilateralPairAudienceTrace
+  /**
+   * Canonical ConstraintFailures for failed audience checks, built ONLY via
+   * the existing audienceFailure (facet 'audience'). The other four classes
+   * exist only in this verdict and emit no ConstraintFailure this sprint
+   * (FREEZE-VWE F2: no new ConstraintFacet).
+   */
+  constraintFailures: ConstraintFailure[]
+}

--- a/tests/bilateral-receipt.test.ts
+++ b/tests/bilateral-receipt.test.ts
@@ -328,3 +328,75 @@ describe('Compromise Window', () => {
     })
   })
 })
+
+// ══════════════════════════════════════════════════════════════════
+// 4. action_ref slot (FREEZE-VWE F1): additive, byte-preserving
+// ══════════════════════════════════════════════════════════════════
+
+describe('action_ref slot (FREEZE-VWE F1)', () => {
+  const base = {
+    requestingAgentId: 'did:aps:zAgentA',
+    servingAgentId: 'did:aps:zAgentB',
+    outcome: makeOutcome(),
+    requestedAt: '2026-07-10T00:00:00Z',
+    completedAt: '2026-07-10T00:00:01Z',
+    requestingAgentPrivateKey: agentA.privateKey,
+    servingAgentPrivateKey: agentB.privateKey,
+  }
+
+  it('slot-absent receipt signs and serializes byte-identically to the pre-slot body shape', async () => {
+    const { canonicalize } = await import('../src/core/canonical.js')
+    const receipt = createBilateralReceipt(base)
+    const { requestingAgentSignature, servingAgentSignature, gatewaySignature, ...body } = receipt
+
+    const canonical = canonicalize(body)
+    // The slot leaves no trace in the signed bytes when absent.
+    assert.ok(!canonical.includes('action_ref'))
+    // Byte-for-byte equal to the exact body key set the builder produced
+    // BEFORE the slot existed (canonicalize strips undefined-valued keys).
+    const preSlotBody = {
+      receiptId: receipt.receiptId,
+      version: receipt.version,
+      requestingAgentId: receipt.requestingAgentId,
+      servingAgentId: receipt.servingAgentId,
+      delegationId: undefined,
+      outcome: receipt.outcome,
+      requestedAt: receipt.requestedAt,
+      completedAt: receipt.completedAt,
+      agreedAt: receipt.agreedAt,
+      evidenceCommitments: undefined,
+      aud: undefined,
+      fieldDisclosureProfile: undefined,
+    }
+    assert.equal(canonical, canonicalize(preSlotBody))
+    // Both signatures verify over those unchanged bytes.
+    const v = verifyBilateralReceipt(receipt, agentA.publicKey, agentB.publicKey)
+    assert.equal(v.valid, true)
+    // And the wire serialization carries no action_ref key either.
+    assert.ok(!JSON.stringify(receipt).includes('action_ref'))
+  })
+
+  it('carries action_ref inside the signed body and verifies', () => {
+    const ref = 'a'.repeat(64)
+    const receipt = createBilateralReceipt({ ...base, action_ref: ref })
+    assert.equal(receipt.action_ref, ref)
+    const v = verifyBilateralReceipt(receipt, agentA.publicKey, agentB.publicKey)
+    assert.equal(v.valid, true)
+  })
+
+  it('tampering with action_ref after signing breaks both signatures', () => {
+    const receipt = createBilateralReceipt({ ...base, action_ref: 'a'.repeat(64) })
+    const tampered = { ...receipt, action_ref: 'b'.repeat(64) }
+    const v = verifyBilateralReceipt(tampered, agentA.publicKey, agentB.publicKey)
+    assert.equal(v.valid, false)
+    assert.equal(v.requestingAgentSignatureValid, false)
+    assert.equal(v.servingAgentSignatureValid, false)
+  })
+
+  it('adding action_ref to a receipt signed without it breaks both signatures', () => {
+    const receipt = createBilateralReceipt(base)
+    const upgraded = { ...receipt, action_ref: 'a'.repeat(64) }
+    const v = verifyBilateralReceipt(upgraded, agentA.publicKey, agentB.publicKey)
+    assert.equal(v.valid, false)
+  })
+})

--- a/tests/v2/bilateral-pair/bilateral-pair.test.ts
+++ b/tests/v2/bilateral-pair/bilateral-pair.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// Bilateral pair reconciliation tests (FREEZE-VWE F2, SCHEMAS-DRAFT 3a).
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { reconcileBilateralPair } from '../../../src/v2/bilateral-pair/reconcile.js'
+import { createBilateralReceipt, verifyBilateralReceipt } from '../../../src/core/bilateral-receipt.js'
+import { bindAudience } from '../../../src/v2/audience-binding/verify.js'
+import { generateKeyPair } from '../../../src/crypto/keys.js'
+import type { BilateralReceipt } from '../../../src/types/bilateral-receipt.js'
+import type { BilateralPairPolicy } from '../../../src/v2/bilateral-pair/types.js'
+
+const fixture = JSON.parse(
+  readFileSync(new URL('./fixtures/bilateral-pair-vectors.json', import.meta.url), 'utf-8'),
+)
+
+describe('bilateral pair fixtures (one reconciled + one per frozen mismatch class)', () => {
+  for (const v of fixture.vectors) {
+    it(`vector: ${v.name}`, () => {
+      const verdict = reconcileBilateralPair(v.local, v.counterparty, v.policy)
+      assert.equal(verdict.status, v.expected.status)
+      assert.deepEqual(verdict.mismatches, v.expected.mismatches)
+    })
+  }
+
+  it('every fixture receipt is genuinely co-signed (precondition holds)', () => {
+    const { requestingAgentPublicKey, servingAgentPublicKey } = fixture.keys
+    for (const v of fixture.vectors) {
+      for (const copy of [v.local, v.counterparty]) {
+        if (copy === null) continue
+        const res = verifyBilateralReceipt(copy, requestingAgentPublicKey, servingAgentPublicKey)
+        assert.equal(res.valid, true, `${v.name}: fixture copy fails signature verification`)
+      }
+    }
+  })
+})
+
+describe('bilateral pair reconciliation behavior (FREEZE-VWE F2)', () => {
+  const req = generateKeyPair()
+  const srv = generateKeyPair()
+  const REQ = 'did:aps:zReqAgent'
+  const SRV = 'did:aps:zSrvAgent'
+
+  const outcome = {
+    toolName: 'web_search',
+    requestHash: 'r'.repeat(64),
+    responseHash: 's'.repeat(64),
+    status: 'success' as const,
+    summary: 'ok',
+  }
+  const mk = (over: Partial<Parameters<typeof createBilateralReceipt>[0]> = {}): BilateralReceipt =>
+    createBilateralReceipt({
+      requestingAgentId: REQ,
+      servingAgentId: SRV,
+      outcome,
+      requestedAt: '2026-07-10T02:00:00Z',
+      completedAt: '2026-07-10T02:00:01Z',
+      requestingAgentPrivateKey: req.privateKey,
+      servingAgentPrivateKey: srv.privateKey,
+      aud: bindAudience([REQ, SRV]),
+      ...over,
+    })
+  const policy: BilateralPairPolicy = { selfRecipientId: REQ, requireAudience: true }
+
+  it('wrong_audience emits the audience ConstraintFailure via audienceFailure, no other facet', () => {
+    const local = mk()
+    const counterparty = mk({ aud: bindAudience(['did:aps:zSomeoneElse']) })
+    const verdict = reconcileBilateralPair(local, counterparty, policy)
+    assert.deepEqual(verdict.mismatches, ['wrong_audience'])
+    assert.ok(verdict.constraintFailures.length >= 1)
+    for (const f of verdict.constraintFailures) {
+      assert.equal(f.facet, 'audience')
+      assert.equal(f.severity, 'hard')
+      assert.equal(f.retryable, false)
+    }
+    assert.equal(verdict.constraintFailures[0].code, 'audience_mismatch')
+    assert.equal(verdict.audience.counterpartyCopyToSelf?.status, 'fail')
+  })
+
+  it('requireAudience: an unbound counterparty copy fails with audience_required_absent', () => {
+    const local = mk()
+    const counterparty = mk({ aud: undefined })
+    const verdict = reconcileBilateralPair(local, counterparty, policy)
+    assert.ok(verdict.mismatches.includes('wrong_audience'))
+    assert.equal(verdict.audience.counterpartyCopyToSelf?.reason, 'audience_required_absent')
+  })
+
+  it('reverse direction: a local copy that does not admit the counterparty is wrong_audience', () => {
+    const local = mk({ aud: bindAudience([REQ]) }) // names only self, not the counterparty
+    const counterparty = mk()
+    const verdict = reconcileBilateralPair(local, counterparty, policy)
+    assert.ok(verdict.mismatches.includes('wrong_audience'))
+    assert.equal(verdict.audience.localCopyToCounterparty?.status, 'fail')
+    assert.equal(verdict.audience.localCopyToCounterparty?.checkedAgainst, SRV)
+  })
+
+  it('jwks-kid self id: reverse direction needs counterpartyRecipientId, else it is not evaluated', () => {
+    const KID_SELF = 'jwks-kid:aeoess-2026-07'
+    const KID_CP = 'jwks-kid:agentlair-2026-05'
+    const local = mk({ aud: bindAudience([KID_SELF, KID_CP]) })
+    const counterparty = mk({ aud: bindAudience([KID_SELF, KID_CP]) })
+    // Without the explicit counterparty id the reverse direction cannot be
+    // derived from agent DIDs (self id matches neither agent id): no trace
+    // entry, no invented failure. The forward direction still runs.
+    const without = reconcileBilateralPair(local, counterparty, {
+      selfRecipientId: KID_SELF,
+      requireAudience: true,
+    })
+    assert.equal(without.audience.localCopyToCounterparty, undefined)
+    assert.equal(without.audience.counterpartyCopyToSelf?.status, 'pass')
+    assert.equal(without.status, 'reconciled')
+    // With the explicit counterparty id both directions run and pass.
+    const withId = reconcileBilateralPair(local, counterparty, {
+      selfRecipientId: KID_SELF,
+      requireAudience: true,
+      counterpartyRecipientId: KID_CP,
+    })
+    assert.equal(withId.audience.localCopyToCounterparty?.status, 'pass')
+    assert.equal(withId.status, 'reconciled')
+  })
+
+  it('expectedActionRef pairs legacy slot-free receipts without penalizing absence', () => {
+    const ref = 'c'.repeat(64)
+    const local = mk() // no action_ref slot
+    const counterparty = mk()
+    const verdict = reconcileBilateralPair(local, counterparty, {
+      ...policy,
+      expectedActionRef: ref,
+    })
+    // Absence never mismatches (the slot is additive, F1).
+    assert.equal(verdict.status, 'reconciled')
+  })
+
+  it('expectedActionRef against a copy carrying a different ref is action_ref_mismatch', () => {
+    const local = mk({ action_ref: 'c'.repeat(64) })
+    const counterparty = mk({ action_ref: 'c'.repeat(64) })
+    const verdict = reconcileBilateralPair(local, counterparty, {
+      ...policy,
+      expectedActionRef: 'd'.repeat(64),
+    })
+    assert.deepEqual(verdict.mismatches, ['action_ref_mismatch'])
+  })
+
+  it('unilateral non-success local copy is unilateral with no unilateral_success finding', () => {
+    const local = mk({ outcome: { ...outcome, status: 'failure' } })
+    const verdict = reconcileBilateralPair(local, null, policy)
+    assert.equal(verdict.status, 'unilateral')
+    assert.ok(!verdict.mismatches.includes('unilateral_success'))
+  })
+
+  it('pair with success on one side and failure on the other is unilateral_success', () => {
+    const local = mk()
+    const counterparty = mk({ outcome: { ...outcome, status: 'failure' } })
+    const verdict = reconcileBilateralPair(local, counterparty, policy)
+    assert.ok(verdict.mismatches.includes('unilateral_success'))
+    // The status divergence also changes the signed body but NOT the payload
+    // hashes, so payload_changed is not implied.
+    assert.ok(!verdict.mismatches.includes('payload_changed'))
+    assert.equal(verdict.status, 'mismatch')
+  })
+
+  it('multiple classes accumulate without duplication', () => {
+    const local = mk({ action_ref: 'c'.repeat(64) })
+    const counterparty = mk({
+      servingAgentId: 'did:aps:zEvil',
+      action_ref: 'd'.repeat(64),
+      outcome: { ...outcome, responseHash: 'x'.repeat(64) },
+      aud: bindAudience(['did:aps:zSomeoneElse']),
+    })
+    const verdict = reconcileBilateralPair(local, counterparty, policy)
+    assert.equal(verdict.status, 'mismatch')
+    assert.deepEqual(
+      [...verdict.mismatches].sort(),
+      ['action_ref_mismatch', 'payload_changed', 'recipient_changed', 'wrong_audience'],
+    )
+    assert.equal(new Set(verdict.mismatches).size, verdict.mismatches.length)
+  })
+
+  it('does not mutate its inputs', () => {
+    const local = mk()
+    const counterparty = mk({ aud: bindAudience(['did:aps:zSomeoneElse']) })
+    const localSnap = JSON.stringify(local)
+    const cpSnap = JSON.stringify(counterparty)
+    reconcileBilateralPair(local, counterparty, policy)
+    assert.equal(JSON.stringify(local), localSnap)
+    assert.equal(JSON.stringify(counterparty), cpSnap)
+  })
+})

--- a/tests/v2/bilateral-pair/fixtures/bilateral-pair-vectors.json
+++ b/tests/v2/bilateral-pair/fixtures/bilateral-pair-vectors.json
@@ -1,0 +1,379 @@
+{
+  "description": "Bilateral pair reconciliation vectors (FREEZE-VWE F2, SCHEMAS-DRAFT 3a). One reconciled pair plus one vector per frozen mismatch class. Receipts are genuinely Ed25519 co-signed; public keys included so signatures can be independently verified.",
+  "freeze": "FREEZE-VWE F2",
+  "keys": {
+    "requestingAgentPublicKey": "bb8a9093fce286ee7848f531be3991b142ec142161fa1100b86072c96d09c0a2",
+    "servingAgentPublicKey": "42b11d44ef18234b96995e85f32c130e90f25c95031b1bd57a7a7deb2be6fa6b"
+  },
+  "vectors": [
+    {
+      "name": "reconciled-pair",
+      "description": "Identical honest copies: aud names both parties, action_ref shared.",
+      "policy": {
+        "selfRecipientId": "did:aps:zPairRequester01",
+        "requireAudience": true
+      },
+      "local": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "counterparty": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "expected": {
+        "status": "reconciled",
+        "mismatches": []
+      }
+    },
+    {
+      "name": "payload-changed",
+      "description": "Counterparty copy re-minted with a different responseHash.",
+      "policy": {
+        "selfRecipientId": "did:aps:zPairRequester01",
+        "requireAudience": true
+      },
+      "local": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "counterparty": {
+        "receiptId": "9f56f989-82cb-4514-8cb3-f26e99b0b2b1",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "3333333333333333333333333333333333333333333333333333333333333333",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.111Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cd5ccbee5f55d3af414024fa5f864841b022545fb675794f011ab12725f40afcc4bd06cae04371dbdf9a24f96599b813c7bcca9e3b70fb11e1d6ffa3f314dd05",
+        "servingAgentSignature": "0d1c73e4e24df9dc2a0acced82a7b1398acc971cf214f709d8a2d161b517ebed1dbcb706bee0c5a9d9c9c3acdc2e71d0c72cd07297fa4799d4848c25de97c707"
+      },
+      "expected": {
+        "status": "mismatch",
+        "mismatches": [
+          "payload_changed"
+        ]
+      }
+    },
+    {
+      "name": "recipient-changed",
+      "description": "Counterparty copy names a different servingAgentId (re-mint attack).",
+      "policy": {
+        "selfRecipientId": "did:aps:zPairRequester01",
+        "requireAudience": true
+      },
+      "local": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "counterparty": {
+        "receiptId": "3df08040-05cd-4bf3-90bf-9b17c3d7cc22",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairEvil01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.111Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "227b86d78a6252dc72e326d79399e7ce3feaf47c728055e646abb6900c4fc941a5484a56cda2e6f93aca9628c553561b59cf407c4e5fec18714ef49e2909df07",
+        "servingAgentSignature": "a4c8d6973abf4dce9dfe7f28c8ee878054cadb3d391e7fb4ee5da2e5d21cf925a7ce92a5eda13d597435977c4b4533dfede665a137c769057ae1b9660ed0fe00"
+      },
+      "expected": {
+        "status": "mismatch",
+        "mismatches": [
+          "recipient_changed"
+        ]
+      }
+    },
+    {
+      "name": "wrong-audience",
+      "description": "Counterparty copy audience-bound to a third party, not to self.",
+      "policy": {
+        "selfRecipientId": "did:aps:zPairRequester01",
+        "requireAudience": true
+      },
+      "local": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "counterparty": {
+        "receiptId": "ab18c1d7-3101-486f-9510-4dcec83571a2",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.111Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairEvil01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "22de7dd876d068ec46dff1bf118e83d4d61068e776ff3bd4384e79177e08b97d6701579e82e910bb89ca84c8f5280990f381255cb3f76d1fb18b090fc5adb109",
+        "servingAgentSignature": "06538648ee2ae6836aba3585483c93bfcc93633a8f49a58a5bf852669d0041a21a5274d6c8205f850161eb4ca0ea7b392d43adf279d55a8f95a51a770f906e03"
+      },
+      "expected": {
+        "status": "mismatch",
+        "mismatches": [
+          "wrong_audience"
+        ]
+      }
+    },
+    {
+      "name": "unilateral-success",
+      "description": "Local copy claims success; no counterparty copy exists.",
+      "policy": {
+        "selfRecipientId": "did:aps:zPairRequester01",
+        "requireAudience": true
+      },
+      "local": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "counterparty": null,
+      "expected": {
+        "status": "unilateral",
+        "mismatches": [
+          "unilateral_success"
+        ]
+      }
+    },
+    {
+      "name": "action-ref-mismatch",
+      "description": "Copies carry different action_ref values for the same interaction.",
+      "policy": {
+        "selfRecipientId": "did:aps:zPairRequester01",
+        "requireAudience": true
+      },
+      "local": {
+        "receiptId": "416ad9cc-f8b1-4212-8c46-bb2e6bf3fc06",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.109Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "c3828feae93209059a038cd3a39c088493a68e1099a6b4dba3cac0223f66c3bf",
+        "requestingAgentSignature": "cc88ada526a66c864b53757a37993f9036bda1585894ea26aa2fd3887fa071bf6d2f7bb4f470f672225f24cb8a6a441322659c35d6677f5258630d01740c050b",
+        "servingAgentSignature": "2f1b03c65279b14f8c8718350540ff2ff71e35780f1513113f12efbe2ae16402ec75a069df9c9cd8a661d5d51244cdc6ee52210df81491f46b1fbcdecc4c900b"
+      },
+      "counterparty": {
+        "receiptId": "dd26d40c-0154-4add-a004-a08fb4389d1f",
+        "version": "1.0",
+        "requestingAgentId": "did:aps:zPairRequester01",
+        "servingAgentId": "did:aps:zPairServer01",
+        "outcome": {
+          "toolName": "document.sign",
+          "requestHash": "1111111111111111111111111111111111111111111111111111111111111111",
+          "responseHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "status": "success",
+          "summary": "signed the document"
+        },
+        "requestedAt": "2026-07-10T01:00:00Z",
+        "completedAt": "2026-07-10T01:00:01Z",
+        "agreedAt": "2026-07-10T07:46:36.112Z",
+        "aud": {
+          "profile": "aps:audience-binding:v1",
+          "recipients": [
+            "did:aps:zPairRequester01",
+            "did:aps:zPairServer01"
+          ]
+        },
+        "action_ref": "9f49b6ea908b45f428f554085f57e2f4ec462c87f393d8797d07c29152502c3c",
+        "requestingAgentSignature": "a3de2da82edaefbe1bf3132777ab5b1d702a3aea7b4c84e760e4af0a60793190ef571fcf3d25ee671324fb81057d4cc25f77a0620217ca12a731971445d81d05",
+        "servingAgentSignature": "65adbcd5b205e9bc1b7976e5349dd0c9fe529c04dd8329ddd1191e7f2e6de5c4464219d2abb4b7cdee22d74e565b5e7b8e011d31ed2988033ca0d97c1e255b06"
+      },
+      "expected": {
+        "status": "mismatch",
+        "mismatches": [
+          "action_ref_mismatch"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
…ation (FREEZE-VWE F1, F2)

F1: optional action_ref inside the BilateralReceipt signed body, mirroring the aud slot pattern. A slot-absent receipt signs and serializes byte-identically to the pre-slot shape (proof test included); tampering or post-hoc addition breaks both signatures.

F2: src/v2/bilateral-pair with the five frozen mismatch classes (payload_changed, recipient_changed, wrong_audience, unilateral_success, action_ref_mismatch). wrong_audience runs checkAudience per copy in both directions per the audience memo invariant and emits ConstraintFailures only through the existing audienceFailure builder; no new ConstraintFacet. Six fixtures (one reconciled plus one per class), genuinely co-signed, with signature-precondition and behavior tests.

## Summary

<!-- Describe what this PR changes. -->

## Checklist

- [ ] **Signed-off-by (DCO) — required.** Every commit in this PR is signed off (`git commit -s`) per the [Developer Certificate of Origin](https://developercertificate.org/).
