### PR TITLE
feat(jurisdiction-selection): add jurisdiction selection provenance p…

### DIFF
--- a/src/core/jurisdiction-selection.ts
+++ b/src/core/jurisdiction-selection.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// ══════════════════════════════════════════════════════════════════
+// Jurisdiction Selection Provenance
+// ══════════════════════════════════════════════════════════════════
+// Given jurisdiction facts and opaque policy pack references, record
+// which packs apply and where they disagree. Disagreements are
+// surfaced, never auto-resolved; explicit operator precedence is the
+// only resolution path, and its use is recorded.
+// ══════════════════════════════════════════════════════════════════
+
+import type {
+  JurisdictionFacts, PolicyPackRef, PackConflict,
+  SelectionOptions, SelectionRecord,
+} from '../types/jurisdiction-selection.js'
+
+/** Resolver version stamped into every SelectionRecord */
+export const RESOLVER_VERSION = '0.1.0' as const
+
+/** Count how many fact dimensions a pack's jurisdiction matches */
+function matchCount(pack: PolicyPackRef, facts: JurisdictionFacts): number {
+  const dims = [
+    facts.principal_jurisdiction,
+    facts.execution_jurisdiction,
+    facts.resource_jurisdiction,
+    ...(facts.subject_jurisdiction ? [facts.subject_jurisdiction] : []),
+  ]
+  return dims.filter(d => d === pack.jurisdiction).length
+}
+
+/** Stable pack label used in conflict records */
+function packLabel(pack: PolicyPackRef): string {
+  return `${pack.id}@${pack.version}`
+}
+
+/**
+ * Select the policy packs applicable to a set of jurisdiction facts
+ * and produce a provenance record of that selection.
+ *
+ * Invariants:
+ * - Pure and deterministic given the same inputs; the only impure
+ *   default is selected_at, which callers should pin via
+ *   opts.selected_at for reproducible records.
+ * - A pack is selected when its jurisdiction matches ANY fact
+ *   dimension. selected_packs is ordered by match count descending,
+ *   then id, then version.
+ * - When two selected packs declare different values for the same
+ *   constraints key, a PackConflict is emitted and resolution becomes
+ *   'conflict-surfaced'. There is no automatic resolution.
+ * - opts.precedence resolves a key only when every pack declaring
+ *   that key is listed in it; the record then carries precedence_used
+ *   so the override is auditable.
+ */
+export function selectJurisdictionPacks(
+  facts: JurisdictionFacts,
+  packs: PolicyPackRef[],
+  opts?: SelectionOptions
+): SelectionRecord {
+  const selected = packs
+    .filter(p => matchCount(p, facts) > 0)
+    .sort((a, b) => {
+      const byCount = matchCount(b, facts) - matchCount(a, facts)
+      if (byCount !== 0) return byCount
+      if (a.id !== b.id) return a.id < b.id ? -1 : 1
+      if (a.version !== b.version) return a.version < b.version ? -1 : 1
+      return 0
+    })
+
+  // Gather declared values per constraints key, in selected order.
+  const byKey = new Map<string, { pack: PolicyPackRef; value: string }[]>()
+  for (const pack of selected) {
+    for (const key of Object.keys(pack.constraints ?? {}).sort()) {
+      const value = (pack.constraints as Record<string, string>)[key]
+      const list = byKey.get(key) ?? []
+      list.push({ pack, value })
+      byKey.set(key, list)
+    }
+  }
+
+  const precedence = opts?.precedence ?? []
+  const conflicts: PackConflict[] = []
+  for (const key of [...byKey.keys()].sort()) {
+    const declared = byKey.get(key) as { pack: PolicyPackRef; value: string }[]
+    const distinct = new Set(declared.map(d => d.value))
+    if (distinct.size <= 1) continue
+    const resolvedByPrecedence =
+      precedence.length > 0 &&
+      declared.every(d => precedence.includes(d.pack.id))
+    if (resolvedByPrecedence) continue
+    conflicts.push({
+      dimension: key,
+      packs: declared.map(d => packLabel(d.pack)),
+      values: declared.map(d => d.value),
+      note: `selected packs declare different values for "${key}"; surfaced, not auto-resolved`,
+    })
+  }
+
+  return {
+    facts,
+    selected_packs: selected,
+    conflicts,
+    resolution: conflicts.length > 0 ? 'conflict-surfaced' : 'selected',
+    resolver_version: RESOLVER_VERSION,
+    ...(opts?.precedence ? { precedence_used: [...opts.precedence] } : {}),
+    selected_at: opts?.selected_at ?? new Date().toISOString(),
+  }
+}

