### PR TITLE
feat(revocation-enforcement): RevocationObservation per FREEZE-VWE F4

### DIFF
--- a/src/v2/revocation-enforcement/fixtures/revocation-observation-fixtures.json
+++ b/src/v2/revocation-enforcement/fixtures/revocation-observation-fixtures.json
@@ -1,0 +1,94 @@
+{
+  "description": "T7 / FREEZE-VWE F4 fixtures: one observation per derived outcome label. The label and freshness_result are TEST INPUTS for classifyObservation; neither is part of the signed record. freshness_result is null where classification needs no context (an observed revocation decides from the record alone). Timestamps are fixed for determinism; signatures are produced at test time by the local Signer, not stored here.",
+  "fixtures": [
+    {
+      "name": "revoked-blocked-set-sourced",
+      "label": "revoked_blocked",
+      "freshness_result": null,
+      "observation": {
+        "authority_ref": "dlg_t7_0001",
+        "status_source": { "kind": "set", "jti": "set_jti_0001" },
+        "revoked_at": "2026-07-10T11:59:30.000Z",
+        "observed_at": "2026-07-10T12:00:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "affected_scope": "cascade:origin=dlg_t7_0001;txn=txn_t7_a",
+        "decision": { "effect": "deny" }
+      }
+    },
+    {
+      "name": "fresh-valid-source-consult",
+      "label": "fresh_valid",
+      "freshness_result": "fresh",
+      "observation": {
+        "authority_ref": "dlg_t7_0002",
+        "status_source": { "kind": "source", "id": "crl://registry.example/v1" },
+        "observed_at": "2026-07-10T12:01:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "decision": { "effect": "allow" }
+      }
+    },
+    {
+      "name": "stale-denied-source-consult",
+      "label": "stale_denied",
+      "freshness_result": "stale",
+      "observation": {
+        "authority_ref": "dlg_t7_0003",
+        "status_source": { "kind": "source", "id": "crl://registry.example/v1" },
+        "observed_at": "2026-07-10T12:02:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "decision": { "effect": "deny" }
+      }
+    },
+    {
+      "name": "stale-permitted-downgraded",
+      "label": "stale_permitted",
+      "freshness_result": "stale",
+      "observation": {
+        "authority_ref": "dlg_t7_0004",
+        "status_source": { "kind": "source", "id": "crl://registry.example/v1" },
+        "observed_at": "2026-07-10T12:03:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "decision": { "effect": "allow", "downgraded": true }
+      }
+    },
+    {
+      "name": "running-terminated-refresh-refused",
+      "label": "running_terminated",
+      "freshness_result": null,
+      "observation": {
+        "authority_ref": "dlg_t7_0005",
+        "status_source": { "kind": "set", "jti": "set_jti_0005" },
+        "revoked_at": "2026-07-10T12:03:45.000Z",
+        "observed_at": "2026-07-10T12:04:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "affected_scope": "cascade:origin=dlg_t7_root;txn=txn_t7_b",
+        "decision": { "effect": "deny" },
+        "workflow_response": { "reissued": false, "reason": "revoked" }
+      }
+    },
+    {
+      "name": "unavailable-fail-closed",
+      "label": "unavailable_fail_closed",
+      "freshness_result": "unavailable",
+      "observation": {
+        "authority_ref": "dlg_t7_0006",
+        "status_source": { "kind": "source", "id": "crl://registry.example/v1" },
+        "observed_at": "2026-07-10T12:05:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "decision": { "effect": "deny" }
+      }
+    },
+    {
+      "name": "unavailable-fail-open",
+      "label": "unavailable_fail_open",
+      "freshness_result": "unavailable",
+      "observation": {
+        "authority_ref": "dlg_t7_0007",
+        "status_source": { "kind": "source", "id": "crl://registry.example/v1" },
+        "observed_at": "2026-07-10T12:06:00.000Z",
+        "maximum_staleness_ms": 60000,
+        "decision": { "effect": "allow" }
+      }
+    }
+  ]
+}

--- a/src/v2/revocation-enforcement/index.ts
+++ b/src/v2/revocation-enforcement/index.ts
@@ -80,6 +80,7 @@ import type {
 } from './types.js'
 
 export * from './types.js'
