### PR TITLE
feat(evidence-bundle): F5 bundle primitives, claim-boundary report, C…

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,12 @@ import {
   RegulatedActionV0
 } from '../index.js'
 
+// Direct module import: src/index.ts export lines are a single-writer
+// item deferred to T9 (FREEZE-VWE F8), so verify-bundle does not go
+// through the barrel.
+import { verifyEvidenceBundle, computeClaimBoundaryReport } from '../core/evidence-bundle.js'
+import type { EvidenceBundle, ClaimState } from '../types/evidence-bundle.js'
+
 import type {
   SignedPassport, FloorAttestation,
   ActionReceipt, Delegation, KeyPair,
@@ -136,6 +142,7 @@ switch (command) {
   case 'status': cmdStatus(); break
   case 'agora': cmdAgora(); break
   case 'verify-regulated': cmdVerifyRegulated(); break
+  case 'verify-bundle': cmdVerifyBundle(); break
   default: cmdHelp(); break
 }
 
@@ -170,6 +177,120 @@ function cmdVerifyRegulated(): void {
   console.log(JSON.stringify(result, null, 2))
   const final = result.disposition === 'reconciled' || result.disposition === 'regulator_grade_for_class'
   process.exit(final ? 0 : 2)
+}
+
+// ══════════════════════════════════════
+// VERIFY-BUNDLE: evidence bundle claim-boundary report
+// ══════════════════════════════════════
+//
+//   agent-passport verify-bundle <bundle.json> [--json] [--strict]
+//
+// Verifies an aps:evidence-bundle:v1 file (manifest signature, Merkle
+// root, member digests, inclusion proofs) and prints a per-axis
+// ClaimState report over authority, action, revocation and evidence,
+// per the SCHEMAS-DRAFT 3d mapping. States are computed from the
+// members present; what cannot be computed is reported MISSING or
+// UNKNOWN, never assumed.
+
+const VERIFY_BUNDLE_USAGE = `Usage: passport verify-bundle <bundle.json> [--json] [--strict]
+
+  Verifies an evidence bundle (aps:evidence-bundle:v1) and prints a
+  per-axis claim report: authority, action, revocation, evidence.
+
+  --json     Emit one JSON object: {axes, overall, exit_reason}
+  --strict   Treat MISSING authority or evidence as failure (exit 2)
+
+  Exit codes: 0 report produced, no axis INVALID
+              2 any axis INVALID, or --strict with MISSING
+                authority or evidence
+              3 bundle unreadable or manifest signature failed`
+
+function emitBundleReport(
+  jsonMode: boolean,
+  axes: Record<'authority' | 'action' | 'revocation' | 'evidence', { state: ClaimState, detail: string }>,
+  overall: ClaimState,
+  exitReason: string,
+): void {
+  if (jsonMode) {
+    console.log(JSON.stringify({
+      axes: {
+        authority: axes.authority.state,
+        action: axes.action.state,
+        revocation: axes.revocation.state,
+        evidence: axes.evidence.state,
+      },
+      overall,
+      exit_reason: exitReason,
+    }, null, 2))
+    return
+  }
+  console.log('')
+  console.log('📦 Evidence Bundle Claim Report')
+  for (const axis of ['authority', 'action', 'revocation', 'evidence'] as const) {
+    console.log(`  ${axis.padEnd(11)} ${axes[axis].state}`)
+    console.log(`     ${axes[axis].detail}`)
+  }
+  console.log(`  Overall: ${overall}`)
+  console.log('')
+}
+
+function cmdVerifyBundle(): void {
+  const file = args[1]
+  const jsonMode = args.includes('--json')
+  const strict = args.includes('--strict')
+  if (!file || file.startsWith('--')) {
+    console.error(VERIFY_BUNDLE_USAGE)
+    process.exit(1)
+  }
+
+  const unknownAxes = {
+    authority: { state: 'UNKNOWN' as ClaimState, detail: 'not computed' },
+    action: { state: 'UNKNOWN' as ClaimState, detail: 'not computed' },
+    revocation: { state: 'UNKNOWN' as ClaimState, detail: 'not computed' },
+    evidence: { state: 'UNKNOWN' as ClaimState, detail: 'not computed' },
+  }
+
+  let bundle: EvidenceBundle
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, 'utf8'))
+    if (typeof parsed !== 'object' || parsed === null
+      || typeof (parsed as EvidenceBundle).signer_public_key !== 'string'
+      || typeof (parsed as EvidenceBundle).manifest !== 'object'
+      || !Array.isArray((parsed as EvidenceBundle).members)) {
+      throw new Error('file is not structurally an evidence bundle (manifest, members, signer_public_key)')
+    }
+    bundle = parsed as EvidenceBundle
+  } catch (e) {
+    console.error(`❌ Bundle unreadable: ${e instanceof Error ? e.message : String(e)}`)
+    emitBundleReport(jsonMode, unknownAxes, 'UNKNOWN', 'bundle_unreadable')
+    process.exit(3)
+  }
+
+  const verification = verifyEvidenceBundle(bundle)
+  if (!verification.signatureValid) {
+    // An unauthenticated manifest cannot support axis claims, so no
+    // axis state is computed from it.
+    console.error('❌ Manifest signature failed under the stated signer_public_key')
+    emitBundleReport(jsonMode, unknownAxes, 'UNKNOWN', 'manifest_signature_failed')
+    process.exit(3)
+  }
+
+  const report = computeClaimBoundaryReport(bundle, { verification })
+  const states = [
+    report.axes.authority.state, report.axes.action.state,
+    report.axes.revocation.state, report.axes.evidence.state,
+  ]
+  let exitCode = 0
+  let exitReason = 'ok'
+  if (states.includes('INVALID')) {
+    exitCode = 2
+    exitReason = 'axis_invalid'
+  } else if (strict && (report.axes.authority.state === 'MISSING' || report.axes.evidence.state === 'MISSING')) {
+    exitCode = 2
+    exitReason = 'strict_missing'
+  }
+  emitBundleReport(jsonMode, report.axes, report.overall, exitReason)
+  process.exit(exitCode)
 }
 
 // ══════════════════════════════════════