--- a/src/types/jurisdiction-selection.ts
+++ b/src/types/jurisdiction-selection.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+// ══════════════════════════════════════════════════════════════════
+// Jurisdiction Selection Provenance, Types
+// ══════════════════════════════════════════════════════════════════
+// Records which policy packs were selected for a set of jurisdiction
+// facts, and surfaces disagreements between them. A selection record,
+// not a router and not a compliance engine. Packs are opaque
+// references; the protocol carries context, no legal content.
+// ══════════════════════════════════════════════════════════════════
+
+/**
+ * The jurisdiction facts of one execution context. Each dimension is
+ * an ISO 3166-1 alpha-2 code, the same vocabulary JurisdictionEnvelope
+ * uses. subject_jurisdiction is optional because many actions have no
+ * identifiable data subject.
+ */
+export interface JurisdictionFacts {
+  /** Jurisdiction of the principal on whose behalf the agent acts */
+  principal_jurisdiction: string
+  /** Jurisdiction where execution happens */
+  execution_jurisdiction: string
+  /** Jurisdiction of the resource being acted on */
+  resource_jurisdiction: string
+  /** Jurisdiction of the data subject, when one exists */
+  subject_jurisdiction?: string
+}
+
+/**
+ * An opaque reference to an externally issued policy pack. The SDK
+ * never inspects pack content; constraints is an opaque key/value
+ * surface used only to detect disagreement between packs.
+ */
+export interface PolicyPackRef {
+  /** Pack identifier, unique per issuer */
+  id: string
+  /** Pack version string */
+  version: string
+  /** Issuer identifier */
+  issuer: string
+  /** Jurisdiction the pack declares itself for (ISO 3166-1 alpha-2) */
+  jurisdiction: string
+  /** Content digest of the pack, for pinning */
+  digest: string
+  /** Opaque declared constraint surface, compared key by key */
+  constraints?: Record<string, string>
+}
+
+/**
+ * One disagreement between selected packs: two or more packs declare
+ * different values for the same constraints key. Never auto-resolved.
+ */
+export interface PackConflict {
+  /** The constraints key the packs disagree on */
+  dimension: string
+  /** Packs declaring this key, as id@version, in selected order */
+  packs: string[]
+  /** Declared values, index-aligned with packs */
+  values: string[]
+  /** Human-readable note; no resolution is implied */
+  note: string
+}
+
+/** Options for selectJurisdictionPacks */
+export interface SelectionOptions {
+  /**
+   * Explicit precedence, highest first, by pack id. A conflict is
+   * resolved by precedence only when every pack declaring the
+   * conflicting key is listed here. Absent or partial coverage means
+   * the conflict is surfaced, never auto-resolved.
+   */
+  precedence?: string[]
+  /** RFC 3339 timestamp for the record; pass for reproducible output */
+  selected_at?: string
+}
+
+/**
+ * Provenance record of one pack selection. Invariants: selected_packs
+ * is deterministically ordered (jurisdiction match count descending,
+ * then id, then version); resolution is 'conflict-surfaced' whenever
+ * conflicts is non-empty; precedence_used is present exactly when a
+ * precedence list was supplied to the resolver.
+ */
+export interface SelectionRecord {
+  facts: JurisdictionFacts
+  selected_packs: PolicyPackRef[]
+  conflicts: PackConflict[]
+  resolution: 'selected' | 'conflict-surfaced'
+  resolver_version: '0.1.0'
+  /** The precedence list that was in effect, when one was supplied */
+  precedence_used?: string[]
+  selected_at: string
+}