+export * from './observation.js'
 
 const CAEP_SESSION_REVOKED: CAEPEventType =
   'https://schemas.openid.net/secevent/caep/event-type/session-revoked'

--- a/src/v2/revocation-enforcement/observation.ts
+++ b/src/v2/revocation-enforcement/observation.ts
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// ══════════════════════════════════════════════════════════════════
+// T7 / FREEZE-VWE F4. RevocationObservation - build, verify, classify, ingest
+// ══════════════════════════════════════════════════════════════════
+// The module's emitter side (buildRevocationSET) and decision side
+// (decideFreshness) existed; this file adds the verifier-side OBSERVATION
+// record: that a specific revocation signal was observed, from which source,
+// for which authority, covering which scope, and what the relying party then
+// did under its stated freshness contract.
+//
+// Claims language: an observation is evidence of what one verifier saw and
+// decided within its freshness contract (maximum_staleness_ms). Nothing here
+// claims instant or universal revocation: a revocation takes effect for a
+// relying party when that party observes it within the contract, and a signal
+// the source has not yet propagated is, by construction, not yet observable.
+//
+// ──────────────────────────── PROOF BOX ────────────────────────────
+// Proves: the observing verifier signed this record of a revocation signal
+//   (or of the failure to obtain one) and of the decision it reached under
+//   its freshness policy at observed_at.
+// Does NOT prove: that the revocation is true, globally current, or visible
+//   to any other relying party; that no revocation occurred after
+//   observed_at; or that the decision was the right one. Outcome labels are
+//   derived reporting vocabulary and are never part of the signed bytes.
+// ════════════════════════════════════════════════════════════════════
+
+import { canonicalize } from '../../core/canonical.js'
+import { verify } from '../../crypto/keys.js'
+import { defaultKeyId } from '../../adapters/remote-signer/types.js'
+import type { Signer } from '../../adapters/remote-signer/types.js'
+import type { RevocationFreshnessResult } from '../../types/policy.js'
+import type {
+  RevocationObservation,
+  RevocationObservationDecision,
+  RevocationOutcomeLabel,
+  RevocationStatusSource,
+  SignedRevocationObservation,
+  ObservationVerifyResult,
+  SecurityEventTokenClaims,
+  CAEPRevocationEvent,
+  RefreshOutcome,
+} from './types.js'
+
+const CAEP_SESSION_REVOKED =
+  'https://schemas.openid.net/secevent/caep/event-type/session-revoked' as const
+
+// ══════════════════════════════════════════════════════════════════
+// Build (signed via the SDK Signer interface)
+// ══════════════════════════════════════════════════════════════════
+
+/** Input to buildRevocationObservation. Field semantics are those of
+ *  {@link RevocationObservation}; timestamps accept Date for convenience and
+ *  are stored ISO 8601. */
+export interface BuildObservationParams {
+  authority_ref: string
+  status_source: RevocationStatusSource
+  revoked_at?: Date | string
+  /** Defaults to now. */
+  observed_at?: Date | string
+  maximum_staleness_ms: number
+  affected_scope?: string
+  /** The decision reached under the relying party's freshness policy. A full
+   *  FreshnessDecision may be passed; only effect and downgraded are stored
+   *  (the frozen field shape), the rest stays verifier-local. */
+  decision: RevocationObservationDecision & { [extra: string]: unknown }
+  workflow_response?: RefreshOutcome
+}
+
+function toISO(value: Date | string): string {
+  const d = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`revocation-observation: invalid timestamp '${String(value)}'`)
+  }
+  return d.toISOString()
+}
+
+/**
+ * Build and sign a RevocationObservation.
+ *
+ * Signing follows the module's Signer discipline: like buildRevocationSET,
+ * this builder does not introduce its own key handling; the caller supplies
+ * the SDK {@link Signer} (local or remote custody) and the signature is that
+ * signer's Ed25519 signature over the canonical form of the record with the
+ * `signature` field absent. observer_key and observer_key_id are taken from
+ * the signer and are covered by the signature, so the record binds its own
+ * verification key material.
+ *
+ * The record asserts an observation under a stated freshness contract. It
+ * does not assert instant or universal revocation.
+ */
+export async function buildRevocationObservation(
+  params: BuildObservationParams,
+  signer: Signer,
+): Promise<SignedRevocationObservation> {
+  if (!params.authority_ref) {
+    throw new Error('revocation-observation: authority_ref is required')
+  }
+  if (!Number.isFinite(params.maximum_staleness_ms) || params.maximum_staleness_ms < 0) {
+    throw new Error('revocation-observation: maximum_staleness_ms must be a non-negative number')
+  }
+  if (params.decision.effect !== 'allow' && params.decision.effect !== 'deny') {
+    throw new Error("revocation-observation: decision.effect must be 'allow' or 'deny'")
+  }
+
+  const observation: RevocationObservation = {
+    authority_ref: params.authority_ref,
+    status_source: params.status_source,
+    observed_at: toISO(params.observed_at ?? new Date()),
+    maximum_staleness_ms: params.maximum_staleness_ms,
+    decision: params.decision.downgraded === undefined
+      ? { effect: params.decision.effect }
+      : { effect: params.decision.effect, downgraded: params.decision.downgraded },
+  }
+  if (params.revoked_at !== undefined) observation.revoked_at = toISO(params.revoked_at)
+  if (params.affected_scope !== undefined) observation.affected_scope = params.affected_scope
+  if (params.workflow_response !== undefined) observation.workflow_response = params.workflow_response
+
+  const observer_key = await signer.publicKeyHex()
+  const observer_key_id = (await signer.keyId()) || defaultKeyId(observer_key)
+  const signable: Omit<SignedRevocationObservation, 'signature'> = {
+    ...observation,
+    observer_key,
+    observer_key_id,
+  }
+  const signature = await signer.sign(canonicalize(signable))
+  return { ...signable, signature }
+}
+
+// ══════════════════════════════════════════════════════════════════
+// Verify
+// ══════════════════════════════════════════════════════════════════
+
+/**
+ * Verify a signed observation: structural well-formedness, then the Ed25519
+ * signature over the canonical record with `signature` absent, against the
+ * record's own observer_key (or a caller-pinned expected key).
+ *
+ * Verifying proves the named observer signed this observation. It does not
+ * prove the observed revocation is true or current beyond the freshness
+ * contract the record states, and it does not prove any other relying party
+ * observed the same signal.
+ */
+export function verifyRevocationObservation(
+  record: SignedRevocationObservation,
+  opts?: { expectedObserverKey?: string },
+): ObservationVerifyResult {
+  if (typeof record !== 'object' || record === null) {
+    return { valid: false, reason: 'not an object' }
+  }
+  if (typeof record.authority_ref !== 'string' || record.authority_ref.length === 0) {
+    return { valid: false, reason: 'authority_ref missing or empty' }
+  }
+  const src = record.status_source
+  const srcOk =
+    typeof src === 'object' && src !== null &&
+    ((src.kind === 'source' && typeof (src as { id?: unknown }).id === 'string') ||
+      (src.kind === 'set' && typeof (src as { jti?: unknown }).jti === 'string'))
+  if (!srcOk) {
+    return { valid: false, reason: "status_source must be {kind:'source',id} or {kind:'set',jti}" }
+  }
+  if (typeof record.observed_at !== 'string' || Number.isNaN(new Date(record.observed_at).getTime())) {
+    return { valid: false, reason: 'observed_at missing or not a parseable timestamp' }
+  }
+  if (record.revoked_at !== undefined &&
+      (typeof record.revoked_at !== 'string' || Number.isNaN(new Date(record.revoked_at).getTime()))) {
+    return { valid: false, reason: 'revoked_at present but not a parseable timestamp' }
+  }
+  if (typeof record.maximum_staleness_ms !== 'number' || !Number.isFinite(record.maximum_staleness_ms) || record.maximum_staleness_ms < 0) {
+    return { valid: false, reason: 'maximum_staleness_ms missing or negative' }
+  }
+  if (typeof record.decision !== 'object' || record.decision === null ||
+      (record.decision.effect !== 'allow' && record.decision.effect !== 'deny')) {
+    return { valid: false, reason: "decision.effect must be 'allow' or 'deny'" }
+  }
+  if (typeof record.observer_key !== 'string' || record.observer_key.length !== 64) {
+    return { valid: false, reason: 'observer_key missing or not 32-byte hex' }
+  }
+  if (typeof record.signature !== 'string' || record.signature.length !== 128) {
+    return { valid: false, reason: 'signature missing or not 64-byte hex' }
+  }
+  if (opts?.expectedObserverKey !== undefined && opts.expectedObserverKey !== record.observer_key) {
+    return { valid: false, reason: 'observer_key does not match the pinned expected key' }
+  }
+
+  const { signature, ...signable } = record
+  const ok = verify(canonicalize(signable), signature, record.observer_key)
+  return ok
+    ? { valid: true, reason: 'signature valid over canonical record (signature field absent)' }
+    : { valid: false, reason: 'signature verification failed' }
+}
+
+// ══════════════════════════════════════════════════════════════════
+// Classify (labels are derived, never stored)
+// ══════════════════════════════════════════════════════════════════
+
+/**
+ * Derive the outcome label for an observation. The label is verifier-report
+ * vocabulary: it is computed on demand and never stored in the signed record.
+ *
+ * Derivation:
+ *  - a revocation was observed (revoked_at present):
+ *      - workflow_response refused a refresh because the original was revoked
+ *        (reissued false, reason 'revoked'): 'running_terminated', the in
+ *        flight workflow was cut short by the observed revocation;
+ *      - decision deny: 'revoked_blocked'.
+ *  - no revocation signal (revoked_at absent): the record's frozen decision
+ *    slot carries effect and downgraded only, which cannot distinguish a
+ *    fresh source from a stale or unreachable one. The caller supplies the
+ *    freshness result it recorded (RevocationFreshnessRecord.result) as
+ *    classification CONTEXT; it is consumed here and never stored:
+ *      - 'fresh': 'fresh_valid';
+ *      - 'stale': 'stale_denied' or 'stale_permitted' by decision effect;
+ *      - 'unavailable' or 'skipped' (no signal obtained either way):
+ *        'unavailable_fail_closed' or 'unavailable_fail_open' by effect.
+ *
+ * Throws on combinations outside the seven labels (an observed revocation
+ * that was allowed without a terminating workflow response, a fresh deny, or
+ * a missing freshness context when no revocation was observed): those states
+ * are not representable outcomes of decideFreshness and indicate a
+ * malformed observation rather than an eighth category.
+ */
+export function classifyObservation(
+  observation: RevocationObservation,
+  freshness?: { result: RevocationFreshnessResult },
+): RevocationOutcomeLabel {
+  if (observation.revoked_at !== undefined) {
+    const wf = observation.workflow_response
+    if (wf !== undefined && wf.reissued === false && wf.reason === 'revoked') {
+      return 'running_terminated'
+    }
+    if (observation.decision.effect === 'deny') {
+      return 'revoked_blocked'
+    }
+    throw new Error(
+      'classifyObservation: an observed revocation with an allow decision and no ' +
+      'terminating workflow response is not one of the seven outcome labels',
+    )
+  }
+
+  if (!freshness) {
+    throw new Error(
+      'classifyObservation: no revocation was observed, so the freshness result ' +
+      "(RevocationFreshnessRecord.result) is required as context to distinguish " +
+      'fresh, stale, and unavailable outcomes; the frozen record shape does not carry it',
+    )
+  }
+
+  switch (freshness.result) {
+    case 'fresh':
+      if (observation.decision.effect === 'allow') return 'fresh_valid'
+      throw new Error('classifyObservation: a fresh result with a deny decision is not a defined outcome')
+    case 'stale':
+      return observation.decision.effect === 'deny' ? 'stale_denied' : 'stale_permitted'
+    case 'unavailable':
+    case 'skipped':
+      return observation.decision.effect === 'deny'
+        ? 'unavailable_fail_closed'
+        : 'unavailable_fail_open'
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════
+// SET ingestion
+// ══════════════════════════════════════════════════════════════════
+
+/**
+ * Map a received Security Event Token claim set into builder params for a
+ * RevocationObservation.
+ *
+ * Wiring per the freeze: status_source becomes {kind: 'set', jti} carrying
+ * the SET's replay key, and the CAEP event_timestamp (seconds since the Unix
+ * epoch) is converted to ISO 8601 for revoked_at, keeping the SDK-wide
+ * timestamp convention; milliseconds and epoch seconds are never mixed in
+ * one field.
+ *
+ * Audience note: a SET's `aud` is the RFC 8417 JWT audience claim, a
+ * receiver hint on the event token. It is not the APS AudienceBinding shape
+ * (the in-body receipt binding checked by checkAudience), and this helper
+ * does not read it: whether the SET was addressed to this receiver is the
+ * transport layer's check, made before ingestion.
+ *
+ * Callers SHOULD validate the claim set with isWellFormedSET first; this
+ * helper re-asserts only the fields it dereferences. Receiving a SET is an
+ * observation of one emitter's signal under this receiver's freshness
+ * contract; it is not proof of instant or universal revocation.
+ */
+export function observationParamsFromSET(
+  set: SecurityEventTokenClaims,
+  params: {
+    decision: RevocationObservationDecision
+    maximum_staleness_ms: number
+    observed_at?: Date | string
+    affected_scope?: string
+    workflow_response?: RefreshOutcome
+  },
+): BuildObservationParams {
+  const event: CAEPRevocationEvent | undefined = set?.events?.[CAEP_SESSION_REVOKED]
+  if (!event || typeof event.event_timestamp !== 'number' || !Number.isFinite(event.event_timestamp)) {
+    throw new Error('observationParamsFromSET: claim set carries no well-formed CAEP session-revoked event')
+  }
+  if (typeof set.jti !== 'string' || set.jti.length === 0) {
+    throw new Error('observationParamsFromSET: claim set has no jti')
+  }
+  if (typeof event.subject?.id !== 'string' || event.subject.id.length === 0) {
+    throw new Error('observationParamsFromSET: event subject has no id')
+  }
+
+  const out: BuildObservationParams = {
+    authority_ref: event.subject.id,
+    status_source: { kind: 'set', jti: set.jti },
+    revoked_at: new Date(event.event_timestamp * 1000).toISOString(),
+    maximum_staleness_ms: params.maximum_staleness_ms,
+    decision: params.decision,
+  }
+  if (params.observed_at !== undefined) out.observed_at = params.observed_at
+  if (params.affected_scope !== undefined) out.affected_scope = params.affected_scope
+  if (params.workflow_response !== undefined) out.workflow_response = params.workflow_response
+  return out
+}

--- a/src/v2/revocation-enforcement/types.ts
+++ b/src/v2/revocation-enforcement/types.ts
@@ -185,10 +185,108 @@ export interface SecurityEventTokenClaims {
   /** RFC 8417 'jti' - unique SET id (replay key for receivers). */
   jti: string
   /** RFC 8417 'aud' - intended audience(s). Optional per spec; populated when
-   *  the emitter knows the receiver. */
+   *  the emitter knows the receiver. This is the RFC 8417 SET audience claim,
+   *  a JWT-level receiver hint. It is NOT the APS AudienceBinding shape (the
+   *  in-body receipt binding verified by checkAudience); the two live at
+   *  different layers and are never interchangeable. */
   aud?: string | string[]
   /** RFC 8417 'sub' - optional subject of the SET as a whole. */
   sub?: string
   /** RFC 8417 'events' - map from event-type URI to the event object. */
   events: Record<CAEPEventType, CAEPRevocationEvent>
+}
+
+// ══════════════════════════════════════════════════════════════════
+// RevocationObservation (T7 / FREEZE-VWE F4) - verifier-side record
+// ══════════════════════════════════════════════════════════════════
+
+/** Which revocation signal an observation is based on.
+ *  - kind 'source': the verifier consulted a revocation source directly
+ *    (a CRL URL, a registry id; the RevocationFreshnessRecord.source value).
+ *  - kind 'set': the verifier received an RFC 8417 Security Event Token and
+ *    the jti is that SET's replay key (SecurityEventTokenClaims.jti). */
+export type RevocationStatusSource =
+  | { kind: 'source'; id: string }
+  | { kind: 'set'; jti: string }
+
+/** The decision slot of an observation. Reuses the FreshnessDecision
+ *  vocabulary: effect is 'allow' | 'deny' and a downgrade resolves to an
+ *  allow with `downgraded: true`. No third verdict value exists. */
+export interface RevocationObservationDecision {
+  effect: 'allow' | 'deny'
+  downgraded?: boolean
+}
+
+/** A verifier-side record that a specific revocation signal was OBSERVED,
+ *  from which source, for which authority, covering which scope, and what
+ *  the relying party then did.
+ *
+ *  This is an observation under a stated freshness contract: it records that
+ *  the verifier saw a signal (or failed to obtain one) at observed_at, with
+ *  maximum_staleness_ms naming the staleness the relying party was willing to
+ *  tolerate. It does not assert instant or universal revocation: a revocation
+ *  becomes effective for a relying party when that party observes it within
+ *  its freshness contract, and nothing here claims the signal reached every
+ *  relying party or reached this one immediately. */
+export interface RevocationObservation {
+  /** The revoked (or checked) delegation / agent id. Opaque string, the same
+   *  convention SETSubjectId.id uses. */
+  authority_ref: string
+  /** Where the revocation status came from. */
+  status_source: RevocationStatusSource
+  /** When the revocation took effect, ISO 8601, when a revocation was
+   *  observed. A SET carries epoch seconds (CAEPRevocationEvent
+   *  .event_timestamp); ingestion converts to ISO 8601 so the SDK-wide
+   *  timestamp convention holds. Absent when no revocation signal was
+   *  obtained (fresh, stale, or unavailable consults). */
+  revoked_at?: string
+  /** When the verifier made this observation, ISO 8601. */
+  observed_at: string
+  /** The maximum staleness, in milliseconds, the relying party's freshness
+   *  contract tolerated for this observation. Milliseconds everywhere: SET
+   *  epoch seconds are converted at ingestion, never stored as a third
+   *  convention. */
+  maximum_staleness_ms: number
+  /** The scope subtree the revocation covers, when the signal carried one.
+   *  Uses the cascade reference language of draft-pidlisnyi-aps-03 revocation
+   *  evidence: an opaque reference to the originating revocation and its
+   *  cascade transaction identity, so a verifier can reconstruct from the
+   *  records why a descendant died. */
+  affected_scope?: string
+  /** What the relying party decided under its freshness policy. */
+  decision: RevocationObservationDecision
+  /** What the relying party did next, when it did something recordable:
+   *  a refresh attempt outcome (reissued, or refused with a reason). */
+  workflow_response?: RefreshOutcome
+}
+
+/** A RevocationObservation signed by the observing verifier. The signature
+ *  covers the canonical form of every field except `signature` itself,
+ *  following the module-wide signable-subset discipline. observer_key is the
+ *  raw Ed25519 public key hex the signature verifies against; observer_key_id
+ *  follows the ed25519:<first-16-hex> convention. */
+export interface SignedRevocationObservation extends RevocationObservation {
+  observer_key: string
+  observer_key_id: string
+  signature: string
+}
+
+/** The seven derived outcome labels for an observation. DERIVED by
+ *  classifyObservation, never stored in the signed object: a label is a
+ *  verifier-report word, not wire surface. */
+export type RevocationOutcomeLabel =
+  | 'revoked_blocked'
+  | 'fresh_valid'
+  | 'stale_denied'
+  | 'stale_permitted'
+  | 'running_terminated'
+  | 'unavailable_fail_closed'
+  | 'unavailable_fail_open'
+
+/** Verdict from verifyRevocationObservation. Mechanical: structural
+ *  well-formedness plus signature validity against observer_key. It does not
+ *  assert the observed revocation is true, current, or universally visible. */
+export interface ObservationVerifyResult {
+  valid: boolean
+  reason: string
 }

--- a/tests/v2/revocation-enforcement.test.ts
+++ b/tests/v2/revocation-enforcement.test.ts
@@ -395,3 +395,146 @@ describe('W2-B3 proof box: ScopeOfClaim dogfood', () => {
     assert.equal(scope.capture_mode, 'gateway_observed')
   })
 })