@@ -741,6 +862,17 @@ function cmdInspect(): void {
     console.log(`  Owner:   ${p.ownerAlias}`)
     console.log(`  Caps:    ${p.capabilities.join(', ')}`)
     console.log(`  Expires: ${p.expiresAt}`)
+  } else if (data.requestingAgentId && data.servingAgentId) {
+    // BilateralReceipt also carries receiptId, so this check must run
+    // before the Action Receipt branch below.
+    console.log('📋 Bilateral Receipt')
+    console.log(`  ID:      ${data.receiptId}`)
+    console.log(`  Requesting: ${data.requestingAgentId}`)
+    console.log(`  Serving:    ${data.servingAgentId}`)
+    console.log(`  Tool:    ${data.outcome?.toolName}`)
+    console.log(`  Status:  ${data.outcome?.status}`)
+    console.log(`  Agreed:  ${data.agreedAt}`)
+    console.log(`  Gateway: ${data.gatewaySignature ? 'countersigned' : 'not countersigned'}`)
   } else if (data.receiptId) {
     console.log('📋 Action Receipt')
     console.log(`  ID:      ${data.receiptId}`)

--- a/src/core/evidence-bundle.ts
+++ b/src/core/evidence-bundle.ts
@@ -1,0 +1,430 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// ══════════════════════════════════════════════════════════════════
+// Evidence Bundle (FREEZE-VWE F5) + Claim-Boundary Report (F6)
+// ══════════════════════════════════════════════════════════════════
+// A bundle is a signed, Merkle-committed evidence set. It reuses the
+// receipt-ledger Merkle surface (buildMerkleRoot, proveInclusion,
+// verifyInclusion) and the verifyBatch signable-subset signature
+// pattern. It is NOT a ledger batch: commitBatch is never called and
+// the epoch/previousBatchId sequencing fields do not exist on bundles.
+//
+// The claim-boundary report reads members STRUCTURALLY by member_type
+// (F7): nothing here imports types from parallel task branches. The
+// per-axis ClaimState mapping follows SCHEMAS-DRAFT 3d. States are
+// computed from what the members allow; anything not computable is
+// reported MISSING or UNKNOWN, never assumed.
+
+import { createHash } from 'node:crypto'
+import { sign, verify } from '../crypto/keys.js'
+import { canonicalize } from './canonical.js'
+import { buildMerkleRoot } from './attribution.js'
+import { proveInclusion, verifyInclusion } from './receipt-ledger.js'
+import type { ReceiptBatch, ReceiptInclusionProof } from './receipt-ledger.js'
+import { verifyPassport } from '../verification/verify.js'
+import { actionRefsMatch } from './action-ref.js'
+import type { SignedPassport } from '../types/passport.js'
+import type {
+  EvidenceBundle,
+  EvidenceBundleManifest,
+  EvidenceBundleMember,
+  EvidenceBundleMemberType,
+  EvidenceBundleMemberVerification,
+  EvidenceBundleVerification,
+  ClaimAxisReport,
+  ClaimBoundaryReport,
+  ClaimState,
+} from '../types/evidence-bundle.js'
+
+// ══════════════════════════════════════
+// DIGEST
+// ══════════════════════════════════════
+
+/**
+ * Digest of one member payload: lowercase hex SHA-256 of
+ * canonicalize(payload). This is the leaf value committed in the
+ * manifest and in the Merkle root.
+ */
+export function computeMemberDigest(payload: unknown): string {
+  return createHash('sha256').update(canonicalize(payload)).digest('hex')
+}
+
+// ══════════════════════════════════════
+// CREATE
+// ══════════════════════════════════════
+
+export interface CreateEvidenceBundleOptions {
+  /** Member payloads to commit. member_id values must be unique. */
+  members: EvidenceBundleMember[]
+  /** Ed25519 private key (hex) that signs the manifest. */
+  signerPrivateKey: string
+  /** Ed25519 public key (hex) carried on the bundle for verification. */
+  signerPublicKey: string
+  /** ISO 8601 creation time. Defaults to now. */
+  createdAt?: string
+}
+
+/**
+ * Assemble and sign an evidence bundle per FREEZE-VWE F5.
+ * Invariants: at least one member; unique member_id values; manifest
+ * digests are canonicalize-then-sha256 of each payload; merkle_root is
+ * buildMerkleRoot over the digests; signature covers
+ * canonicalize(manifest minus signature). commitBatch is never
+ * involved and no ledger-sequencing field is emitted.
+ */
+export function createEvidenceBundle(opts: CreateEvidenceBundleOptions): EvidenceBundle {
+  if (opts.members.length === 0) {
+    throw new Error('createEvidenceBundle: at least one member is required')
+  }
+  const seen = new Set<string>()
+  for (const m of opts.members) {
+    if (seen.has(m.member_id)) {
+      throw new Error(`createEvidenceBundle: duplicate member_id "${m.member_id}"`)
+    }
+    seen.add(m.member_id)
+  }
+
+  const manifestMembers = opts.members.map(m => ({
+    member_id: m.member_id,
+    member_type: m.member_type,
+    digest: computeMemberDigest(m.payload),
+  }))
+
+  const signable = {
+    profile: 'aps:evidence-bundle:v1' as const,
+    created_at: opts.createdAt ?? new Date().toISOString(),
+    members: manifestMembers,
+    merkle_root: buildMerkleRoot(manifestMembers.map(m => m.digest)),
+  }
+  const signature = sign(canonicalize(signable), opts.signerPrivateKey)
+
+  return {
+    manifest: { ...signable, signature },
+    signer_public_key: opts.signerPublicKey,
+    members: opts.members.map(m => ({ ...m })),
+  }
+}
+
+// ══════════════════════════════════════
+// INCLUSION (via the receipt-ledger primitives)
+// ══════════════════════════════════════
+
+// proveInclusion reads only batchId, merkleRoot and receiptHashes. The
+// remaining ReceiptBatch fields are inert placeholders needed to
+// satisfy the parameter type; none of them enters the bundle wire
+// format (F5 forbids the ledger-sequencing fields on bundles).
+function manifestAsBatchView(manifest: EvidenceBundleManifest): ReceiptBatch {
+  return {
+    batchId: `evidence-bundle:${manifest.merkle_root}`,
+    merkleRoot: manifest.merkle_root,
+    receiptCount: manifest.members.length,
+    receiptHashes: manifest.members.map(m => m.digest),
+    epoch: 0,
+    previousBatchId: null,
+    previousMerkleRoot: null,
+    committedAt: manifest.created_at,
+    committedBy: '',
+    signature: '',
+  }
+}
+
+/**
+ * Merkle inclusion proof for one member digest against the bundle
+ * root, produced by the receipt-ledger proveInclusion primitive.
+ */
+export function proveMemberInclusion(
+  manifest: EvidenceBundleManifest,
+  memberId: string,
+): ReceiptInclusionProof {
+  const entry = manifest.members.find(m => m.member_id === memberId)
+  if (!entry) {
+    throw new Error(`proveMemberInclusion: unknown member_id "${memberId}"`)
+  }
+  return proveInclusion(manifestAsBatchView(manifest), entry.digest)
+}
+
+/**
+ * Verify a member inclusion proof. Thin passthrough to the
+ * receipt-ledger verifyInclusion primitive, exported so bundle
+ * consumers never need to import the ledger module.
+ */
+export function verifyMemberInclusion(proof: ReceiptInclusionProof): boolean {
+  return verifyInclusion(proof)
+}
+
+// ══════════════════════════════════════
+// VERIFY
+// ══════════════════════════════════════
+
+/**
+ * Verify an evidence bundle end to end: manifest signature over the
+ * signable subset, Merkle root over the manifest digests, per-member
+ * payload digest against the manifest, and per-member inclusion via
+ * proveInclusion/verifyInclusion. Single-member manifests skip the
+ * inclusion-proof check (the digest IS the root and generateMerkleProof
+ * has no sibling path to build); the digest and root checks still bind
+ * the member. valid is true only when every check passes.
+ */
+export function verifyEvidenceBundle(bundle: EvidenceBundle): EvidenceBundleVerification {
+  const errors: string[] = []
+  const manifest = bundle.manifest
+
+  if (manifest.profile !== 'aps:evidence-bundle:v1') {
+    errors.push(`Unknown profile "${String(manifest.profile)}"`)
+  }
+
+  const signable = {
+    profile: manifest.profile,
+    created_at: manifest.created_at,
+    members: manifest.members,
+    merkle_root: manifest.merkle_root,
+  }
+  let signatureValid = false
+  try {
+    signatureValid = verify(canonicalize(signable), manifest.signature, bundle.signer_public_key)
+  } catch {
+    signatureValid = false
+  }
+  if (!signatureValid) errors.push('Invalid manifest signature')
+
+  const rootValid = buildMerkleRoot(manifest.members.map(m => m.digest)) === manifest.merkle_root
+  if (!rootValid) errors.push('Merkle root does not match manifest member digests')
+
+  const payloadsById = new Map(bundle.members.map(m => [m.member_id, m]))
+  if (bundle.members.length !== manifest.members.length) {
+    errors.push(`Member count mismatch: manifest has ${manifest.members.length}, bundle carries ${bundle.members.length}`)
+  }
+
+  const memberResults: EvidenceBundleMemberVerification[] = manifest.members.map(entry => {
+    const carried = payloadsById.get(entry.member_id)
+    if (!carried) {
+      errors.push(`Member "${entry.member_id}" is in the manifest but not carried in the bundle`)
+      return { member_id: entry.member_id, digestValid: false, inclusionValid: false }
+    }
+    const digestValid = computeMemberDigest(carried.payload) === entry.digest
+    if (!digestValid) {
+      errors.push(`Member "${entry.member_id}" payload digest does not match the manifest`)
+    }
+    const inclusionValid = manifest.members.length === 1
+      ? rootValid && entry.digest === manifest.merkle_root
+      : verifyMemberInclusion(proveMemberInclusion(manifest, entry.member_id))
+    if (!inclusionValid) {
+      errors.push(`Member "${entry.member_id}" inclusion proof failed against the bundle root`)
+    }
+    return { member_id: entry.member_id, digestValid, inclusionValid }
+  })
+
+  return { valid: errors.length === 0, signatureValid, rootValid, memberResults, errors }
+}
+
+// ══════════════════════════════════════
+// CLAIM-BOUNDARY REPORT (F6, SCHEMAS-DRAFT 3d)
+// ══════════════════════════════════════
+
+// Worst state first. overall and multi-member axis folding take the
+// worst state present.
+const SEVERITY: ClaimState[] = [
+  'INVALID', 'STALE', 'MISSING', 'UNKNOWN', 'ASSERTED', 'EVALUATED', 'RESOLVED', 'VERIFIED',
+]
+
+function worstState(states: ClaimState[]): ClaimState {
+  let worst: ClaimState = 'VERIFIED'
+  for (const s of states) {
+    if (SEVERITY.indexOf(s) < SEVERITY.indexOf(worst)) worst = s
+  }
+  return worst
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+function membersOfType(bundle: EvidenceBundle, type: EvidenceBundleMemberType): EvidenceBundleMember[] {
+  return bundle.members.filter(m => m.member_type === type)
+}
+
+function looksLikeSignedPassport(payload: unknown): payload is SignedPassport {
+  return isRecord(payload) && isRecord(payload.passport) && typeof payload.signature === 'string'
+}
+
+// Authority axis (3d row 1). The CLI supplies no trustedIssuers, so
+// VERIFIED is unreachable here by design: a structurally valid,
+// signature-passing passport is the self-signed acceptance path and
+// reports ASSERTED.
+function authorityAxis(bundle: EvidenceBundle): ClaimAxisReport {
+  const passports = membersOfType(bundle, 'passport')
+  const delegations = membersOfType(bundle, 'delegation')
+  if (passports.length === 0 && delegations.length === 0) {
+    return { state: 'MISSING', detail: 'no passport or delegation member in the bundle' }
+  }
+
+  const outcomes: ClaimAxisReport[] = []
+  for (const member of passports) {
+    if (!looksLikeSignedPassport(member.payload)) {
+      outcomes.push({ state: 'UNKNOWN', detail: `member "${member.member_id}" is not structurally a signed passport` })
+      continue
+    }
+    const result = verifyPassport(member.payload)
+    if (result.valid) {
+      outcomes.push({ state: 'ASSERTED', detail: `member "${member.member_id}" signature passes; self-signed accepted, no trust anchors supplied` })
+      continue
+    }
+    const expiryOnly = result.errors.length > 0 && result.errors.every(e =>
+      e.startsWith('Passport expired') || e.startsWith('Passport not valid before'))
+    if (expiryOnly) {
+      outcomes.push({ state: 'STALE', detail: `member "${member.member_id}" signature passes but the passport is outside its validity window` })
+    } else {
+      outcomes.push({ state: 'INVALID', detail: `member "${member.member_id}" failed verification: ${result.errors.join('; ')}` })
+    }
+  }
+  for (const member of delegations) {
+    outcomes.push({ state: 'ASSERTED', detail: `delegation member "${member.member_id}" supplied; chain verification is not performed by verify-bundle` })
+  }
+  return foldAxis(outcomes)
+}
+
+// Action axis (3d row 2). Compares action_ref values found
+// structurally on bilateral_receipt and action_receipt members via
+// actionRefsMatch, and folds in any bilateral_pair_verdict members by
+// their status field.
+function actionAxis(bundle: EvidenceBundle): ClaimAxisReport {
+  const outcomes: ClaimAxisReport[] = []
+
+  for (const member of membersOfType(bundle, 'bilateral_pair_verdict')) {
+    const status = isRecord(member.payload) ? member.payload.status : undefined
+    if (status === 'reconciled') {
+      outcomes.push({ state: 'RESOLVED', detail: `pair verdict "${member.member_id}" reports reconciled` })
+    } else if (status === 'unilateral') {
+      outcomes.push({ state: 'ASSERTED', detail: `pair verdict "${member.member_id}" reports a unilateral claim, counterparty silent` })
+    } else if (status === 'mismatch') {
+      outcomes.push({ state: 'INVALID', detail: `pair verdict "${member.member_id}" reports a mismatch` })
+    } else {
+      outcomes.push({ state: 'UNKNOWN', detail: `pair verdict "${member.member_id}" has an unrecognized status` })
+    }
+  }
+
+  const refs: { memberId: string, ref: string }[] = []
+  for (const member of [...membersOfType(bundle, 'bilateral_receipt'), ...membersOfType(bundle, 'action_receipt')]) {
+    if (isRecord(member.payload) && typeof member.payload.action_ref === 'string' && member.payload.action_ref.length > 0) {
+      refs.push({ memberId: member.member_id, ref: member.payload.action_ref })
+    }
+  }
+  if (refs.length >= 2) {
+    const allMatch = refs.every(r => actionRefsMatch(r.ref, refs[0].ref))
+    outcomes.push(allMatch
+      ? { state: 'VERIFIED', detail: `${refs.length} members carry matching action_ref values` }
+      : { state: 'INVALID', detail: 'members carry conflicting action_ref values' })
+  } else if (refs.length === 1) {
+    outcomes.push({ state: 'UNKNOWN', detail: `only member "${refs[0].memberId}" carries an action_ref; no counterparty data to compare` })
+  }
+
+  if (outcomes.length === 0) {
+    return { state: 'MISSING', detail: 'no action_ref and no pair verdict present in the bundle' }
+  }
+  return foldAxis(outcomes)
+}
+
+// Revocation axis (3d row 3). Reads revocation_observation members
+// structurally per F4 field names. No observation means no revocation
+// check ran, which is reported MISSING, never assumed fresh.
+function revocationAxis(bundle: EvidenceBundle, now: Date): ClaimAxisReport {
+  const observations = membersOfType(bundle, 'revocation_observation')
+  if (observations.length === 0) {
+    return { state: 'MISSING', detail: 'no revocation_observation member; no revocation check ran' }
+  }
+
+  const outcomes: ClaimAxisReport[] = []
+  for (const member of observations) {
+    const p = member.payload
+    const wellFormed = isRecord(p)
+      && typeof p.authority_ref === 'string'
+      && isRecord(p.status_source) && (p.status_source.kind === 'source' || p.status_source.kind === 'set')
+      && typeof p.observed_at === 'string' && !Number.isNaN(Date.parse(p.observed_at))
+      && typeof p.maximum_staleness_ms === 'number'
+      && isRecord(p.decision) && (p.decision.effect === 'allow' || p.decision.effect === 'deny')
+    if (!wellFormed) {
+      outcomes.push({ state: 'INVALID', detail: `observation "${member.member_id}" is malformed against the F4 field set` })
+      continue
+    }
+    const workflow = isRecord(p.workflow_response) ? p.workflow_response : undefined
+    const workflowResult = workflow ? (workflow.result ?? workflow.status) : undefined
+    if (workflowResult === 'unavailable' || workflowResult === 'skipped') {
+      outcomes.push({ state: 'UNKNOWN', detail: `observation "${member.member_id}" reports the status source as ${String(workflowResult)}` })
+      continue
+    }
+    const decision = p.decision as Record<string, unknown>
+    if (decision.effect === 'deny') {
+      outcomes.push({ state: 'RESOLVED', detail: `observation "${member.member_id}" shows revocation observed and enforced (deny)` })
+      continue
+    }
+    if (decision.downgraded === true) {
+      outcomes.push({ state: 'EVALUATED', detail: `observation "${member.member_id}" allowed on non-fresh input (downgraded)` })
+      continue
+    }
+    const freshUntil = Date.parse(p.observed_at as string) + (p.maximum_staleness_ms as number)
+    if (freshUntil >= now.getTime()) {
+      outcomes.push({ state: 'VERIFIED', detail: `observation "${member.member_id}" is fresh and shows not revoked` })
+    } else {
+      outcomes.push({ state: 'STALE', detail: `observation "${member.member_id}" exceeded maximum_staleness_ms at verification time` })
+    }
+  }
+  return foldAxis(outcomes)
+}
+
+// Evidence axis (3d row 4). EVALUATED is the ceiling here: the bundle
+// root is recomputed and member digests are checked, but external
+// credentials are never fetched by verify-bundle, so VERIFIED is
+// unreachable by design.
+function evidenceAxis(bundle: EvidenceBundle, verification: EvidenceBundleVerification): ClaimAxisReport {
+  if (bundle.manifest.members.length === 0) {
+    return { state: 'MISSING', detail: 'the bundle manifest has no members' }
+  }
+  const membersOk = verification.memberResults.length === bundle.manifest.members.length
+    && verification.memberResults.every(r => r.digestValid && r.inclusionValid)
+  if (!verification.rootValid || !membersOk) {
+    const bad = verification.memberResults.filter(r => !r.digestValid || !r.inclusionValid).map(r => r.member_id)
+    return {
+      state: 'INVALID',
+      detail: bad.length > 0
+        ? `member digest or inclusion check failed for: ${bad.join(', ')}`
+        : 'bundle Merkle root does not match the manifest member digests',
+    }
+  }
+  return { state: 'EVALUATED', detail: 'bundle root recomputed and matches; all member digests match the manifest' }
+}
+
+function foldAxis(outcomes: ClaimAxisReport[]): ClaimAxisReport {
+  const worst = worstState(outcomes.map(o => o.state))
+  const first = outcomes.find(o => o.state === worst)
+  return first ?? { state: 'UNKNOWN', detail: 'no outcome computed' }
+}
+
+export interface ClaimBoundaryReportOptions {
+  /** Verification clock for revocation staleness. Defaults to now. */
+  now?: Date
+  /** Reuse an existing verifyEvidenceBundle result instead of recomputing. */
+  verification?: EvidenceBundleVerification
+}
+
+/**
+ * Compute the per-axis claim-boundary report for a bundle per the
+ * SCHEMAS-DRAFT 3d mapping. Report-local vocabulary only (F6): the
+ * result is never embedded in a signed artifact. Members are read
+ * structurally by member_type (F7). Axes that cannot be computed from
+ * the members present report MISSING or UNKNOWN.
+ */
+export function computeClaimBoundaryReport(
+  bundle: EvidenceBundle,
+  opts?: ClaimBoundaryReportOptions,
+): ClaimBoundaryReport {
+  const now = opts?.now ?? new Date()
+  const verification = opts?.verification ?? verifyEvidenceBundle(bundle)
+  const axes = {
+    authority: authorityAxis(bundle),
+    action: actionAxis(bundle),
+    revocation: revocationAxis(bundle, now),
+    evidence: evidenceAxis(bundle, verification),
+  }
+  const overall = worstState([axes.authority.state, axes.action.state, axes.revocation.state, axes.evidence.state])
+  return { axes, overall }
+}

--- a/src/types/evidence-bundle.ts
+++ b/src/types/evidence-bundle.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// ══════════════════════════════════════════════════════════════════
+// Evidence Bundle - Type Definitions (FREEZE-VWE F5, F6, F7)
+// ══════════════════════════════════════════════════════════════════
+// A signed, Merkle-committed collection of protocol artifacts assembled
+// as verification evidence. The manifest commits to each member by
+// content digest; the bundle carries the member payloads alongside.
+//
+// Bundles are NOT ledger batches: there is no epoch chain and no
+// previousBatchId. A bundle is a standalone evidence set (F5).
+// Members are read structurally by member_type; T8 imports no types
+// from parallel branches (F7). T9 unifies to real types after merge.
+
+/**
+ * Structural member discriminator per FREEZE-VWE F7. Verification code
+ * keys on this string, never on imported types from parallel branches.
+ */
+export type EvidenceBundleMemberType =
+  | 'bilateral_receipt'
+  | 'bilateral_pair_verdict'
+  | 'revocation_observation'
+  | 'passport'
+  | 'delegation'
+  | 'action_receipt'
+  | 'other'
+
+/**
+ * One manifest entry. digest is the lowercase hex SHA-256 of
+ * canonicalize(payload) of the corresponding bundle member.
+ * Invariant: member_id is unique within a manifest.
+ */
+export interface EvidenceBundleManifestMember {
+  member_id: string
+  member_type: EvidenceBundleMemberType
+  digest: string
+}
+
+/**
+ * Signed bundle manifest per FREEZE-VWE F5. Field set is frozen:
+ * profile, created_at, members, merkle_root, signature. merkle_root is
+ * buildMerkleRoot over the member digests. signature is Ed25519 over
+ * canonicalize(manifest minus signature), the verifyBatch
+ * signable-subset pattern. No epoch, no previousBatchId (forbidden).
+ */
+export interface EvidenceBundleManifest {
+  profile: 'aps:evidence-bundle:v1'
+  created_at: string
+  members: EvidenceBundleManifestMember[]
+  merkle_root: string
+  signature: string
+}
+
+/**
+ * One carried member payload. payload is unknown by design: bundle
+ * members are foreign artifacts read structurally (F7), so no member
+ * type from another module is imported here.
+ */
+export interface EvidenceBundleMember {
+  member_id: string
+  member_type: EvidenceBundleMemberType
+  payload: unknown
+}
+
+/**
+ * The bundle file shape: manifest plus member payloads plus the
+ * signer's public key. signer_public_key sits OUTSIDE the signed
+ * subset (the F5 manifest field set is frozen), so the signature
+ * proves integrity under the stated key, not who the signer is.
+ * Binding the key to an expected signer is the caller's trust
+ * decision, exactly as with ReceiptBatch.committedBy.
+ */
+export interface EvidenceBundle {
+  manifest: EvidenceBundleManifest
+  signer_public_key: string
+  members: EvidenceBundleMember[]
+}
+
+/** Per-member outcome inside a bundle verification. */
+export interface EvidenceBundleMemberVerification {
+  member_id: string
+  /** Recomputed payload digest equals the manifest digest. */
+  digestValid: boolean
+  /** Merkle inclusion proof for the manifest digest verifies against merkle_root. */
+  inclusionValid: boolean
+}
+
+/** Result of verifyEvidenceBundle. valid is true only when every check passed. */
+export interface EvidenceBundleVerification {
+  valid: boolean
+  signatureValid: boolean
+  rootValid: boolean
+  memberResults: EvidenceBundleMemberVerification[]
+  errors: string[]
+}
+
+/**
+ * Verifier-report vocabulary per FREEZE-VWE F6. Report-local only:
+ * this enum never appears inside a signed artifact. The per-axis
+ * mapping in SCHEMAS-DRAFT 3d is normative for how CLI verify-bundle
+ * assigns these states.
+ */
+export type ClaimState =
+  | 'VERIFIED'
+  | 'EVALUATED'
+  | 'RESOLVED'
+  | 'ASSERTED'
+  | 'STALE'
+  | 'UNKNOWN'
+  | 'MISSING'
+  | 'INVALID'
+
+/** The four report axes of the claim-boundary report. */
+export type ClaimAxis = 'authority' | 'action' | 'revocation' | 'evidence'
+
+/** One axis outcome: the state plus a one-line human-readable reason. */
+export interface ClaimAxisReport {
+  state: ClaimState
+  detail: string
+}
+
+/**
+ * Full claim-boundary report over a bundle. overall is the worst axis
+ * state by severity (INVALID worst, VERIFIED best). Severity order:
+ * INVALID, STALE, MISSING, UNKNOWN, ASSERTED, EVALUATED, RESOLVED,
+ * VERIFIED.
+ */
+export interface ClaimBoundaryReport {
+  axes: {
+    authority: ClaimAxisReport
+    action: ClaimAxisReport
+    revocation: ClaimAxisReport
+    evidence: ClaimAxisReport
+  }
+  overall: ClaimState
+}

--- a/tests/evidence-bundle.test.ts
+++ b/tests/evidence-bundle.test.ts
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// Evidence bundle (F5) + claim-boundary report (F6, SCHEMAS-DRAFT 3d)
+// + CLI verify-bundle exit codes and JSON shape.
+//
+// NOTE (F8): registering this file in the package.json test script is
+// a single-writer T9 item. Until then run it directly:
+//   npx tsx --test tests/evidence-bundle.test.ts
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { generateKeyPair } from '../src/crypto/keys.js'
+import { createPassport } from '../src/core/passport.js'
+import {
+  createEvidenceBundle, verifyEvidenceBundle,
+  proveMemberInclusion, verifyMemberInclusion,
+  computeClaimBoundaryReport, computeMemberDigest,
+} from '../src/core/evidence-bundle.js'
+import type { EvidenceBundle, EvidenceBundleMember } from '../src/types/evidence-bundle.js'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const FIXTURES = join(ROOT, 'tests', 'fixtures', 'evidence-bundle')
+const NOW = new Date('2026-07-10T12:00:00Z')
+
+const signer = generateKeyPair()
+
+function makeBundle(members: EvidenceBundleMember[]): EvidenceBundle {
+  return createEvidenceBundle({
+    members,
+    signerPrivateKey: signer.privateKey,
+    signerPublicKey: signer.publicKey,
+    createdAt: '2026-07-10T00:00:00Z',
+  })
+}
+
+function runCli(cliArgs: string[]): { status: number | null, stdout: string, stderr: string } {
+  const res = spawnSync('npx', ['tsx', join('src', 'cli', 'index.ts'), 'verify-bundle', ...cliArgs], {
+    cwd: ROOT, encoding: 'utf8',
+  })
+  return { status: res.status, stdout: res.stdout, stderr: res.stderr }
+}
+
+// ── Bundle create + verify ──
+
+test('createEvidenceBundle: manifest carries the frozen F5 field set and nothing else', () => {
+  const bundle = makeBundle([{ member_id: 'a', member_type: 'other', payload: { x: 1 } }])
+  assert.deepStrictEqual(
+    Object.keys(bundle.manifest).sort(),
+    ['created_at', 'members', 'merkle_root', 'profile', 'signature'],
+  )
+  assert.strictEqual(bundle.manifest.profile, 'aps:evidence-bundle:v1')
+})
+
+test('verifyEvidenceBundle: roundtrip on a multi-member bundle passes every check', () => {
+  const bundle = makeBundle([
+    { member_id: 'a', member_type: 'other', payload: { x: 1 } },
+    { member_id: 'b', member_type: 'other', payload: { y: [1, 2, 3] } },
+    { member_id: 'c', member_type: 'other', payload: 'plain string payload' },
+  ])
+  const v = verifyEvidenceBundle(bundle)
+  assert.strictEqual(v.valid, true, v.errors.join('; '))
+  assert.strictEqual(v.signatureValid, true)
+  assert.strictEqual(v.rootValid, true)
+  assert.ok(v.memberResults.every(r => r.digestValid && r.inclusionValid))
+})
+
+test('verifyEvidenceBundle: single-member bundle verifies (digest is the root)', () => {
+  const bundle = makeBundle([{ member_id: 'only', member_type: 'other', payload: { z: true } }])
+  assert.strictEqual(bundle.manifest.merkle_root, computeMemberDigest({ z: true }))
+  const v = verifyEvidenceBundle(bundle)
+  assert.strictEqual(v.valid, true, v.errors.join('; '))
+})
+
+test('verifyEvidenceBundle: tampered member payload fails its digest, root and signature stay valid', () => {
+  const bundle = makeBundle([
+    { member_id: 'a', member_type: 'other', payload: { x: 1 } },
+    { member_id: 'b', member_type: 'other', payload: { y: 2 } },
+  ])
+  ;(bundle.members[1].payload as { y: number }).y = 999
+  const v = verifyEvidenceBundle(bundle)
+  assert.strictEqual(v.valid, false)
+  assert.strictEqual(v.signatureValid, true)
+  assert.strictEqual(v.rootValid, true)
+  assert.strictEqual(v.memberResults.find(r => r.member_id === 'b')?.digestValid, false)
+  assert.strictEqual(v.memberResults.find(r => r.member_id === 'a')?.digestValid, true)
+})
+
+test('verifyEvidenceBundle: tampered manifest field fails the signature', () => {
+  const bundle = makeBundle([{ member_id: 'a', member_type: 'other', payload: { x: 1 } }])
+  bundle.manifest.created_at = '2027-01-01T00:00:00Z'
+  const v = verifyEvidenceBundle(bundle)
+  assert.strictEqual(v.signatureValid, false)
+  assert.strictEqual(v.valid, false)
+})
+
+test('inclusion proofs via the receipt-ledger primitives verify per member', () => {
+  const bundle = makeBundle([
+    { member_id: 'a', member_type: 'other', payload: { x: 1 } },
+    { member_id: 'b', member_type: 'other', payload: { y: 2 } },
+    { member_id: 'c', member_type: 'other', payload: { z: 3 } },
+  ])
+  for (const id of ['a', 'b', 'c']) {
+    const proof = proveMemberInclusion(bundle.manifest, id)
+    assert.strictEqual(verifyMemberInclusion(proof), true, `inclusion failed for ${id}`)
+    assert.strictEqual(proof.merkleRoot, bundle.manifest.merkle_root)
+  }
+  assert.throws(() => proveMemberInclusion(bundle.manifest, 'nope'), /unknown member_id/)
+})
+
+// ── Claim-boundary report: axis mapping (SCHEMAS-DRAFT 3d) ──
+
+test('empty axes report MISSING: no authority member, no action data, no revocation observation', () => {
+  const bundle = makeBundle([{ member_id: 'n', member_type: 'other', payload: { note: 'x' } }])
+  const report = computeClaimBoundaryReport(bundle, { now: NOW })
+  assert.strictEqual(report.axes.authority.state, 'MISSING')
+  assert.strictEqual(report.axes.action.state, 'MISSING')
+  assert.strictEqual(report.axes.revocation.state, 'MISSING')
+  assert.strictEqual(report.axes.evidence.state, 'EVALUATED')
+})
+
+test('authority: valid self-signed passport reports ASSERTED, garbage passport member reports UNKNOWN', () => {
+  const { signedPassport } = createPassport({
+    agentId: 't', agentName: 't', ownerAlias: 't', mission: 't',
+    capabilities: ['code_execution'], runtime: { platform: 'node', models: ['x'] },
+    validityWindow: { notAfter: '2036-01-01T00:00:00.000Z' },
+  })
+  const asserted = computeClaimBoundaryReport(
+    makeBundle([{ member_id: 'p', member_type: 'passport', payload: signedPassport }]), { now: NOW })
+  assert.strictEqual(asserted.axes.authority.state, 'ASSERTED')
+
+  const unknown = computeClaimBoundaryReport(
+    makeBundle([{ member_id: 'p', member_type: 'passport', payload: { not: 'a passport' } }]), { now: NOW })
+  assert.strictEqual(unknown.axes.authority.state, 'UNKNOWN')
+})
+
+test('authority: passport with a broken signature reports INVALID', () => {
+  const { signedPassport } = createPassport({
+    agentId: 't', agentName: 't', ownerAlias: 't', mission: 't',
+    capabilities: ['code_execution'], runtime: { platform: 'node', models: ['x'] },
+    validityWindow: { notAfter: '2036-01-01T00:00:00.000Z' },
+  })
+  const broken = { ...signedPassport, signature: 'f'.repeat(128) }
+  const report = computeClaimBoundaryReport(
+    makeBundle([{ member_id: 'p', member_type: 'passport', payload: broken }]), { now: NOW })
+  assert.strictEqual(report.axes.authority.state, 'INVALID')
+})
+
+test('action: matching refs VERIFIED, conflicting refs INVALID, lone ref UNKNOWN', () => {
+  const receipt = (id: string, ref: string) => ({
+    member_id: id, member_type: 'bilateral_receipt' as const,
+    payload: { receiptId: id, requestingAgentId: 'a', servingAgentId: 'b', action_ref: ref },
+  })
+  const match = computeClaimBoundaryReport(makeBundle([receipt('r1', 'a'.repeat(64)), receipt('r2', 'a'.repeat(64))]), { now: NOW })
+  assert.strictEqual(match.axes.action.state, 'VERIFIED')
+  const clash = computeClaimBoundaryReport(makeBundle([receipt('r1', 'a'.repeat(64)), receipt('r2', 'b'.repeat(64))]), { now: NOW })
+  assert.strictEqual(clash.axes.action.state, 'INVALID')
+  const lone = computeClaimBoundaryReport(makeBundle([receipt('r1', 'a'.repeat(64))]), { now: NOW })
+  assert.strictEqual(lone.axes.action.state, 'UNKNOWN')
+})
+
+test('action: pair verdict statuses map to RESOLVED / ASSERTED / INVALID', () => {
+  const verdict = (status: string) => makeBundle([
+    { member_id: 'v', member_type: 'bilateral_pair_verdict', payload: { status } },
+  ])
+  assert.strictEqual(computeClaimBoundaryReport(verdict('reconciled'), { now: NOW }).axes.action.state, 'RESOLVED')
+  assert.strictEqual(computeClaimBoundaryReport(verdict('unilateral'), { now: NOW }).axes.action.state, 'ASSERTED')
+  assert.strictEqual(computeClaimBoundaryReport(verdict('mismatch'), { now: NOW }).axes.action.state, 'INVALID')
+})
+
+test('revocation: observation states map per the 3d row, nothing is hardcoded', () => {
+  const obs = (payload: Record<string, unknown>) => makeBundle([
+    { member_id: 'o', member_type: 'revocation_observation', payload },
+  ])
+  const base = {
+    authority_ref: 'del-1',
+    status_source: { kind: 'source', id: 's1' },
+    observed_at: '2026-07-10T11:59:00Z',
+    maximum_staleness_ms: 300_000,
+  }
+  const rep = (p: Record<string, unknown>) => computeClaimBoundaryReport(obs(p), { now: NOW }).axes.revocation
+
+  assert.strictEqual(rep({ ...base, revoked_at: '2026-07-10T11:58:00Z', decision: { effect: 'deny' } }).state, 'RESOLVED')
+  assert.strictEqual(rep({ ...base, decision: { effect: 'allow' } }).state, 'VERIFIED')
+  assert.strictEqual(rep({ ...base, decision: { effect: 'allow', downgraded: true } }).state, 'EVALUATED')
+  assert.strictEqual(rep({ ...base, observed_at: '2026-07-10T00:00:00Z', decision: { effect: 'allow' } }).state, 'STALE')
+  assert.strictEqual(rep({ ...base, decision: { effect: 'allow' }, workflow_response: { result: 'unavailable' } }).state, 'UNKNOWN')
+  assert.strictEqual(rep({ authority_ref: 'del-1', decision: { effect: 'allow' } }).state, 'INVALID')
+})
+
+test('evidence: tampered member turns the evidence axis INVALID and overall INVALID', () => {
+  const bundle = makeBundle([
+    { member_id: 'a', member_type: 'other', payload: { x: 1 } },
+    { member_id: 'b', member_type: 'other', payload: { y: 2 } },
+  ])
+  ;(bundle.members[0].payload as { x: number }).x = 2
+  const report = computeClaimBoundaryReport(bundle, { now: NOW })
+  assert.strictEqual(report.axes.evidence.state, 'INVALID')
+  assert.strictEqual(report.overall, 'INVALID')
+})
+
+// ── CLI: fixtures, exit codes, JSON shape ──
+
+test('CLI: valid fixture exits 0 and the JSON object has the stable shape', () => {
+  const res = runCli([join(FIXTURES, 'valid', 'bundle.json'), '--json'])
+  assert.strictEqual(res.status, 0, res.stderr)
+  const parsed = JSON.parse(res.stdout)
+  assert.deepStrictEqual(Object.keys(parsed).sort(), ['axes', 'exit_reason', 'overall'])
+  assert.deepStrictEqual(Object.keys(parsed.axes).sort(), ['action', 'authority', 'evidence', 'revocation'])
+  assert.deepStrictEqual(parsed.axes, {
+    authority: 'ASSERTED', action: 'VERIFIED', revocation: 'MISSING', evidence: 'EVALUATED',
+  })
+  assert.strictEqual(parsed.overall, 'MISSING')
+  assert.strictEqual(parsed.exit_reason, 'ok')
+})
+
+test('CLI: tampered-member fixture exits 2 with evidence INVALID', () => {
+  const res = runCli([join(FIXTURES, 'tampered-member', 'bundle.json'), '--json'])
+  assert.strictEqual(res.status, 2)
+  const parsed = JSON.parse(res.stdout)
+  assert.strictEqual(parsed.axes.evidence, 'INVALID')
+  assert.strictEqual(parsed.exit_reason, 'axis_invalid')
+})
+
+test('CLI: --strict turns MISSING authority into exit 2; without it exit 0', () => {
+  const dir = mkdtempSync(join(tmpdir(), 't8-bundle-'))
+  const bundle = makeBundle([{ member_id: 'n', member_type: 'other', payload: { note: 'no authority member' } }])
+  const file = join(dir, 'bundle.json')
+  writeFileSync(file, JSON.stringify(bundle))
+  const loose = runCli([file, '--json'])
+  assert.strictEqual(loose.status, 0, loose.stderr)
+  const strict = runCli([file, '--json', '--strict'])
+  assert.strictEqual(strict.status, 2)
+  assert.strictEqual(JSON.parse(strict.stdout).exit_reason, 'strict_missing')
+})
+
+test('CLI: unreadable file and failed manifest signature both exit 3', () => {
+  const unreadable = runCli(['/definitely/not/a/file.json', '--json'])
+  assert.strictEqual(unreadable.status, 3)
+  assert.strictEqual(JSON.parse(unreadable.stdout).exit_reason, 'bundle_unreadable')
+
+  const dir = mkdtempSync(join(tmpdir(), 't8-badsig-'))
+  const bundle: EvidenceBundle = JSON.parse(readFileSync(join(FIXTURES, 'valid', 'bundle.json'), 'utf8'))
+  bundle.manifest.created_at = '2030-01-01T00:00:00Z'
+  const file = join(dir, 'bundle.json')
+  writeFileSync(file, JSON.stringify(bundle))
+  const badsig = runCli([file, '--json'])
+  assert.strictEqual(badsig.status, 3)
+  assert.strictEqual(JSON.parse(badsig.stdout).exit_reason, 'manifest_signature_failed')
+})

--- a/tests/fixtures/evidence-bundle/make-fixtures.ts
+++ b/tests/fixtures/evidence-bundle/make-fixtures.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// Regenerates the evidence-bundle fixtures. Run from the repo root:
+//   npx tsx tests/fixtures/evidence-bundle/make-fixtures.ts
+//
+// valid/bundle.json: a signed bundle whose members exercise the axis
+// mapping without time-sensitive members (no revocation_observation,
+// so the revocation axis honestly reports MISSING forever; the
+// passport expires in 2036 so the authority axis stays ASSERTED).
+// tampered-member/bundle.json: the same bundle with one member payload
+// mutated AFTER signing, so its digest no longer matches the manifest.
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { generateKeyPair } from '../../../src/crypto/keys.js'
+import { createPassport } from '../../../src/core/passport.js'
+import { createEvidenceBundle } from '../../../src/core/evidence-bundle.js'
+import type { EvidenceBundle } from '../../../src/types/evidence-bundle.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+const signer = generateKeyPair()
+const { signedPassport } = createPassport({
+  agentId: 'fixture-agent-t8',
+  agentName: 'fixture-agent-t8',
+  ownerAlias: 'sprint-vwe-fixtures',
+  mission: 'Static fixture for evidence-bundle tests',
+  capabilities: ['code_execution'],
+  runtime: { platform: 'node', models: ['fixture'] },
+  validityWindow: { notAfter: '2036-01-01T00:00:00.000Z' },
+})
+
+// Two structural bilateral receipt copies carrying the same action_ref
+// (the F1 slot, read structurally per F7), so the action axis can
+// compare them via actionRefsMatch.
+const actionRef = 'a'.repeat(64)
+const bilateralLocal = {
+  receiptId: 'br-fixture-1',
+  version: '1.0',
+  requestingAgentId: 'fixture-agent-t8',
+  servingAgentId: 'fixture-counterparty',
+  outcome: { toolName: 'echo', requestHash: 'b'.repeat(64), responseHash: 'c'.repeat(64), status: 'success', summary: 'fixture interaction' },
+  requestedAt: '2026-07-10T00:00:00Z',
+  completedAt: '2026-07-10T00:00:01Z',
+  agreedAt: '2026-07-10T00:00:02Z',
+  requestingAgentSignature: 'd'.repeat(128),
+  servingAgentSignature: 'e'.repeat(128),
+  action_ref: actionRef,
+}
+const bilateralCounterparty = { ...bilateralLocal, receiptId: 'br-fixture-2' }
+
+const bundle = createEvidenceBundle({
+  members: [
+    { member_id: 'passport-1', member_type: 'passport', payload: signedPassport },
+    { member_id: 'bilateral-local', member_type: 'bilateral_receipt', payload: bilateralLocal },
+    { member_id: 'bilateral-counterparty', member_type: 'bilateral_receipt', payload: bilateralCounterparty },
+    { member_id: 'note-1', member_type: 'other', payload: { note: 'uncommitted context attachment' } },
+  ],
+  signerPrivateKey: signer.privateKey,
+  signerPublicKey: signer.publicKey,
+  createdAt: '2026-07-10T00:00:00Z',
+})
+
+const tampered: EvidenceBundle = JSON.parse(JSON.stringify(bundle))
+const victim = tampered.members.find(m => m.member_id === 'bilateral-local')
+if (!victim) throw new Error('fixture generation: expected member missing')
+;(victim.payload as { outcome: { summary: string } }).outcome.summary = 'tampered after signing'
+
+for (const [dir, content] of [['valid', bundle], ['tampered-member', tampered]] as const) {
+  mkdirSync(join(HERE, dir), { recursive: true })
+  writeFileSync(join(HERE, dir, 'bundle.json'), JSON.stringify(content, null, 2) + '\n')
+  console.log(`wrote ${join(HERE, dir, 'bundle.json')}`)
+}

--- a/tests/fixtures/evidence-bundle/tampered-member/bundle.json
+++ b/tests/fixtures/evidence-bundle/tampered-member/bundle.json
@@ -1,0 +1,126 @@
+{
+  "manifest": {
+    "profile": "aps:evidence-bundle:v1",
+    "created_at": "2026-07-10T00:00:00Z",
+    "members": [
+      {
+        "member_id": "passport-1",
+        "member_type": "passport",
+        "digest": "3247e2a5402ffe4122f6e153b250a241cb19b73c1eab6afacc59bc358dbb6ca7"
+      },
+      {
+        "member_id": "bilateral-local",
+        "member_type": "bilateral_receipt",
+        "digest": "59e04e1861b516831ce4c2ba4fa8d7182b38bf0bac1f728f2e9c3499085bc130"
+      },
+      {
+        "member_id": "bilateral-counterparty",
+        "member_type": "bilateral_receipt",
+        "digest": "ae1a7219a85ab1b2055b7abf608ed14a36f1fcb8265cc8e6de53473d3bf79072"
+      },
+      {
+        "member_id": "note-1",
+        "member_type": "other",
+        "digest": "8a7389fa4f50d85c12f022f6d5523575382177648e9b63ba9fdb3473cad34023"
+      }
+    ],
+    "merkle_root": "60571c150d8a0623050fb4cf473592c13d02e1dee541a52f1eda4d6776d6f051",
+    "signature": "ceed7f332db3fbbad7474912ad13a1a783d56235a04dd3250353d19928820382922bf02b21f7b3c6b024025b0dc7901c2e4906405ef3de025586c14a40a66d09"
+  },
+  "signer_public_key": "47a9be6aeeda27cb18a4e84b9bd2c87085cff8d8b98fce08bc30bf758faf09df",
+  "members": [
+    {
+      "member_id": "passport-1",
+      "member_type": "passport",
+      "payload": {
+        "passport": {
+          "version": "1.0.0",
+          "agentId": "fixture-agent-t8",
+          "agentName": "fixture-agent-t8",
+          "ownerAlias": "sprint-vwe-fixtures",
+          "publicKey": "d937b269ad814f6871b45a3a0c44ee6315e01cb1b394f958108bb64e7c0ee12e",
+          "mission": "Static fixture for evidence-bundle tests",
+          "capabilities": [
+            "code_execution"
+          ],
+          "runtime": {
+            "platform": "node",
+            "models": [
+              "fixture"
+            ]
+          },
+          "createdAt": "2026-07-10T07:48:01.464Z",
+          "expiresAt": "2036-01-01T00:00:00.000Z",
+          "notBefore": "2026-07-10T07:48:01.464Z",
+          "voteWeight": 2,
+          "reputation": {
+            "overall": 1,
+            "collaborationsCompleted": 0,
+            "proposalsSubmitted": 0,
+            "proposalsApproved": 0,
+            "tokensContributed": 0,
+            "tasksCompleted": 0,
+            "lastUpdated": "2026-07-10T07:48:01.465Z"
+          },
+          "delegations": [],
+          "metadata": {}
+        },
+        "signature": "5246f29cd8689956fb3595b47ba0ace06994d5c17c29518ae2feb6652ce11c76d04cb0906b37336c04f465aeca2d73cff76587cff6eed338d7f27d88fe6f460b",
+        "signedAt": "2026-07-10T07:48:01.466Z"
+      }
+    },
+    {
+      "member_id": "bilateral-local",
+      "member_type": "bilateral_receipt",
+      "payload": {
+        "receiptId": "br-fixture-1",
+        "version": "1.0",
+        "requestingAgentId": "fixture-agent-t8",
+        "servingAgentId": "fixture-counterparty",
+        "outcome": {
+          "toolName": "echo",
+          "requestHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "responseHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "status": "success",
+          "summary": "tampered after signing"
+        },
+        "requestedAt": "2026-07-10T00:00:00Z",
+        "completedAt": "2026-07-10T00:00:01Z",
+        "agreedAt": "2026-07-10T00:00:02Z",
+        "requestingAgentSignature": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "servingAgentSignature": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "action_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    {
+      "member_id": "bilateral-counterparty",
+      "member_type": "bilateral_receipt",
+      "payload": {
+        "receiptId": "br-fixture-2",
+        "version": "1.0",
+        "requestingAgentId": "fixture-agent-t8",
+        "servingAgentId": "fixture-counterparty",
+        "outcome": {
+          "toolName": "echo",
+          "requestHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "responseHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "status": "success",
+          "summary": "fixture interaction"
+        },
+        "requestedAt": "2026-07-10T00:00:00Z",
+        "completedAt": "2026-07-10T00:00:01Z",
+        "agreedAt": "2026-07-10T00:00:02Z",
+        "requestingAgentSignature": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "servingAgentSignature": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "action_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    {
+      "member_id": "note-1",
+      "member_type": "other",
+      "payload": {
+        "note": "uncommitted context attachment"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/evidence-bundle/valid/bundle.json
+++ b/tests/fixtures/evidence-bundle/valid/bundle.json
@@ -1,0 +1,126 @@
+{
+  "manifest": {
+    "profile": "aps:evidence-bundle:v1",
+    "created_at": "2026-07-10T00:00:00Z",
+    "members": [
+      {
+        "member_id": "passport-1",
+        "member_type": "passport",
+        "digest": "3247e2a5402ffe4122f6e153b250a241cb19b73c1eab6afacc59bc358dbb6ca7"
+      },
+      {
+        "member_id": "bilateral-local",
+        "member_type": "bilateral_receipt",
+        "digest": "59e04e1861b516831ce4c2ba4fa8d7182b38bf0bac1f728f2e9c3499085bc130"
+      },
+      {
+        "member_id": "bilateral-counterparty",
+        "member_type": "bilateral_receipt",
+        "digest": "ae1a7219a85ab1b2055b7abf608ed14a36f1fcb8265cc8e6de53473d3bf79072"
+      },
+      {
+        "member_id": "note-1",
+        "member_type": "other",
+        "digest": "8a7389fa4f50d85c12f022f6d5523575382177648e9b63ba9fdb3473cad34023"
+      }
+    ],
+    "merkle_root": "60571c150d8a0623050fb4cf473592c13d02e1dee541a52f1eda4d6776d6f051",
+    "signature": "ceed7f332db3fbbad7474912ad13a1a783d56235a04dd3250353d19928820382922bf02b21f7b3c6b024025b0dc7901c2e4906405ef3de025586c14a40a66d09"
+  },
+  "signer_public_key": "47a9be6aeeda27cb18a4e84b9bd2c87085cff8d8b98fce08bc30bf758faf09df",
+  "members": [
+    {
+      "member_id": "passport-1",
+      "member_type": "passport",
+      "payload": {
+        "passport": {
+          "version": "1.0.0",
+          "agentId": "fixture-agent-t8",
+          "agentName": "fixture-agent-t8",
+          "ownerAlias": "sprint-vwe-fixtures",
+          "publicKey": "d937b269ad814f6871b45a3a0c44ee6315e01cb1b394f958108bb64e7c0ee12e",
+          "mission": "Static fixture for evidence-bundle tests",
+          "capabilities": [
+            "code_execution"
+          ],
+          "runtime": {
+            "platform": "node",
+            "models": [
+              "fixture"
+            ]
+          },
+          "createdAt": "2026-07-10T07:48:01.464Z",
+          "expiresAt": "2036-01-01T00:00:00.000Z",
+          "notBefore": "2026-07-10T07:48:01.464Z",
+          "voteWeight": 2,
+          "reputation": {
+            "overall": 1,
+            "collaborationsCompleted": 0,
+            "proposalsSubmitted": 0,
+            "proposalsApproved": 0,
+            "tokensContributed": 0,
+            "tasksCompleted": 0,
+            "lastUpdated": "2026-07-10T07:48:01.465Z"
+          },
+          "delegations": [],
+          "metadata": {}
+        },
+        "signature": "5246f29cd8689956fb3595b47ba0ace06994d5c17c29518ae2feb6652ce11c76d04cb0906b37336c04f465aeca2d73cff76587cff6eed338d7f27d88fe6f460b",
+        "signedAt": "2026-07-10T07:48:01.466Z"
+      }
+    },
+    {
+      "member_id": "bilateral-local",
+      "member_type": "bilateral_receipt",
+      "payload": {
+        "receiptId": "br-fixture-1",
+        "version": "1.0",
+        "requestingAgentId": "fixture-agent-t8",
+        "servingAgentId": "fixture-counterparty",
+        "outcome": {
+          "toolName": "echo",
+          "requestHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "responseHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "status": "success",
+          "summary": "fixture interaction"
+        },
+        "requestedAt": "2026-07-10T00:00:00Z",
+        "completedAt": "2026-07-10T00:00:01Z",
+        "agreedAt": "2026-07-10T00:00:02Z",
+        "requestingAgentSignature": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "servingAgentSignature": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "action_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    {
+      "member_id": "bilateral-counterparty",
+      "member_type": "bilateral_receipt",
+      "payload": {
+        "receiptId": "br-fixture-2",
+        "version": "1.0",
+        "requestingAgentId": "fixture-agent-t8",
+        "servingAgentId": "fixture-counterparty",
+        "outcome": {
+          "toolName": "echo",
+          "requestHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "responseHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "status": "success",
+          "summary": "fixture interaction"
+        },
+        "requestedAt": "2026-07-10T00:00:00Z",
+        "completedAt": "2026-07-10T00:00:01Z",
+        "agreedAt": "2026-07-10T00:00:02Z",
+        "requestingAgentSignature": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "servingAgentSignature": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "action_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    {
+      "member_id": "note-1",
+      "member_type": "other",
+      "payload": {
+        "note": "uncommitted context attachment"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
…LI verify-bundle and inspect bilateral fix

- createEvidenceBundle/verifyEvidenceBundle per FREEZE-VWE F5: digests via canonicalize, root via buildMerkleRoot, inclusion via proveInclusion/ verifyInclusion, signature over the signable subset. No commitBatch, no epoch/previousBatchId on the bundle wire format.
- computeClaimBoundaryReport: per-axis ClaimState (F6) over authority, action, revocation, evidence per the SCHEMAS-DRAFT 3d mapping. Members read structurally by member_type (F7), zero imports from T6/T7 branches. Uncomputable axes report MISSING or UNKNOWN, nothing hardcoded.
- CLI: inspect detects a BilateralReceipt before the receiptId branch (keyed on requestingAgentId plus servingAgentId); new verify-bundle <path> [--json] [--strict] with exit codes 0/2/3. All other command output untouched, src/index.ts untouched (exports deferred to T9).
- Fixtures valid/ and tampered-member/ plus 17 tests (run directly via tsx --test until T9 registers the file in the package.json test script).

## Summary

<!-- Describe what this PR changes. -->

## Checklist

- [ ] **Signed-off-by (DCO) — required.** Every commit in this PR is signed off (`git commit -s`) per the [Developer Certificate of Origin](https://developercertificate.org/).