--- a/tests/jurisdiction-selection.test.ts
+++ b/tests/jurisdiction-selection.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { selectJurisdictionPacks, RESOLVER_VERSION } from '../src/core/jurisdiction-selection.js'
+import type { JurisdictionFacts, PolicyPackRef } from '../src/types/jurisdiction-selection.js'
+
+const AT = '2026-07-10T00:00:00Z'
+
+function pack(over: Partial<PolicyPackRef> & Pick<PolicyPackRef, 'id' | 'jurisdiction'>): PolicyPackRef {
+  return { version: '1.0.0', issuer: 'issuer-x', digest: 'sha256:0000', ...over }
+}
+
+describe('Jurisdiction Selection Provenance', () => {
+  it('three-country case surfaces a residency conflict, never auto-resolves', () => {
+    // Principal in US, executor in DE, resource in JP. Two packs whose
+    // residency constraint values differ. Expect exactly one conflict.
+    const facts: JurisdictionFacts = {
+      principal_jurisdiction: 'US',
+      execution_jurisdiction: 'DE',
+      resource_jurisdiction: 'JP',
+    }
+    const packs = [
+      pack({ id: 'pack-us-base', jurisdiction: 'US', constraints: { residency: 'local-only' } }),
+      pack({ id: 'pack-de-base', jurisdiction: 'DE', constraints: { residency: 'in-jurisdiction' } }),
+    ]
+    const record = selectJurisdictionPacks(facts, packs, { selected_at: AT })
+
+    assert.equal(record.selected_packs.length, 2)
+    assert.equal(record.conflicts.length, 1)
+    assert.equal(record.resolution, 'conflict-surfaced')
+    assert.equal(record.conflicts[0].dimension, 'residency')
+    assert.deepEqual(record.conflicts[0].packs, ['pack-de-base@1.0.0', 'pack-us-base@1.0.0'])
+    assert.deepEqual(record.conflicts[0].values, ['in-jurisdiction', 'local-only'])
+    assert.equal(record.resolver_version, RESOLVER_VERSION)
+    assert.equal(record.selected_at, AT)
+    assert.equal(record.precedence_used, undefined)
+  })
+
+  it('no-conflict two-pack case selects with deterministic ordering', () => {
+    const facts: JurisdictionFacts = {
+      principal_jurisdiction: 'US',
+      execution_jurisdiction: 'US',
+      resource_jurisdiction: 'DE',
+    }
+    const packs = [
+      pack({ id: 'pack-a-de', jurisdiction: 'DE', constraints: { retention: 'short' } }),
+      pack({ id: 'pack-x-none', jurisdiction: 'BR' }),
+      pack({ id: 'pack-z-us', jurisdiction: 'US', constraints: { logging: 'required' } }),
+    ]
+    const record = selectJurisdictionPacks(facts, packs, { selected_at: AT })
+
+    // pack-z-us matches two dimensions so it ranks first despite its
+    // later id; pack-x-none matches nothing and is excluded.
+    assert.deepEqual(record.selected_packs.map(p => p.id), ['pack-z-us', 'pack-a-de'])
+    assert.deepEqual(record.conflicts, [])
+    assert.equal(record.resolution, 'selected')
+
+    // Equal match counts fall back to id order, regardless of input order.
+    const tied = selectJurisdictionPacks(facts, [
+      pack({ id: 'pack-b', jurisdiction: 'DE' }),
+      pack({ id: 'pack-a', jurisdiction: 'DE' }),
+    ], { selected_at: AT })
+    assert.deepEqual(tied.selected_packs.map(p => p.id), ['pack-a', 'pack-b'])
+  })
+
+  it('explicit precedence covering all declaring packs resolves the key and is recorded', () => {
+    const facts: JurisdictionFacts = {
+      principal_jurisdiction: 'US',
+      execution_jurisdiction: 'DE',
+      resource_jurisdiction: 'JP',
+    }
+    const packs = [
+      pack({ id: 'pack-us-base', jurisdiction: 'US', constraints: { residency: 'local-only' } }),
+      pack({ id: 'pack-de-base', jurisdiction: 'DE', constraints: { residency: 'in-jurisdiction' } }),
+    ]
+    const record = selectJurisdictionPacks(facts, packs, {
+      precedence: ['pack-us-base', 'pack-de-base'],
+      selected_at: AT,
+    })
+    assert.deepEqual(record.conflicts, [])
+    assert.equal(record.resolution, 'selected')
+    assert.deepEqual(record.precedence_used, ['pack-us-base', 'pack-de-base'])
+
+    // Partial coverage does not resolve: the conflict stays surfaced.
+    const partial = selectJurisdictionPacks(facts, packs, {
+      precedence: ['pack-us-base'],
+      selected_at: AT,
+    })
+    assert.equal(partial.conflicts.length, 1)
+    assert.equal(partial.resolution, 'conflict-surfaced')
+  })
+})


### PR DESCRIPTION
…rimitive

Selection record over opaque policy pack references: a pack is selected when its jurisdiction matches any fact dimension, ordering is deterministic (match count desc, then id, then version), and constraint disagreements are surfaced as PackConflict, never auto-resolved. Explicit opts.precedence is the only resolution path and its use is recorded in the SelectionRecord.

New files only; src/index.ts untouched per sprint rules. Export lines and the package.json test-script addition are listed in HANDOFF-T5.

## Summary

<!-- Describe what this PR changes. -->

## Checklist

- [ ] **Signed-off-by (DCO) — required.** Every commit in this PR is signed off (`git commit -s`) per the [Developer Certificate of Origin](https://developercertificate.org/).