+
+// ── (5) T7 / FREEZE-VWE F4: RevocationObservation ──
+
+import {
+  buildRevocationObservation,
+  verifyRevocationObservation,
+  classifyObservation,
+  observationParamsFromSET,
+} from '../../src/v2/revocation-enforcement/index.js'
+import type {
+  RevocationObservation,
+  RevocationOutcomeLabel,
+  SignedRevocationObservation,
+} from '../../src/v2/revocation-enforcement/index.js'
+import type { RevocationFreshnessResult } from '../../src/types/policy.js'
+import { createLocalSigner } from '../../src/adapters/remote-signer/index.js'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const fixturesPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../src/v2/revocation-enforcement/fixtures/revocation-observation-fixtures.json',
+)
+interface ObservationFixture {
+  name: string
+  label: RevocationOutcomeLabel
+  freshness_result: RevocationFreshnessResult | null
+  observation: RevocationObservation
+}
+const observationFixtures: ObservationFixture[] =
+  JSON.parse(readFileSync(fixturesPath, 'utf8')).fixtures
+
+describe('T7 RevocationObservation: classification (labels derived, never stored)', () => {
+  it('covers all seven labels, one fixture each', () => {
+    const labels = observationFixtures.map(f => f.label).sort()
+    assert.deepEqual(labels, [
+      'fresh_valid', 'revoked_blocked', 'running_terminated', 'stale_denied',
+      'stale_permitted', 'unavailable_fail_closed', 'unavailable_fail_open',
+    ].sort())
+  })
+
+  for (const fixture of observationFixtures) {
+    it(`classifies ${fixture.name} as ${fixture.label}`, () => {
+      const context = fixture.freshness_result === null
+        ? undefined
+        : { result: fixture.freshness_result }
+      assert.equal(classifyObservation(fixture.observation, context), fixture.label)
+    })
+  }
+
+  it('no fixture stores a label field in the observation', () => {
+    for (const fixture of observationFixtures) {
+      assert.ok(!('label' in fixture.observation), fixture.name)
+      assert.ok(!('outcome' in fixture.observation), fixture.name)
+    }
+  })
+
+  it('throws when no revocation was observed and no freshness context is supplied', () => {
+    const fresh = observationFixtures.find(f => f.label === 'fresh_valid')!
+    assert.throws(() => classifyObservation(fresh.observation), /freshness result/)
+  })
+
+  it('throws on an observed revocation that was allowed without a terminating workflow response', () => {
+    const blocked = observationFixtures.find(f => f.label === 'revoked_blocked')!
+    const anomalous = { ...blocked.observation, decision: { effect: 'allow' as const } }
+    assert.throws(() => classifyObservation(anomalous), /not one of the seven/)
+  })
+})
+
+describe('T7 RevocationObservation: sign-and-verify round trip per fixture', () => {
+  const keys = generateKeyPair()
+  const signer = createLocalSigner({ privateKeyHex: keys.privateKey })
+
+  for (const fixture of observationFixtures) {
+    it(`round-trips ${fixture.name}`, async () => {
+      const signed = await buildRevocationObservation({ ...fixture.observation }, signer)
+      const verdict = verifyRevocationObservation(signed)
+      assert.equal(verdict.valid, true, verdict.reason)
+      // signed record carries the F4 fields unchanged
+      assert.equal(signed.authority_ref, fixture.observation.authority_ref)
+      assert.deepEqual(signed.status_source, fixture.observation.status_source)
+      assert.deepEqual(signed.decision, fixture.observation.decision)
+      // and no derived label anywhere in the signed bytes
+      assert.ok(!('label' in signed))
+    })
+  }
+
+  it('rejects a tampered decision (signature covers the record)', async () => {
+    const fixture = observationFixtures.find(f => f.label === 'stale_denied')!
+    const signed = await buildRevocationObservation({ ...fixture.observation }, signer)
+    const tampered: SignedRevocationObservation = {
+      ...signed,
+      decision: { effect: 'allow' },
+    }
+    assert.equal(verifyRevocationObservation(tampered).valid, false)
+  })
+
+  it('rejects a wrong pinned observer key', async () => {
+    const fixture = observationFixtures.find(f => f.label === 'fresh_valid')!
+    const signed = await buildRevocationObservation({ ...fixture.observation }, signer)
+    const other = generateKeyPair()
+    const verdict = verifyRevocationObservation(signed, { expectedObserverKey: other.publicKey })
+    assert.equal(verdict.valid, false)
+  })
+})
+
+describe('T7 RevocationObservation: SET ingestion', () => {
+  const keys = generateKeyPair()
+  const signer = createLocalSigner({ privateKeyHex: keys.privateKey })
+
+  it('converts event_timestamp epoch seconds to ISO 8601 and wires {kind:set, jti}', async () => {
+    const revokedAt = new Date('2026-07-10T11:59:30.000Z')
+    const set = buildRevocationSET({
+      issuer: 'https://issuer.example',
+      subject_id: 'dlg_t7_set_01',
+      revokedAt,
+      issuedAt: new Date('2026-07-10T12:00:00.000Z'),
+      jti: 'set_jti_ingest_01',
+    })
+    assert.ok(isWellFormedSET(set))
+    const params = observationParamsFromSET(set, {
+      decision: { effect: 'deny' },
+      maximum_staleness_ms: 60_000,
+      observed_at: new Date('2026-07-10T12:00:05.000Z'),
+    })
+    assert.equal(params.authority_ref, 'dlg_t7_set_01')
+    assert.deepEqual(params.status_source, { kind: 'set', jti: 'set_jti_ingest_01' })
+    // epoch seconds floor(revokedAt) converted back to ISO 8601
+    assert.equal(params.revoked_at, '2026-07-10T11:59:30.000Z')
+
+    const signed = await buildRevocationObservation(params, signer)
+    assert.equal(verifyRevocationObservation(signed).valid, true)
+    assert.equal(classifyObservation(signed), 'revoked_blocked')
+  })
+
+  it('refuses a claim set without the CAEP event', () => {
+    assert.throws(() => observationParamsFromSET(
+      { iss: 'x', iat: 1, jti: 'j', events: {} } as never,
+      { decision: { effect: 'deny' }, maximum_staleness_ms: 1000 },
+    ), /no well-formed CAEP/)
+  })
+})


### PR DESCRIPTION
Verifier-side observation record: which revocation signal was observed, from which source (direct consult or received RFC 8417 SET), for which authority, covering which scope, and what the relying party did under its stated freshness contract.

- types: RevocationObservation with the F4 fields exactly (authority_ref, status_source union {kind:'source',id}|{kind:'set',jti}, revoked_at?, observed_at, maximum_staleness_ms, affected_scope?, decision reusing the FreshnessDecision effect+downgraded vocabulary, workflow_response?); SignedRevocationObservation adds observer_key/observer_key_id/signature
- buildRevocationObservation signs via the SDK Signer interface (local or remote custody) over canonicalize(record minus signature), binding the observer key material inside the signed bytes
- verifyRevocationObservation: structural checks plus Ed25519 verification, optional pinned observer key
- classifyObservation derives the seven outcome labels, never stored; where no revocation was observed the caller supplies the recorded freshness result as classification context, since the frozen record shape cannot distinguish fresh from stale from unavailable (flagged in HANDOFF-T7)
- observationParamsFromSET converts CAEP event_timestamp epoch seconds to ISO 8601 and wires status_source {kind:'set', jti}; SET aud documented as RFC 8417 audience, distinct from APS AudienceBinding
- fixtures: seven, one per label, including unavailable fail-open and fail-closed; tests assert classification plus a sign-and-verify round trip for each, plus tamper and wrong-key rejections

Doc language uses the freshness-contract framing throughout and never claims instant or universal revocation. src/index.ts and types/policy.ts untouched.

## Summary

<!-- Describe what this PR changes. -->

## Checklist

- [ ] **Signed-off-by (DCO) — required.** Every commit in this PR is signed off (`git commit -s`) per the [Developer Certificate of Origin](https://developercertificate.org/).
