### PR TITLE
v2 receipt-core, delegation, identity-binding, and OAuth composition vectors

### DIFF
--- a/interop/oauth-liu-composition/MAPPING-TABLE.md
+++ b/interop/oauth-liu-composition/MAPPING-TABLE.md
@@ -1,0 +1,66 @@
+# Liu draft family to APS record mapping
+
+Mechanical field map for the three vectors. Draft line references are into the
+fetched .txt files in drafts/. "Their field" spellings are verbatim from the drafts
+except the three marked constructed, whose content Section 9.7 prescribes without
+JSON spellings. APS slots are existing exported shapes only; no record shape or
+signing profile was modified.
+
+How column vocabulary: digest means the sha256 of the strict JCS form of their
+object lands in the APS slot; copied means the value is carried verbatim; derived
+means the APS value is computed from their values; referenced means their id string
+is embedded in an APS string slot.
+
+## draft-liu-oauth-chain-delegation-00 (vectors v1, v2, v3)
+
+| Their ref | Their field | APS slot | How |
+|---|---|---|---|
+| Fig. 1, line 200 | delegation_chain (whole array) | ReceiptV1.evidence_refs[] artifact_type liu-oauth-chain-delegation-00/delegation_chain | digest |
+| Fig. 1, line 200 | delegation_chain (whole array) | ReceiptV1.delegation_ref | derived (liu-chain:sha256:digest string) |
+| Fig. 1, line 200 | delegation_chain (whole array) | DecisionRefInputV1.authority_state_ref via buildDecisionRefV1 authority_state | digest |
+| Fig. 1, line 203 | delegatee_id (final hop) | ReceiptV1.subject_agent | copied |
+| Fig. 1, line 203 | delegatee_id (final hop) | ActionReferenceInputV2.agent_id | copied |
+| Fig. 1, lines 206-210 | delegated_policy.content (rego allow clauses) | narrowed subset in result.narrowed_subset and CoreDecisionOutputV1.constraints (permit) | derived (input.action equality clauses parsed per the draft's own clause form) |
+| Fig. 1, lines 206-210 | delegated_policy.content (final hop) | rego_decision_context.policy_ref.hash | derived (sha256- base64, the rego draft's format) |
+| Fig. 1, lines 202, 203 | delegator_id, delegatee_id (revoked hop) | RevocationObservation.authority_ref | derived (liu-chain-hop:delegator->delegatee) |
+| Sec. 10.8, lines 2073-2090 | back-channel revocation notification | RevocationObservation.status_source {kind: set, jti} | referenced (the SET jti string; the RFC 8417 tie is the APS status_source vocabulary, the Liu draft names back-channel notification without citing 8417) |
+| Sec. 10.8 | revocation takes effect on observation | RevocationObservation.observed_at, maximum_staleness_ms, decision | derived (the relying party's freshness contract and the deny that followed) |
+| Fig. 1, lines 206-210 | delegated_policy scope (final hop) | RevocationObservation.affected_scope | derived (space-joined narrowed action set) |
+| Fig. 1, lines 204, 205, 211-213 | delegation_timestamp, root_evidence_ref, operation_summary, delegator_signature, as_signature | covered by the chain digest only | digest (inside the whole-array digest; not individually mapped) |
+
+## draft-liu-oauth-authorization-evidence-01 (vectors v1, v2)
+
+| Their ref | Their field | APS slot | How |
+|---|---|---|---|
+| Sec. 3.3, lines 254-272 | authorization_details (whole enriched array) | ReceiptV1.evidence_refs[] artifact_type liu-oauth-authorization-evidence-01/authorization_details | digest |
+| Sec. 3.3 | evidence.id, user_confirmation.*, as_signature, audit_trail.* | covered by the authorization_details digest | digest (inside the whole-object digest; not individually mapped) |
+
+## draft-liu-oauth-rego-policy-00 (vectors v1, v2)
+
+| Their ref | Their field | APS slot | How |
+|---|---|---|---|
+| Sec. 3.2.2, Fig. 3 | policy_ref (id, version, hash) | DecisionRefInputV1.policy_ref via buildDecisionRefV1 policy_input | digest |
+| Sec. 3.2.2, Fig. 3 | policy_ref.id | ReceiptV1.result.policy_id | copied |
+| Sec. 9.7, line 1497 | policy identifier (policy_ref.id) | decision_context component of decision_ref | digest (as part of the 9.7 tuple object) |
+| Sec. 9.7 | hash of the evaluated input | fixture field input_hash (constructed spelling) in the decision_context component | derived (sha256: digest of the evaluated input) |
+| Sec. 9.7 | allow/deny result | fixture field result (constructed spelling) in decision_context; CoreDecisionOutputV1.verdict; ReceiptV1.result.decision | copied / derived (allow to permit, deny to deny) |
+| Sec. 9.7 | evaluation timestamp | fixture field evaluation_timestamp (constructed spelling) in decision_context | copied |
+
+## Consulted but unmapped
+
+| Their ref | Their field | Why unmapped |
+|---|---|---|
+| rego-policy-00 Sec. 3.2.2 | policy_ref.endpoint | the draft's own privacy section recommends abstract identifiers; the vectors carry id, version, hash only |
+| rego-policy-00 error vocabulary | error, error_description, rego_profile | error negotiation is a request-time flow; the vectors record decisions, not the negotiation |
+| chain-delegation-00 Sec. 4.3 phase 2 | interaction_required | user-interaction phase precedes the decision the receipt records; the evidence object already carries the user confirmation |
+| authorization-evidence-01 Sec. 3.2 | client request form (minimal type-only object) | the vectors carry the enriched response, which is the evidence-bearing form |
+
+## Gap notes
+
+No new field or profile was needed for any of the three vectors. Two observations
+that are conventions rather than gaps: the evidence tie-back uses digest-only
+evidence_refs (artifact_type plus sha256), so a relying party needs the input
+artifact out of band to re-derive the digest, which is the intended evidence_refs
+model; and the 9.7 tuple has prescribed content but no prescribed JSON spellings,
+so the three constructed spellings (input_hash, result, evaluation_timestamp) are
+fixture conventions, marked above.

--- a/interop/oauth-liu-composition/README.md
+++ b/interop/oauth-liu-composition/README.md
@@ -1,0 +1,53 @@
+# OAuth composition vectors for the Liu draft family
+
+Three runnable vectors that carry inputs shaped by the Liu OAuth drafts into
+signed APS records another party can verify later. The pinned draft texts and
+the field extraction live in drafts/. The full field map is MAPPING-TABLE.md.
+
+## The vectors
+
+vectors/v1-permit: an allow under a two-hop delegation_chain whose final hop
+narrows the action set. The receipt binds the authorization evidence and the
+chain state by digest.
+
+vectors/v2-denial: the requested action falls outside the final hop's narrowed
+subset. The signed denial names the requested action and the subset it
+exceeded.
+
+vectors/v3-observation: the Section 10.8 case where per-hop introspection is
+impractical. A signed revocation observation captures what the relying party
+consulted and decided; the field layout is in MAPPING-TABLE.md.
+
+## Verify without the SDK
+
+Node 18 or later, no installs:
+
+    node independent-verify.mjs
+
+From the committed files alone it recomputes:
+
+- the strict JCS (RFC 8785) canonical form of every signed body
+- each receipt_id
+- the evidence digests from the fixtures in vectors/*/input.json
+- every Ed25519 signature
+
+## Verify through the SDK
+
+From the repo root:
+
+    npm ci
+    npx tsx interop/oauth-liu-composition/verify-vectors.ts
+    npx tsx --test interop/oauth-liu-composition/test.ts
+
+The suite re-emits the vectors and checks byte stability, then runs tamper
+cases on in-memory copies.
+
+## Boundaries
+
+The signing keys are fixed test keys published with the vectors; never reuse
+them for any real identity. Evidence refs are digest-only, so re-deriving them
+needs the input artifact, which is the intended model. Section 9.7 of the Rego
+draft prescribes the audit tuple's content but not its JSON spellings; the
+constructed spellings are marked in MAPPING-TABLE.md. The SET binding in v3
+comes from APS record vocabulary; the chain-delegation draft names back-channel
+notification without citing RFC 8417.

--- a/interop/oauth-liu-composition/drafts/EXTRACTED-FIELDS.md
+++ b/interop/oauth-liu-composition/drafts/EXTRACTED-FIELDS.md
@@ -1,0 +1,58 @@
+# Extracted fields from the Liu OAuth draft family
+
+Source texts fetched 2026-07-18 from www.ietf.org/archive/id/ into this directory.
+Line references are into the fetched .txt files. Field names below are used verbatim
+by the input fixtures in ../vectors/. Where a draft gives a JSON example, the fixture
+adapts it; where it gives none, the fixture constructs a minimal instance from the
+field definitions and the mapping table says so.
+
+## draft-liu-oauth-chain-delegation-00.txt
+
+Figure 1 (lines 199-219) gives a complete delegation_chain example. Fields per hop:
+
+- `delegation_chain` (array of hop records), line 200
+- `delegator_id` (line 202), `delegatee_id` (line 203): wit:// agent identifiers
+- `delegation_timestamp` (line 204): unix epoch seconds
+- `root_evidence_ref` (line 205): string reference to the root evidence record
+- `delegated_policy` (line 206): object with `type` ("rego"), `content` (rego source
+  whose allow rules test `input.action == "..."`), `entry_point` ("allow")
+- `operation_summary` (line 211): human-readable summary
+- `delegator_signature` (line 212), `as_signature` (line 213): JWS compact strings
+
+Section 4.3 (line 224): four lifecycle phases; narrowing semantics are that each hop
+delegates a policy scope. Section 10.8 (line 2032): revocation semantics. Root and
+intermediate hop revocation invalidate downstream tokens; detection mechanisms
+include short-lived tokens, RFC 7662 introspection, and back-channel revocation
+notifications (lines 2073-2090). The draft names back-channel notification but does
+not itself cite RFC 8417; the SET tie in vector v3 comes from the APS observation
+record's status_source vocabulary, which accepts a SET jti reference.
+
+## draft-liu-oauth-authorization-evidence-01.txt
+
+Type identifier `authorization_evidence` (Section 3.1, line 232), carried inside
+`authorization_details` (RFC 9396). Enriched response example (Section 3.3, lines
+254-272):
+
+- `authorization_details[].type` = "authorization_evidence"
+- `evidence.id`: urn:uuid
+- `evidence.user_confirmation.displayed_content`, `.user_action`, `.timestamp`
+  (unix epoch seconds)
+- `evidence.as_signature`: JWS compact string
+- `evidence.audit_trail.semantic_expansion_level`, `.proposal_ref`
+
+## draft-liu-oauth-rego-policy-00.txt
+
+`policy_ref` claim structure (Section 3.2.2, lines 143-156 area, Figure 3):
+
+- `policy_ref.id` REQUIRED, `policy_ref.version` OPTIONAL,
+- `policy_ref.hash` OPTIONAL ("algorithm-base64value", sha256 mandatory to support),
+- `policy_ref.endpoint` OPTIONAL (privacy note in Section 10 recommends abstract ids).
+
+Section 9.7 Behavioral Audit (line 1497): Resource Servers SHOULD log each policy
+evaluation event including: the policy identifier (policy_ref.id), a hash or summary
+of the evaluated input, the allow/deny result, and the evaluation timestamp. This
+four-part tuple is the decision context carried by vectors v1 and v2 as:
+`policy_ref`, `input_hash`, `result`, `evaluation_timestamp`. The composite object
+name and those last three field spellings are constructed for the fixture (the draft
+prescribes the tuple's content, not JSON field names); the mapping table marks them
+constructed.

--- a/interop/oauth-liu-composition/drafts/draft-liu-oauth-authorization-evidence-01.txt
+++ b/interop/oauth-liu-composition/drafts/draft-liu-oauth-authorization-evidence-01.txt
@@ -1,0 +1,1288 @@
+
+
+
+
+Web Authorization Protocol                                        D. Liu
+Internet-Draft                                                    H. Zhu
+Intended status: Standards Track                           Alibaba Group
+Expires: 25 December 2026                                    S. Krishnan
+                                                                   Cisco
+                                                              A. Parecki
+                                                                    Okta
+                                                            23 June 2026
+
+
+   Authorization Evidence and Audit Trail for OAuth 2.0 Access Tokens
+               draft-liu-oauth-authorization-evidence-01
+
+Abstract
+
+   This specification defines an authorization details type for
+   including authorization evidence and audit trail information in OAuth
+   2.0 access tokens using the Rich Authorization Requests (RAR)
+   framework.  When an Authorization Server processes user consent, it
+   enriches the authorization details with cryptographic proof of user
+   confirmation, supporting accountability, compliance, and dispute
+   resolution in scenarios where autonomous agents act on behalf of
+   users.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 25 December 2026.
+
+Copyright Notice
+
+   Copyright (c) 2026 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 1]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
+     1.2.  Relationship to Rich Authorization Requests . . . . . . .   4
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  The authorization_evidence Authorization Details Type . . . .   5
+     3.1.  Type Definition . . . . . . . . . . . . . . . . . . . . .   5
+     3.2.  Client Request  . . . . . . . . . . . . . . . . . . . . .   5
+     3.3.  Enriched Response . . . . . . . . . . . . . . . . . . . .   5
+     3.4.  Evidence Object Structure . . . . . . . . . . . . . . . .   6
+     3.5.  Field Definitions . . . . . . . . . . . . . . . . . . . .   7
+       3.5.1.  user_confirmation Object  . . . . . . . . . . . . . .   7
+     3.6.  AS Signature  . . . . . . . . . . . . . . . . . . . . . .   8
+   4.  The audit_trail Sub-object  . . . . . . . . . . . . . . . . .   9
+     4.1.  Structure . . . . . . . . . . . . . . . . . . . . . . . .   9
+     4.2.  Field Definitions . . . . . . . . . . . . . . . . . . . .  10
+     4.3.  Semantic Expansion Levels . . . . . . . . . . . . . . . .  11
+   5.  Audit Trail Purposes  . . . . . . . . . . . . . . . . . . . .  12
+   6.  Authorization Server Processing . . . . . . . . . . . . . . .  12
+     6.1.  Evidence Collection from User Interaction . . . . . . . .  12
+       6.1.1.  General Consent-to-Evidence Pattern . . . . . . . . .  12
+       6.1.2.  Consent UI to Evidence Field Mapping  . . . . . . . .  13
+       6.1.3.  Example: JWT Grant Interaction Response Flow  . . . .  14
+       6.1.4.  Applicability to Other Flows  . . . . . . . . . . . .  15
+     6.2.  Evidence Generation . . . . . . . . . . . . . . . . . . .  16
+   7.  Resource Server Processing  . . . . . . . . . . . . . . . . .  16
+     7.1.  Evidence Verification . . . . . . . . . . . . . . . . . .  16
+     7.2.  Audit Logging . . . . . . . . . . . . . . . . . . . . . .  17
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  17
+     8.1.  Signature Verification  . . . . . . . . . . . . . . . . .  17
+     8.2.  Evidence Tampering and Trust in the AS  . . . . . . . . .  17
+     8.3.  Replay Attacks  . . . . . . . . . . . . . . . . . . . . .  18
+     8.4.  Token-Evidence Binding  . . . . . . . . . . . . . . . . .  18
+     8.5.  Cross-Domain Evidence Verification  . . . . . . . . . . .  19
+     8.6.  Privacy Considerations  . . . . . . . . . . . . . . . . .  19
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  19
+     9.1.  OAuth Authorization Details Type Registration . . . . . .  19
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  19
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 2]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  19
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  20
+   Appendix A.  Complete Example . . . . . . . . . . . . . . . . . .  21
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  23
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
+
+1.  Introduction
+
+   In traditional OAuth 2.0 [RFC6749] flows, the Authorization Server
+   records user consent internally, but this information is not
+   typically conveyed to Resource Servers or included in access tokens.
+   For many use cases, this is sufficient.  However, emerging scenarios,
+   particularly those involving AI agents acting autonomously on behalf
+   of users, require stronger guarantees about user intent and consent.
+
+   This specification addresses the need for:
+
+   *  Verifiable consent: Cryptographic proof that a user explicitly
+      authorized a specific operation;
+
+   *  Audit trails: Traceable records linking user intent to system
+      actions;
+
+   *  Dispute resolution: Evidence that can be examined if questions
+      arise about what was authorized;
+
+   *  Regulatory compliance: Documentation required by applicable
+      regulations.
+
+   This specification defines an authorization details type that
+   leverages the Rich Authorization Requests (RAR) [RFC9396] framework
+   to convey authorization evidence.  When a client includes an
+   authorization_evidence authorization details object in its request,
+   the Authorization Server enriches it during the consent process with
+   cryptographic proof of user confirmation.
+
+   Unless otherwise noted, all data types and serialization rules follow
+   the JSON data interchange format as defined in [RFC8259].
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals.
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 3]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+1.2.  Relationship to Rich Authorization Requests
+
+   This specification builds on the Rich Authorization Requests (RAR)
+   framework [RFC9396].  In RAR, clients include authorization_details
+   in authorization requests to convey fine-grained authorization data.
+   RAR Section 7.1 defines an "Enriched Response" mechanism where the
+   Authorization Server dynamically populates fields in the
+   authorization_details based on user consent decisions or policy
+   rules.
+
+   The authorization_evidence type defined in this specification follows
+   this enriched response pattern:
+
+   1.  The client includes an authorization_evidence authorization
+       details object in its request, typically with minimal or
+       placeholder fields indicating that evidence is requested.
+
+   2.  During the consent interaction, the AS presents the requested
+       operation to the user and captures the user's confirmation
+       action.
+
+   3.  The AS enriches the authorization_evidence object with the
+       complete evidence record, including user_confirmation details and
+       the AS's cryptographic signature.
+
+   4.  The enriched authorization details is included in the token
+       response and bound to the issued access token.
+
+   This approach ensures that authorization evidence is structured as a
+   first-class authorization detail rather than a standalone JWT claim,
+   enabling consistent handling across OAuth flows and composability
+   with other authorization details types.
+
+2.  Terminology
+
+   User Confirmation:  An explicit action by the user (e.g., clicking
+      "Allow") to approve an authorization request.
+
+   Displayed Content:  The human-readable description of the operation
+      shown to the user during the consent flow.
+
+   Evidence:  A cryptographically signed record of user confirmation,
+      including what was displayed and how the user responded.
+
+   Audit Trail:  Metadata that enables tracing from user intent through
+      system interpretation to final authorized action.
+
+   Semantic Expansion:  The process of translating user intent (e.g.,
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 4]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+      natural language) into concrete system operations.
+
+3.  The authorization_evidence Authorization Details Type
+
+   The authorization_evidence authorization details type contains a
+   record of the user's confirmation action during the authorization
+   process.  Following the RAR enriched response pattern ([RFC9396]
+   Section 7.1), the client requests this type and the AS enriches it
+   with the complete evidence record.
+
+3.1.  Type Definition
+
+   Type Identifier:  authorization_evidence
+
+   Usage:  authorization_details in authorization requests and token
+      responses
+
+3.2.  Client Request
+
+   A client requests authorization evidence by including an
+   authorization_evidence authorization details object in its
+   authorization request.  The client typically includes minimal fields,
+   indicating that evidence is requested:
+
+   {
+     "authorization_details": [
+       {
+         "type": "authorization_evidence"
+       }
+     ]
+   }
+
+                                  Figure 1
+
+   The client MAY include optional fields to indicate preferences, such
+   as specific audit trail requirements.  However, the AS has final
+   authority over the evidence content based on the actual consent
+   interaction.
+
+3.3.  Enriched Response
+
+   After the user completes the consent interaction, the AS enriches the
+   authorization_evidence object with the complete evidence record.  The
+   enriched authorization details is included in the token response:
+
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 5]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   {
+     "authorization_details": [
+       {
+         "type": "authorization_evidence",
+         "evidence": {
+           "id": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+           "user_confirmation": {
+             "displayed_content": "Add items under $50 to cart",
+             "user_action": "confirmed_via_button_click",
+             "timestamp": 1731320595
+           },
+           "as_signature": "eyJhbGciOiJFUzI1NiJ9..MEUCIQDx...",
+           "audit_trail": {
+             "semantic_expansion_level": "medium",
+             "proposal_ref": "urn:uuid:proposal-xyz"
+           }
+         }
+       }
+     ]
+   }
+
+                                  Figure 2
+
+3.4.  Evidence Object Structure
+
+   The evidence object within the authorization_evidence authorization
+   details type contains the following fields:
+
+   {
+     "evidence": {
+       "id": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+       "user_confirmation": {
+         "displayed_content": "Add items under $50 to cart",
+         "user_action": "confirmed_via_button_click",
+         "timestamp": 1731320595
+       },
+       "as_signature": "eyJhbGciOiJFUzI1NiJ9..MEUCIQDx..."
+     }
+   }
+
+                                  Figure 3
+
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 6]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+3.5.  Field Definitions
+
+    +===================+======+===========+==========================+
+    | Field             |Type  |Requirement| Description              |
+    +===================+======+===========+==========================+
+    | id                |string|REQUIRED   | Unique identifier for    |
+    |                   |      |           | this evidence record.    |
+    |                   |      |           | The value MUST use a URI |
+    |                   |      |           | or URN format with at    |
+    |                   |      |           | least 128 bits of        |
+    |                   |      |           | collision resistance.    |
+    |                   |      |           | UUID URNs (e.g.,         |
+    |                   |      |           | "urn:uuid:f81d4fae-7dec- |
+    |                   |      |           | 11d0-a765-00a0c91e6bf6") |
+    |                   |      |           | are RECOMMENDED.         |
+    +-------------------+------+-----------+--------------------------+
+    | user_confirmation |object|REQUIRED   | Details of the user's    |
+    |                   |      |           | confirmation action.     |
+    +-------------------+------+-----------+--------------------------+
+    | as_signature      |string|REQUIRED   | AS signature over the    |
+    |                   |      |           | confirmation record.     |
+    +-------------------+------+-----------+--------------------------+
+
+                      Table 1: Evidence Object Fields
+
+3.5.1.  user_confirmation Object
+
+   +=================+===========+===========+=========================+
+   |Field            |Type       |Requirement| Description             |
+   +=================+===========+===========+=========================+
+   |displayed_content|string     |REQUIRED   | The text shown to user  |
+   |                 |           |           | for confirmation.       |
+   +-----------------+-----------+-----------+-------------------------+
+   |user_action      |string     |REQUIRED   | How the user confirmed  |
+   |                 |           |           | the operation.  The     |
+   |                 |           |           | value is a free-form    |
+   |                 |           |           | string, but             |
+   |                 |           |           | implementations SHOULD  |
+   |                 |           |           | use values from the     |
+   |                 |           |           | following set for       |
+   |                 |           |           | interoperability:       |
+   |                 |           |           | button_click,           |
+   |                 |           |           | biometric_confirmation, |
+   |                 |           |           | pin_entry,              |
+   |                 |           |           | voice_confirmation,     |
+   |                 |           |           | hardware_key,           |
+   |                 |           |           | implicit_consent.       |
+   |                 |           |           | Custom values MAY be    |
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 7]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   |                 |           |           | used for deployment-    |
+   |                 |           |           | specific confirmation   |
+   |                 |           |           | mechanisms.             |
+   +-----------------+-----------+-----------+-------------------------+
+   |timestamp        |NumericDate|REQUIRED   | When the confirmation   |
+   |                 |           |           | occurred.               |
+   +-----------------+-----------+-----------+-------------------------+
+
+                     Table 2: user_confirmation Fields
+
+3.6.  AS Signature
+
+   The as_signature field contains a cryptographic signature from the
+   Authorization Server over the evidence record.  This signature:
+
+   *  Proves the AS witnessed the user's consent;
+
+   *  Ensures the evidence has not been tampered with;
+
+   *  Provides strong evidence of user consent for dispute resolution
+      (subject to trust in the AS, as discussed in Section 8).
+
+   The signature MUST be computed over the following fields of the
+   evidence object:
+
+   *  id
+
+   *  user_confirmation (entire object)
+
+   The as_signature field itself MUST be excluded from the signature
+   computation.  The signature format MUST be a detached JWS [RFC7515]
+   in Compact Serialization using the AS's signing key.  In detached
+   Compact Serialization (see RFC 7515 Appendix F), the payload portion
+   is omitted, resulting in the format "header..signature".
+
+   The signature input is constructed using the following deterministic
+   algorithm:
+
+   1.  Create a new JSON object containing only the id and
+       user_confirmation fields copied from the evidence object.  No
+       other fields from the evidence object are included.
+
+   2.  Apply the JSON Canonicalization Scheme (JCS) as defined in
+       [RFC8785] to the JSON object from the previous step, producing a
+       deterministic byte string.
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 8]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   3.  Compute a detached JWS (Compact Serialization) over the JCS
+       output from Step 2 using the AS's private signing key.  The
+       resulting value (header..signature) is stored in the as_signature
+       field of the evidence object.
+
+   To verify an as_signature, the verifier reconstructs the JCS input by
+   performing Steps 1 and 2 above on the received evidence object
+   (excluding the as_signature field), then verifies the detached JWS
+   using the AS's public key.  Any extension fields present in the
+   evidence object beyond id, user_confirmation, and as_signature MUST
+   NOT be included in the JCS input and therefore are not covered by the
+   signature.
+
+   Note: In examples throughout this document, the as_signature value is
+   shown in abbreviated form for readability.  Actual values MUST use
+   the detached JWS Compact Serialization format described above.
+
+   The key used to sign the evidence record MAY be the same key used to
+   sign the access token, or it MAY be a separate dedicated key.  When a
+   separate key is used, implementations MUST ensure that the evidence
+   signing key is associated with the AS through a verifiable mechanism
+   (e.g., published in the AS's JWKS endpoint as defined in [RFC7517]).
+   Using a dedicated evidence signing key enables independent key
+   rotation without affecting token validation.
+
+4.  The audit_trail Sub-object
+
+   The audit_trail sub-object provides metadata for semantic
+   traceability, enabling analysis of how user intent was interpreted
+   and translated into authorized operations.  It is included within the
+   evidence object in the authorization_evidence authorization details
+   type.
+
+4.1.  Structure
+
+   {
+     "audit_trail": {
+       "semantic_expansion_level": "medium",
+       "proposal_ref": "urn:uuid:proposal-xyz"
+     }
+   }
+
+                                  Figure 4
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026                [Page 9]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+4.2.  Field Definitions
+
+   +==========================+========+=============+=================+
+   | Field                    | Type   | Requirement | Description     |
+   +==========================+========+=============+=================+
+   | evidence_ref             | string | OPTIONAL    | Reference to a  |
+   |                          |        |             | related         |
+   |                          |        |             | evidence        |
+   |                          |        |             | record by ID.   |
+   |                          |        |             | Can be used to  |
+   |                          |        |             | link this       |
+   |                          |        |             | audit trail to  |
+   |                          |        |             | another         |
+   |                          |        |             | evidence        |
+   |                          |        |             | record, such    |
+   |                          |        |             | as the          |
+   |                          |        |             | original        |
+   |                          |        |             | consent in a    |
+   |                          |        |             | delegation      |
+   |                          |        |             | chain.          |
+   +--------------------------+--------+-------------+-----------------+
+   | semantic_expansion_level | string | OPTIONAL    | Degree of       |
+   |                          |        |             | interpretation  |
+   |                          |        |             | applied (none,  |
+   |                          |        |             | low, medium,    |
+   |                          |        |             | high).          |
+   +--------------------------+--------+-------------+-----------------+
+   | proposal_ref             | URI    | OPTIONAL    | Reference to    |
+   |                          |        |             | the original    |
+   |                          |        |             | authorization   |
+   |                          |        |             | proposal, the   |
+   |                          |        |             | agent's         |
+   |                          |        |             | initial         |
+   |                          |        |             | request         |
+   |                          |        |             | describing the  |
+   |                          |        |             | intended        |
+   |                          |        |             | operation       |
+   |                          |        |             | before the AS   |
+   |                          |        |             | applied policy  |
+   |                          |        |             | evaluation,     |
+   |                          |        |             | scope           |
+   |                          |        |             | reduction, or   |
+   |                          |        |             | user consent    |
+   |                          |        |             | modifications.  |
+   |                          |        |             | The value is    |
+   |                          |        |             | an opaque URI   |
+   |                          |        |             | assigned by     |
+   |                          |        |             | the AS for      |
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 10]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   |                          |        |             | internal        |
+   |                          |        |             | correlation;    |
+   |                          |        |             | no protocol     |
+   |                          |        |             | for retrieving  |
+   |                          |        |             | the proposal    |
+   |                          |        |             | content via     |
+   |                          |        |             | this URI is     |
+   |                          |        |             | defined by      |
+   |                          |        |             | this            |
+   |                          |        |             | specification.  |
+   |                          |        |             | This enables    |
+   |                          |        |             | post-hoc        |
+   |                          |        |             | comparison      |
+   |                          |        |             | between what    |
+   |                          |        |             | the agent       |
+   |                          |        |             | originally      |
+   |                          |        |             | requested and   |
+   |                          |        |             | what was        |
+   |                          |        |             | ultimately      |
+   |                          |        |             | authorized.     |
+   +--------------------------+--------+-------------+-----------------+
+
+                        Table 3: audit_trail Fields
+
+4.3.  Semantic Expansion Levels
+
+   The semantic_expansion_level field indicates how much the system
+   interpreted or expanded the user's original intent.  The following
+   four values form a closed set; implementations MUST NOT use values
+   outside this set:
+
+   none:  No interpretation; user specified exact parameters.  Example:
+      User explicitly sets "transfer $100 to account X".
+
+   low:  Minor defaults applied.  Example: User says "add to cart" and
+      the system defaults quantity to 1 and selects the user's saved
+      shipping address.
+
+   medium:  Significant interpretation of qualitative terms.  Example:
+      User says "buy cheap headphones" and the system maps "cheap" to a
+      price ceiling of $50 and selects a specific product category.
+
+   high:  Substantial expansion from a high-level goal into a multi-step
+      plan.  Example: User says "plan my trip to Tokyo" and the agent
+      derives flight search, hotel booking, and itinerary creation as
+      separate authorized operations.
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 11]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+5.  Audit Trail Purposes
+
+   The evidence and audit trail objects serve several important
+   purposes:
+
+   +================+=================================================+
+   | Purpose        | Description                                     |
+   +================+=================================================+
+   | Intent         | Records what the user intended, preventing      |
+   | Provenance     | disputes about authorization scope.             |
+   +----------------+-------------------------------------------------+
+   | Action         | Documents how the system translated intent into |
+   | Interpretation | operations, showing the reasoning process.      |
+   +----------------+-------------------------------------------------+
+   | Semantic       | Reveals any expansions or defaults applied,     |
+   | Transparency   | enabling users to understand what was           |
+   |                | authorized.                                     |
+   +----------------+-------------------------------------------------+
+   | User           | Provides timestamped proof that the user        |
+   | Confirmation   | reviewed and approved the operation.            |
+   +----------------+-------------------------------------------------+
+   | Accountability | Enables post-hoc analysis to determine          |
+   | Support        | responsibility for erroneous transactions.      |
+   +----------------+-------------------------------------------------+
+
+               Table 4: Purposes of Authorization Evidence
+
+6.  Authorization Server Processing
+
+6.1.  Evidence Collection from User Interaction
+
+   The evidence object records the outcome of a user consent
+   interaction.  Before the AS can generate a signed evidence record, it
+   must first present a consent interface to the user and capture the
+   user's response.  This section describes the general consent-to-
+   evidence pattern and provides a concrete example using the JWT Grant
+   Interaction Response flow.
+
+6.1.1.  General Consent-to-Evidence Pattern
+
+   Regardless of the specific OAuth grant type, evidence collection
+   follows a common pattern:
+
+   1.  The AS receives an authorization request from a client (which may
+       be acting on behalf of an AI agent).
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 12]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   2.  The AS determines that user consent is required and presents a
+       consent interface to the user.  The consent interface displays a
+       human-readable description of the requested operation (the
+       displayed_content).
+
+   3.  The user reviews the displayed content and performs a
+       confirmation action (e.g., clicking an "Allow" button, providing
+       biometric input, entering a PIN).
+
+   4.  The AS captures the interaction details (what was displayed, what
+       action the user took, when, and in what session context) and
+       constructs the evidence object as defined in Section 3.
+
+   5.  The AS signs the evidence record and includes it in the issued
+       access token.
+
+   The following diagram illustrates this pattern:
+
+   Client/Agent          Authorization Server              User
+       |                         |                          |
+       |-- authorization req --->|                          |
+       |                         |                          |
+       |                         |--- consent UI ---------->|
+       |                         |    (displayed_content)   |
+       |                         |                          |
+       |                         |<-- user action ----------|
+       |                         |    (button_click, etc.)  |
+       |                         |                          |
+       |                         |  [capture evidence]      |
+       |                         |  [sign with as_signature]|
+       |                         |                          |
+       |<-- access token --------|                          |
+       |    (with evidence)      |                          |
+       |                         |                          |
+
+                                  Figure 5
+
+6.1.2.  Consent UI to Evidence Field Mapping
+
+   Each field in the evidence object corresponds to a specific event
+   during the consent interaction:
+
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 13]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+       +==============+===================+========================+
+       | Consent UI   | Evidence Field    | Description            |
+       | Event        |                   |                        |
+       +==============+===================+========================+
+       | AS renders   | displayed_content | The text shown to the  |
+       | consent page |                   | user describing the    |
+       |              |                   | requested operation    |
+       +--------------+-------------------+------------------------+
+       | User         | user_action       | How the user responded |
+       | confirms or  |                   | (button click,         |
+       | denies       |                   | biometric, PIN, etc.)  |
+       +--------------+-------------------+------------------------+
+       | Confirmation | timestamp         | Server-side time when  |
+       | timestamp    |                   | the user's action was  |
+       |              |                   | received               |
+       +--------------+-------------------+------------------------+
+
+            Table 5: Consent UI Event to Evidence Field Mapping
+
+6.1.3.  Example: JWT Grant Interaction Response Flow
+
+   The JWT Grant Interaction Response
+   ([I-D.parecki-oauth-jwt-grant-interaction-response]) defines a
+   mechanism for AI agents to obtain user consent from an external
+   Authorization Server.  The following sequence shows how evidence is
+   collected during this flow:
+
+   1.  An AI agent sends a token request to the AS using a JWT
+       authorization grant ([RFC7523]), including the requested scope
+       and authorization_details.
+
+   2.  The AS validates the agent's identity and determines that user
+       interaction is required.  It responds with an
+       interaction_required error containing an interaction_uri (a URL
+       hosted by the AS for the consent interface) and a polling
+       interval.
+
+   3.  The agent opens the interaction_uri in the user's browser.  The
+       AS presents a consent page showing the interpreted operation
+       (e.g., "Add items under $50 to cart on your behalf").
+
+   4.  The user reviews the displayed content and clicks "Allow".  The
+       AS captures:
+
+       *  displayed_content: the operation description shown on the
+          consent page;
+
+       *  user_action: button_click;
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 14]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+       *  timestamp: the server time of the click.
+
+   5.  The AS constructs the evidence object, computes the as_signature
+       per Section 3, and stores the evidence record.
+
+   6.  The agent polls the token endpoint.  Upon detecting that the user
+       has completed interaction, the AS issues an access token
+       containing the signed evidence object.
+
+   AI Agent          External AS                      User
+      |                   |                            |
+      |-- token request ->|                            |
+      |                   |                            |
+      |<- interaction_    |                            |
+      |   required        |                            |
+      |   (interaction_   |                            |
+      |    uri, interval) |                            |
+      |                   |                            |
+      |-- open interaction_uri in browser ------------>|
+      |                   |                            |
+      |                   |--- consent UI ------------>|
+      |                   |    "Add items under $50    |
+      |                   |     to cart on your behalf"|
+      |                   |                            |
+      |                   |<-- user clicks [Allow] ----|
+      |                   |                            |
+      |                   |  [capture evidence fields] |
+      |                   |  [compute as_signature]    |
+      |                   |                            |
+      |-- poll token  --->|                            |
+      |   endpoint        |                            |
+      |                   |                            |
+      |<- access token ---|                            |
+      |   (with evidence) |                            |
+      |                   |                            |
+
+                                  Figure 6
+
+6.1.4.  Applicability to Other Flows
+
+   The consent-to-evidence pattern described above applies to any OAuth
+   flow that involves user interaction.  For example:
+
+   *  *Authorization Code Grant*: The AS presents a consent screen
+      during the /authorize redirect.  Evidence is collected when the
+      user approves or denies the request.
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 15]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   *  *CIBA (Client-Initiated Backchannel Authentication)*: The AS
+      delivers a consent request to the user's authentication device
+      (e.g., push notification).  Evidence captures the user's out-of-
+      band confirmation action.
+
+   *  *Consent-Only Flow*: When the user already holds a valid session
+      and the AS determines that only operation-specific consent is
+      needed (not re-authentication), the AS presents a targeted consent
+      prompt.  Evidence records the scoped approval.
+
+   Flows that do not involve user interaction (e.g., Client Credentials
+   Grant without user context) cannot produce evidence records, since
+   there is no user confirmation to record.  Such flows MAY still use
+   the audit_trail sub-object (Section 4) for semantic traceability
+   without user confirmation evidence.
+
+6.2.  Evidence Generation
+
+   When issuing an access token with evidence, the AS MUST:
+
+   1.  Record the exact content displayed to the user during consent;
+
+   2.  Capture the user's confirmation action and timestamp;
+
+   3.  Generate a unique evidence identifier;
+
+   4.  Sign the evidence fields (id and user_confirmation) with the AS's
+       private key using JCS canonicalization;
+
+   5.  Include the authorization_evidence authorization details in the
+       access token.
+
+7.  Resource Server Processing
+
+7.1.  Evidence Verification
+
+   Resource Servers MAY verify the evidence object by:
+
+   1.  Extracting the as_signature from the evidence;
+
+   2.  Verifying the signature using the AS's public key;
+
+   3.  Confirming that the evidence id and timestamp are consistent with
+       the token's iat claim (i.e., the user confirmation occurred
+       before or at token issuance);
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 16]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   Note: The displayed_content field records what was shown to the user
+   during consent.  The RS typically does not have direct knowledge of
+   the consent interaction and therefore cannot independently verify
+   this field.  Instead, the RS relies on the AS signature as proof that
+   the AS witnessed the user's consent to the described operation.
+
+7.2.  Audit Logging
+
+   Resource Servers SHOULD log evidence information for audit purposes,
+   including:
+
+   *  Evidence ID;
+
+   *  User confirmation timestamp;
+
+   *  Displayed content summary;
+
+   *  Operation performed;
+
+   *  Outcome (success/failure).
+
+8.  Security Considerations
+
+   This section discusses security considerations specific to
+   authorization evidence in OAuth 2.0.  General OAuth 2.0 security
+   considerations, including token threats and countermeasures, are
+   described in [RFC6819].
+
+8.1.  Signature Verification
+
+   The AS signature over the evidence fields (id and user_confirmation)
+   is critical for evidence integrity.  Implementations MUST:
+
+   *  Use strong cryptographic algorithms (e.g., RS256, ES256);
+
+   *  Protect AS signing keys appropriately;
+
+   *  Rotate keys periodically with proper key management.
+
+8.2.  Evidence Tampering and Trust in the AS
+
+   The evidence object is protected by the access token's signature.
+   However, the as_signature field provides an additional layer of
+   protection specifically for the user confirmation record.
+
+   It is important to understand the trust boundary of the evidence
+   mechanism: the as_signature provides cryptographic proof that the AS
+   *recorded* a user confirmation.  It does not independently prove that
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 17]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   the user *actually* consented.  The AS controls both the consent
+   interaction and the signing key, so a compromised or malicious AS
+   could fabricate evidence records.  Trust in the evidence record
+   therefore depends on trust in the AS and its operational security.
+   Deployments requiring stronger non-repudiation guarantees SHOULD
+   supplement this mechanism with user-side signatures or independent
+   consent auditing.
+
+8.3.  Replay Attacks
+
+   Evidence records are bound to specific access tokens.  The evidence
+   ID and timestamp help detect attempts to reuse evidence across
+   different authorization contexts.
+
+8.4.  Token-Evidence Binding
+
+   The evidence object is embedded in a signed access token ([RFC9068]),
+   which provides integrity protection at the token level.  The inner
+   as_signature provides a second, independent integrity layer
+   specifically over the user confirmation record.  This dual-signature
+   design ensures that:
+
+   *  Evidence cannot be moved from one token to another without
+      detection (the token signature would not cover the new evidence);
+
+   *  Evidence fields cannot be modified within a valid token (the inner
+      AS signature would be invalidated);
+
+   *  Evidence can be independently verified even when extracted from
+      the token (e.g., via introspection) using the as_signature.
+
+   Implementations MUST NOT copy an evidence object from one access
+   token into another without re-validating the as_signature and
+   confirming that the evidence id and timestamp are consistent with the
+   new token's context.
+
+   The dual-signature design described above applies to signed JWT
+   access tokens ([RFC9068]).  When opaque (reference) tokens are used,
+   the evidence object is not embedded in the token itself and MUST be
+   retrieved by the RS via token introspection ([RFC7662]) or a
+   dedicated evidence retrieval endpoint.  In this case, the
+   as_signature provides the sole integrity protection for the evidence
+   record, and implementations MUST ensure that the transport between
+   the RS and the introspection or retrieval endpoint is protected with
+   TLS.
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 18]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+8.5.  Cross-Domain Evidence Verification
+
+   In cross-domain scenarios where the RS is in a different trust domain
+   than the AS, the RS must be able to verify the as_signature using the
+   AS's public key.  Implementations SHOULD:
+
+   *  Publish the AS's evidence signing keys at a well-known JWKS
+      endpoint ([RFC7517]) accessible to the RS;
+
+   *  Include a kid (Key ID) in the JWS header of the as_signature to
+      enable key selection;
+
+   *  Support key caching at the RS with appropriate cache invalidation
+      to balance performance and key freshness.
+
+   When the AS and RS belong to different administrative domains, trust
+   establishment for the evidence signing key MAY be facilitated through
+   a trust framework, federation agreement, or explicit key distribution
+   mechanism.
+
+8.6.  Privacy Considerations
+
+   Evidence records contain information about user consent interactions,
+   including what was displayed to the user and how they responded.
+   Implementations should consider applicable data protection
+   requirements when storing and processing evidence records.
+
+9.  IANA Considerations
+
+9.1.  OAuth Authorization Details Type Registration
+
+   This specification registers the following authorization details type
+   in the "OAuth Authorization Details Types" registry established by
+   [RFC9396]:
+
+   Type:  authorization_evidence
+
+   Description:  Authorization evidence and audit trail information
+      using the enriched response pattern, providing cryptographic proof
+      of user consent for authorization proof and audit purposes.
+
+   Change Controller:  IETF
+
+   Specification Document:  Section 3 of this document
+
+10.  References
+
+10.1.  Normative References
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 19]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <https://www.rfc-editor.org/info/rfc6749>.
+
+   [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
+              Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
+              2015, <https://www.rfc-editor.org/info/rfc7515>.
+
+   [RFC7517]  Jones, M., "JSON Web Key (JWK)", RFC 7517,
+              DOI 10.17487/RFC7517, May 2015,
+              <https://www.rfc-editor.org/info/rfc7517>.
+
+   [RFC6819]  Lodderstedt, T., Ed., McGloin, M., and P. Hunt, "OAuth 2.0
+              Threat Model and Security Considerations", RFC 6819,
+              DOI 10.17487/RFC6819, January 2013,
+              <https://www.rfc-editor.org/info/rfc6819>.
+
+   [RFC8785]  Rundgren, A., Jordan, B., and S. Erdtman, "JSON
+              Canonicalization Scheme (JCS)", RFC 8785,
+              DOI 10.17487/RFC8785, June 2020,
+              <https://www.rfc-editor.org/info/rfc8785>.
+
+   [RFC8259]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", STD 90, RFC 8259,
+              DOI 10.17487/RFC8259, December 2017,
+              <https://www.rfc-editor.org/info/rfc8259>.
+
+   [RFC9068]  Bertocci, V., "JSON Web Token (JWT) Profile for OAuth 2.0
+              Access Tokens", RFC 9068, DOI 10.17487/RFC9068, October
+              2021, <https://www.rfc-editor.org/info/rfc9068>.
+
+   [RFC9396]  Lodderstedt, T., Richer, J., and B. Campbell, "OAuth 2.0
+              Rich Authorization Requests", RFC 9396,
+              DOI 10.17487/RFC9396, May 2023,
+              <https://www.rfc-editor.org/info/rfc9396>.
+
+10.2.  Informative References
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 20]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   [RFC7662]  Richer, J., Ed., "OAuth 2.0 Token Introspection",
+              RFC 7662, DOI 10.17487/RFC7662, October 2015,
+              <https://www.rfc-editor.org/info/rfc7662>.
+
+   [RFC7523]  Jones, M., Campbell, B., and C. Mortimore, "JSON Web Token
+              (JWT) Profile for OAuth 2.0 Client Authentication and
+              Authorization Grants", RFC 7523, DOI 10.17487/RFC7523, May
+              2015, <https://www.rfc-editor.org/info/rfc7523>.
+
+   [I-D.liu-oauth-rego-policy]
+              Liu, D., "Rego Policy Language for OAuth 2.0", Work in
+              Progress, Internet-Draft, draft-liu-oauth-rego-policy-00,
+              June 2026, <https://datatracker.ietf.org/doc/html/draft-
+              liu-oauth-rego-policy-00>.
+
+   [I-D.parecki-oauth-jwt-grant-interaction-response]
+              Parecki, A., Campbell, B., and D. Liu, "JWT Authorization
+              Grant with Interaction Response", Work in Progress,
+              Internet-Draft, draft-parecki-oauth-jwt-grant-interaction-
+              response-00, June 2026,
+              <https://datatracker.ietf.org/doc/html/draft-parecki-
+              oauth-jwt-grant-interaction-response-00>.
+
+   [I-D.ietf-oauth-identity-assertion-authz-grant]
+              Ying, K. and B. Campbell, "OAuth 2.0 Identity Assertion
+              Authorization Grant", Work in Progress, Internet-Draft,
+              draft-ietf-oauth-identity-assertion-authz-grant, January
+              2026, <https://datatracker.ietf.org/doc/html/draft-ietf-
+              oauth-identity-assertion-authz-grant>.
+
+Appendix A.  Complete Example
+
+   The following shows a complete access token with
+   authorization_details containing both authorization_evidence and
+   rego_policy authorization details types:
+
+   This example illustrates how the authorization_evidence type
+   complements the rego_policy type ([I-D.liu-oauth-rego-policy]).
+   While the Rego policy defines *what operations are permitted* (the
+   behavioral constraint contract), the authorization evidence records
+   *why those operations were authorized* (the user's explicit consent).
+   Together, they enable a Resource Server to enforce fine-grained
+   policy while maintaining a verifiable audit trail linking each
+   authorized action back to user intent.
+
+   The act.sub value uses the wit:// URI scheme to identify the acting
+   agent by its workload identity, as defined in the Identity Assertion
+   Authorization Grant
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 21]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+   ([I-D.ietf-oauth-identity-assertion-authz-grant]).  The hash suffix
+   provides a collision-resistant binding between the URI and the
+   agent's attestation evidence.
+
+   {
+     "iss": "https://as.example.com",
+     "sub": "user_12345",
+     "aud": "https://api.shop.example",
+     "exp": 1731369540,
+     "iat": 1731320700,
+     "jti": "urn:uuid:token-abc-123",
+
+     "act": {
+       "sub": "wit://myassistant.example/sha256.abc123..."
+     },
+
+     "authorization_details": [
+       {
+         "type": "authorization_evidence",
+         "evidence": {
+           "id": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+           "user_confirmation": {
+             "displayed_content": "Add items under $50 to cart",
+             "user_action": "confirmed_via_button_click",
+             "timestamp": 1731320595
+           },
+           "as_signature": "eyJhbGciOiJFUzI1NiJ9..MEUCIQDx...",
+           "audit_trail": {
+             "semantic_expansion_level": "medium",
+             "proposal_ref": "urn:uuid:proposal-xyz"
+           }
+         }
+       },
+       {
+         "type": "rego_policy",
+         "policy": {
+           "type": "rego",
+           "uri": "https://as.example.com/policies/policy-cart-50",
+           "entry_point": "allow"
+         }
+       }
+     ]
+   }
+
+                                  Figure 7
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 22]
+
+Internet-Draft        OAuth Authorization Evidence             June 2026
+
+
+Acknowledgments
+
+   The authors would like to thank Brian Campbell for his valuable
+   feedback and insightful discussions during the development of this
+   specification.  His contributions helped shape key design decisions.
+
+Authors' Addresses
+
+   Dapeng Liu
+   Alibaba Group
+   Email: max.ldp@alibaba-inc.com
+
+
+   Hongru Zhu
+   Alibaba Group
+   Email: hongru.zhr@alibaba-inc.com
+
+
+   Suresh Krishnan
+   Cisco
+   Email: suresh.krishnan@gmail.com
+
+
+   Aaron Parecki
+   Okta
+   Email: aaron@parecki.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 25 December 2026               [Page 23]

--- a/interop/oauth-liu-composition/drafts/draft-liu-oauth-chain-delegation-00.txt
+++ b/interop/oauth-liu-composition/drafts/draft-liu-oauth-chain-delegation-00.txt
@@ -1,0 +1,2576 @@
+
+
+
+
+Web Authorization Protocol                                        D. Liu
+Internet-Draft                                                    H. Zhu
+Intended status: Standards Track                           Alibaba Group
+Expires: 8 December 2026                                     S. Krishnan
+                                                                   Cisco
+                                                              A. Parecki
+                                                                    Okta
+                                                             6 June 2026
+
+
+                     Delegation Chain for OAuth 2.0
+                  draft-liu-oauth-chain-delegation-00
+
+Abstract
+
+   RFC 8693 defines the act claim for expressing delegation semantics in
+   JWTs, including nested multi-hop actor identification.  However, act
+   captures only the identity of each actor in the chain, not the
+   authorization constraints applied at each hop, and is constructed
+   unilaterally by the Authorization Server without cryptographic
+   confirmation from the delegating agent.  This specification defines
+   the delegation_chain JWT claim as a structured delegation record
+   companion to act: an ordered array of delegation records, each
+   capturing the Authorization Server's attestation and, when present,
+   the delegated policy constraints, and optionally carrying the
+   delegator's cryptographic confirmation.  Together, act and
+   delegation_chain provide both runtime authorization and verifiable
+   delegation lineage for multi-hop agent delegation.  The specification
+   supports cross-domain delegation by composing with the identity
+   chaining transport pattern, and integrates a user interaction
+   mechanism for explicit consent when required by policy or regulation.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 8 December 2026.
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 1]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+Copyright Notice
+
+   Copyright (c) 2026 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   5
+   2.  Relationship to Existing Mechanisms . . . . . . . . . . . . .   5
+     2.1.  Relationship to the act Claim . . . . . . . . . . . . . .   5
+     2.2.  Relationship to Identity Chaining . . . . . . . . . . . .   6
+     2.3.  Relationship to Claims Transcription  . . . . . . . . . .   7
+   3.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   7
+   4.  The delegation_chain Claim  . . . . . . . . . . . . . . . . .   8
+     4.1.  Claim Definition  . . . . . . . . . . . . . . . . . . . .   8
+     4.2.  Structure . . . . . . . . . . . . . . . . . . . . . . . .   8
+     4.3.  Delegation Lifecycle  . . . . . . . . . . . . . . . . . .   9
+     4.4.  Field Definitions . . . . . . . . . . . . . . . . . . . .  10
+     4.5.  Key Resolution for Agent Identifiers  . . . . . . . . . .  13
+     4.6.  Chain Ordering  . . . . . . . . . . . . . . . . . . . . .  14
+   5.  Delegation with User Interaction  . . . . . . . . . . . . . .  14
+     5.1.  Step 1-2: Initial Authorization . . . . . . . . . . . . .  16
+     5.2.  Step 3: Delegation Request  . . . . . . . . . . . . . . .  16
+     5.3.  Step 4: User Interaction Required . . . . . . . . . . . .  17
+     5.4.  Steps 5-7: User Review and Approval . . . . . . . . . . .  18
+     5.5.  Step 8: Retry Token Exchange  . . . . . . . . . . . . . .  18
+     5.6.  Step 9: AS Validation . . . . . . . . . . . . . . . . . .  19
+     5.7.  Step 10: Token Issuance . . . . . . . . . . . . . . . . .  19
+     5.8.  Steps 11-12: API Request and Validation . . . . . . . . .  19
+     5.9.  When to Require Interaction . . . . . . . . . . . . . . .  20
+   6.  Delegation without User Interaction . . . . . . . . . . . . .  20
+   7.  Chain Extension . . . . . . . . . . . . . . . . . . . . . . .  22
+     7.1.  Evidence Propagation  . . . . . . . . . . . . . . . . . .  22
+     7.2.  For First Delegation  . . . . . . . . . . . . . . . . . .  22
+     7.3.  For Subsequent Delegations  . . . . . . . . . . . . . . .  23
+   8.  Cross-Domain Delegation . . . . . . . . . . . . . . . . . . .  24
+     8.1.  Cross-Domain Delegation Flow  . . . . . . . . . . . . . .  25
+     8.2.  Cross-Domain Trust Requirements . . . . . . . . . . . . .  26
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 2]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+     8.3.  Multi-Domain Chain Extension  . . . . . . . . . . . . . .  27
+     8.4.  Claims Transcription for Delegation . . . . . . . . . . .  27
+   9.  Resource Server Validation  . . . . . . . . . . . . . . . . .  28
+     9.1.  Signature Verification  . . . . . . . . . . . . . . . . .  28
+     9.2.  Root Authorization Anchor . . . . . . . . . . . . . . . .  28
+     9.3.  Dual-Signature Verification . . . . . . . . . . . . . . .  29
+     9.4.  Agent Identifier Status Validation  . . . . . . . . . . .  29
+     9.5.  Chain Continuity  . . . . . . . . . . . . . . . . . . . .  30
+     9.6.  Scope and Policy Validation . . . . . . . . . . . . . . .  30
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  30
+     10.1.  Threat Model . . . . . . . . . . . . . . . . . . . . . .  30
+     10.2.  Privilege Escalation Prevention  . . . . . . . . . . . .  32
+     10.3.  Chain Integrity  . . . . . . . . . . . . . . . . . . . .  32
+     10.4.  Chain Stripping Prevention . . . . . . . . . . . . . . .  33
+     10.5.  Token Protection . . . . . . . . . . . . . . . . . . . .  33
+     10.6.  Delegation Depth Limits  . . . . . . . . . . . . . . . .  35
+     10.7.  Cross-Domain Trust . . . . . . . . . . . . . . . . . . .  36
+     10.8.  Delegation Revocation  . . . . . . . . . . . . . . . . .  37
+   11. Privacy Considerations  . . . . . . . . . . . . . . . . . . .  38
+     11.1.  Data Minimization  . . . . . . . . . . . . . . . . . . .  38
+     11.2.  Cross-Domain Information Leakage . . . . . . . . . . . .  39
+     11.3.  User Consent Transparency  . . . . . . . . . . . . . . .  39
+   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  39
+     12.1.  JWT Claims Registration  . . . . . . . . . . . . . . . .  39
+     12.2.  OAuth Parameters Registration  . . . . . . . . . . . . .  40
+     12.3.  OAuth Error Registration . . . . . . . . . . . . . . . .  40
+   13. References  . . . . . . . . . . . . . . . . . . . . . . . . .  41
+     13.1.  Normative References . . . . . . . . . . . . . . . . . .  41
+     13.2.  Informative References . . . . . . . . . . . . . . . . .  42
+   Appendix A.  Complete Multi-Hop Example . . . . . . . . . . . . .  43
+   Appendix B.  Validation Checklist . . . . . . . . . . . . . . . .  45
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  46
+
+1.  Introduction
+
+   In multi-agent systems, a primary agent (Agent A) may need to
+   delegate a subset of its authorized operations to a secondary agent
+   (Agent B), which may in turn delegate further to Agent C.  Each
+   delegation hop must preserve the original user's authorization intent
+   while constraining what each downstream agent is permitted to do.
+
+   OAuth 2.0 already provides building blocks for expressing delegation.
+   RFC 8693 defines the act claim, which supports nested multi-hop actor
+   identification — enabling a token to express that Agent A delegated
+   to Agent B, which in turn delegated to Agent C.
+   [I-D.ietf-oauth-identity-chaining] defines the cross-domain transport
+   pattern combining Token Exchange ([RFC8693]) and JWT Authorization
+   Grant ([RFC7523]) to carry identity and authorization information
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 3]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   across trust domain boundaries.  Together, these mechanisms address
+   the runtime dimension of delegation: who is currently acting, and how
+   to move tokens across domains.
+
+   However, three structural gaps remain for agent delegation scenarios:
+
+   *  *Per-hop policy constraint:* The act claim identifies the actors
+      at each hop but does not record what authorization constraints
+      were applied at each delegation step.  A downstream Resource
+      Server sees the final scope but cannot verify whether intermediate
+      agents narrowed or expanded the authorization along the way.
+
+   *  *Delegator cryptographic confirmation:* The act claim is
+      constructed unilaterally by the Authorization Server.  The
+      delegating agent leaves no independent cryptographic evidence that
+      it authorized a specific delegation.  This limits non-repudiation
+      and post-hoc audit capabilities.
+
+   *  *User interaction for delegation:* Neither act nor identity
+      chaining defines a mechanism for pausing a delegation flow to
+      obtain explicit user consent.  This is a gap specific to agent
+      scenarios, where agents may autonomously delegate to other agents
+      without the user's awareness.
+
+   This specification introduces the delegation_chain claim as a
+   structured companion to act.  While act provides runtime actor
+   identification for authorization decisions, delegation_chain records
+   the full delegation history as an ordered array of delegation
+   records.  Each record captures the AS's attestation and, when
+   present, the delegated policy at that hop, and MAY additionally carry
+   the delegator's cryptographic confirmation, ensuring that neither the
+   AS nor any delegating agent can unilaterally construct or deny a
+   delegation record.  The two claims coexist in the same token: act
+   answers "who is acting now" for the Resource Server, while
+   delegation_chain answers "how was this authorization delegated, step
+   by step" for verification and compliance systems.
+
+   The delegation_chain claim addresses the delegation lineage and
+   verification dimension of complex delegation, complementing the
+   runtime semantics provided by existing OAuth mechanisms.  Cross-
+   domain delegation (Section 8) addresses the multi-domain scenario.
+   This version of the specification focuses on linear delegation
+   chains; other complex topologies such as diamond-shaped delegation,
+   where multiple paths converge on the same agent, may be addressed by
+   future extensions.
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 4]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *Scope Boundary:* This specification addresses problems that lie
+   outside the design scope of Token Exchange ([RFC8693]) and Identity
+   Chaining ([I-D.ietf-oauth-identity-chaining]).  Token Exchange
+   defines how to convert one token into another but does not record the
+   delegation lineage across multiple hops.  Identity Chaining defines
+   how to transport identity across trust domains but intentionally
+   leaves Claims Transcription representation undefined.  The three
+   problems solved by this specification — multi-hop delegation lineage,
+   delegator non-repudiation, and delegation consent interaction — are
+   orthogonal to both token conversion and cross-domain transport.
+   Absorbing this mechanism into either existing specification would
+   broaden their scope beyond their original design intent and impose
+   delegation lineage complexity on deployments that do not need it.
+
+   *Deployment Options:* A minimal deployment requires only the
+   delegation_chain claim structure (Section 4), the delegation Token
+   Exchange flow (Section 6), and the AS validation rules (Section 5.2).
+   Implementations MAY additionally support structured policy
+   (delegated_policy), user interaction (Section 5), cross-domain
+   delegation (Section 8), delegator_signature, and authorization
+   evidence propagation, depending on deployment requirements.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals.
+
+2.  Relationship to Existing Mechanisms
+
+   This section describes how the delegation_chain claim relates to
+   existing OAuth 2.0 mechanisms, establishing the precise boundary
+   between runtime delegation semantics and structured delegation
+   records.
+
+2.1.  Relationship to the act Claim
+
+   RFC 8693 defines the act claim to express that delegation has
+   occurred and to identify the acting party.  The act claim supports
+   nested multi-hop actor chains: a token can express that Agent A
+   delegated to Agent B, which delegated to Agent C, all within a single
+   nested JSON structure.  This nesting enables Resource Servers to
+   identify the current actor and trace the actor lineage for
+   authorization decisions.
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 5]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   The act claim is constructed by the Authorization Server alone: the
+   AS assembles the nested actor chain without requiring independent
+   proof from each delegating agent.  This is sufficient for runtime
+   authorization decisions but does not capture per-hop policy
+   constraints or delegator consent.
+
+   The delegation_chain claim complements act by recording the
+   delegation lineage as a structured array of signed records.  Each
+   record captures the AS's attestation (as_signature), the policy
+   constraints applied at that hop (scope, and — when present —
+   delegated_policy), and — when present — the delegator's own
+   cryptographic proof (delegator_signature).  This enables:
+
+   *  *Per-hop policy constraints:* Each delegation record carries the
+      policy that was applied at that hop, not just the final scope.
+      This preserves the full delegation lineage and enables policy
+      narrowing verification.
+
+   *  *Delegator proof:* The optional delegator_signature on each record
+      provides independent evidence of each delegator's consent,
+      enabling non-repudiation that the AS alone cannot provide.
+
+   *  *User interaction:* The delegation flow supports optional user
+      consent interaction (Section 5) at each hop, which is outside the
+      scope of act.
+
+   In a token carrying both claims, act identifies the current actor for
+   the Resource Server's authorization decision, while delegation_chain
+   provides the structured delegation record from the current actor back
+   to the original human principal.  The delegatee_id of the most recent
+   delegation record (index 0) MUST match the act.sub value, ensuring
+   continuity between the two claims.
+
+2.2.  Relationship to Identity Chaining
+
+   [I-D.ietf-oauth-identity-chaining] defines a general-purpose pattern
+   for preserving identity and authorization information across trust
+   domains, combining Token Exchange ([RFC8693]) and JWT Authorization
+   Grant ([RFC7523]).  It addresses the *transport dimension* of cross-
+   domain delegation: how to move a token from Domain A to Domain B
+   while preserving the user identity and authorization context.
+
+   This specification reuses the identity chaining transport for cross-
+   domain delegation (Section 8) and adds agent-specific extensions:
+
+   *  *delegation_chain claim:* An explicit, cryptographically signed
+      delegation record of all delegation hops, which identity chaining
+      does not define;
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 6]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *Policy narrowing enforcement:* Each delegation hop MUST carry a
+      scope equal to or narrower than its predecessor; structured policy
+      (delegated_policy) is additionally enforced when present;
+
+   *  *Optional dual-signature security:* Both the AS and the delegating
+      agent can sign each delegation record, preventing unilateral
+      forgery; deployments that omit delegator_signature rely on AS
+      signature alone;
+
+   *  *Agent Identifier URIs:* Resolvable URI-based identity for
+      delegators and delegatees, supporting WIT and SPIFFE schemes.
+
+   The key distinction in deployment context is scope: identity chaining
+   addresses general cross-domain identity propagation (human users, CI/
+   CD pipelines, SSO extension), while this specification profiles that
+   transport specifically for agent-to-agent delegation with delegation
+   lineage requirements.
+
+2.3.  Relationship to Claims Transcription
+
+   Section 2.5 of [I-D.ietf-oauth-identity-chaining] defines Claims
+   Transcription — the process by which Authorization Servers add,
+   change, or remove claims when producing JWT authorization grants or
+   access tokens during cross-domain flows.  That specification
+   explicitly leaves the representation of transcribed claims undefined:
+   "The representation of transcribed claims and their format is not
+   defined in this specification."
+
+   The delegation_chain claim provides one such representation.  When
+   delegation crosses a trust domain boundary, each delegation record
+   captures the transcribed policy (when present, delegated_policy) and
+   the cryptographic evidence of the transcribing party (the AS via
+   as_signature, and — when present — the delegator via
+   delegator_signature).  This enables the receiving domain to verify
+   not just _what_ was transcribed but _who authorized the
+   transcription_ and under what constraints — closing the
+   representation gap left by identity chaining.
+
+   Implementations using identity chaining for cross-domain delegation
+   SHOULD include the delegation_chain claim in the JWT authorization
+   grant as a structured Claims Transcription format, enabling the
+   receiving AS to validate the delegation lineage before issuing a
+   local access token.
+
+3.  Terminology
+
+   Delegator:  An agent that transfers a subset of its authorization to
+      another agent.
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 7]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   Delegatee:  An agent that receives delegated authorization from a
+      delegator.
+
+   Delegation Hop:  A single transfer of authorization from one agent to
+      another.
+
+   Delegation Chain:  An ordered sequence of delegation hops from the
+      most recent back to the original authorization.
+
+   Root Authorization:  The original authorization granted by a human
+      principal, from which all delegations derive.
+
+   Workload Identity Token (WIT):  A token that cryptographically
+      attests to the identity of a workload or agent, typically issued
+      by a workload identity provider.  A WIT URI is a URI that
+      identifies a specific agent and references the WIT bound to that
+      agent's identity.
+
+   Agent Identifier:  A URI used to identify a delegating or delegatee
+      agent in a delegation record.  This specification defines two URI
+      schemes for agent identifiers: WIT URIs (wit://) and SPIFFE IDs
+      (spiffe://).  The identifier MUST be resolvable to a verifiable
+      public key for signature verification when delegator_signature is
+      present.
+
+4.  The delegation_chain Claim
+
+4.1.  Claim Definition
+
+   Claim Name:  delegation_chain
+
+   Claim Type:  Array of Objects
+
+   Usage:  Access tokens (JWT format)
+
+   Specification:  [RFC7519] (JWT)
+
+4.2.  Structure
+
+   The delegation_chain is an ordered array of delegation records, from
+   most recent to earliest.  Each record represents one delegation hop.
+
+   The following example shows a delegation record with WIT-based agent
+   identifiers, a machine-enforceable structured policy, a root evidence
+   reference, and dual signatures:
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 8]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+{
+  "delegation_chain": [
+    {
+      "delegator_id": "wit://agent-a.example/sha256.aaa111...",
+      "delegatee_id": "wit://agent-b.example/sha256.bbb222...",
+      "delegation_timestamp": 1734516900,
+      "root_evidence_ref": "evidence-root-abc123",
+      "delegated_policy": {
+        "type": "rego",
+        "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n  input.item_id == \"123\"\n}",
+        "entry_point": "allow"
+      },
+      "operation_summary": "Delegate inventory check for item 123",
+      "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..MEYCIQD...",
+      "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDx..."
+    }
+  ]
+}
+
+                               Figure 1
+
+4.3.  Delegation Lifecycle
+
+   A delegation record transitions through four phases during its
+   lifecycle:
+
+   1.  *Delegation Proposal Phase:* The delegating agent creates a
+       delegation proposal that includes the delegatee identity, the
+       delegated scope, and — when structured policy is used — the
+       delegated policy and operation context.
+
+   2.  *Delegation Interaction Phase (CONDITIONAL):* When the
+       Authorization Server determines that user interaction is required
+       before the delegation can be authorized — for example, when
+       delegating to a new agent for the first time, when the delegation
+       involves high-risk operations, or when the delegation crosses
+       trust domain boundaries — the AS returns an interaction_required
+       response as defined in
+       [I-D.parecki-oauth-jwt-grant-interaction-response].  The
+       delegating agent launches the interaction URI so the user can
+       review and approve the delegation.  Upon user approval, the agent
+       retries the delegation request.  This phase is skipped when the
+       AS determines that no additional user interaction is needed
+       (e.g., the delegation is covered by a standing authorization or
+       the policy has been pre-approved).  Implementations that do not
+       require user interaction MAY omit this phase entirely.
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026                [Page 9]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   3.  *Delegation Enforcement Phase:* The Authorization Server
+       validates the delegation request, verifies the delegator's token,
+       confirms that any required user interaction has been completed,
+       and signs the delegation record upon successful validation.  For
+       the first delegation (User to Agent A), the AS MAY additionally
+       verify the user's identity using an identity assertion grant
+       ([I-D.ietf-oauth-identity-assertion-authz-grant]).
+
+   4.  *Chain Propagation Phase:* The signed delegation record is
+       embedded into an access token's delegation_chain claim, enabling
+       multi-hop propagation within or across trust domains.
+
+   This four-phase model ensures cryptographic binding between user
+   authorization, agent identity, and policy constraints throughout the
+   delegation chain, with explicit user interaction support when
+   required.
+
+4.4.  Field Definitions
+
+   +====================+===========+===========+=======================================+
+   |Field               |Type       |Requirement|Description                            |
+   +====================+===========+===========+=======================================+
+   |delegator_id        |string     |REQUIRED   |A URI identifying the delegating agent.|
+   |                    |           |           |This specification defines two URI     |
+   |                    |           |           |schemes: wit:// (WIT URI) and spiffe://|
+   |                    |           |           |(SPIFFE ID).  The URI MUST be          |
+   |                    |           |           |resolvable to a verifiable public key  |
+   |                    |           |           |for delegator_signature verification.  |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |delegatee_id        |string     |REQUIRED   |A URI identifying the receiving agent. |
+   |                    |           |           |The same URI scheme considerations as  |
+   |                    |           |           |delegator_id apply.                    |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |delegation_timestamp|NumericDate|REQUIRED   |When this delegation was authorized.   |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |scope               |string     |OPTIONAL   |The delegated scope at this hop,       |
+   |                    |           |           |expressed as a space-delimited list of |
+   |                    |           |           |scope values ([RFC6749], Section 3.3). |
+   |                    |           |           |When present, this field captures the  |
+   |                    |           |           |scope explicitly authorized by the     |
+   |                    |           |           |delegator and is included in the       |
+   |                    |           |           |signature computation to prevent scope |
+   |                    |           |           |expansion by a compromised AS.  When   |
+   |                    |           |           |omitted, the delegated scope is        |
+   |                    |           |           |conveyed through the access token's    |
+   |                    |           |           |scope claim and the delegated_policy   |
+   |                    |           |           |field (if present).                    |
+   +--------------------+-----------+-----------+---------------------------------------+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 10]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   |delegated_policy    |object     |OPTIONAL   |A machine-readable expression of the   |
+   |                    |           |           |authorization constraints that apply to|
+   |                    |           |           |this delegation hop.  The delegated    |
+   |                    |           |           |policy MUST be equal to or more        |
+   |                    |           |           |restrictive than the delegator's       |
+   |                    |           |           |policy; policy or scope expansion is   |
+   |                    |           |           |NOT allowed.  See below for deployment-|
+   |                    |           |           |specific structure.                    |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |operation_summary   |string     |OPTIONAL   |Human-readable description of delegated|
+   |                    |           |           |operation.                             |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |root_evidence_ref   |string     |CONDITIONAL|An opaque identifier referencing the   |
+   |                    |           |           |root authorization event — the original|
+   |                    |           |           |consent granted by the human principal |
+   |                    |           |           |from which all delegations in the chain|
+   |                    |           |           |derive.  This field MUST be present for|
+   |                    |           |           |the first delegation (User to Agent A) |
+   |                    |           |           |when structured evidence is used and   |
+   |                    |           |           |SHOULD be propagated through the chain.|
+   |                    |           |           |The format of the identifier and the   |
+   |                    |           |           |mechanism for resolving it are         |
+   |                    |           |           |deployment-specific: implementations   |
+   |                    |           |           |using a structured authorization       |
+   |                    |           |           |evidence model (such as the one        |
+   |                    |           |           |described in                           |
+   |                    |           |           |[I-D.liu-oauth-authorization-evidence])|
+   |                    |           |           |SHOULD set this value to the           |
+   |                    |           |           |evidence.id from the root token; other |
+   |                    |           |           |deployments MAY use any stable, unique |
+   |                    |           |           |identifier (e.g., a consent record ID  |
+   |                    |           |           |or an audit log entry reference) that  |
+   |                    |           |           |enables post-hoc retrieval of the      |
+   |                    |           |           |original authorization context.        |
+   |                    |           |           |Implementations not using structured   |
+   |                    |           |           |authorization evidence MAY omit this   |
+   |                    |           |           |field.                                 |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |delegator_signature |string     |RECOMMENDED|Cryptographic signature from the       |
+   |                    |           |           |delegating agent's private key over    |
+   |                    |           |           |this delegation record.  This provides |
+   |                    |           |           |dual-signature security alongside      |
+   |                    |           |           |as_signature, preventing a malicious AS|
+   |                    |           |           |from forging unauthorized delegations  |
+   |                    |           |           |and ensuring non-repudiation.          |
+   |                    |           |           |Implementations SHOULD include this    |
+   |                    |           |           |field on every delegation record.  It  |
+   |                    |           |           |MAY be omitted when the AS is the sole |
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 11]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   |                    |           |           |trust anchor and the deployment does   |
+   |                    |           |           |not require independent delegator non- |
+   |                    |           |           |repudiation.                           |
+   +--------------------+-----------+-----------+---------------------------------------+
+   |as_signature        |string     |REQUIRED   |AS signature over this delegation      |
+   |                    |           |           |record.                                |
+   +--------------------+-----------+-----------+---------------------------------------+
+
+                  Table 1: delegation_chain Record Fields
+
+   The structure of the delegated_policy field depends on the deployment
+   profile:
+
+   *  *Scope-based (typical):* This field is typically absent.  The
+      delegation is governed solely by the OAuth scope parameter, and
+      the Resource Server applies scope-based authorization.  When this
+      field is absent, the Resource Server MUST apply scope-based
+      authorization only.
+
+   *  *Structured policy:* This field carries a machine-enforceable
+      policy.  The policy language and comparison mechanism are
+      implementation-specific: implementations MAY use a Rego policy
+      structure (with type, content, and entry_point sub-fields, as
+      described in [I-D.liu-oauth-rego-policy]), ALFA (Attribute-based
+      Logical Framework for Authorization), XACML, or any other policy
+      representation agreed upon by the delegator and the Authorization
+      Server.
+
+   The delegation_timestamp MUST satisfy the following constraints:
+
+   *  It MUST be less than or equal to the access token's iat (issued
+      at) claim, since the delegation event occurs before or at the time
+      the token is issued;
+
+   *  It MUST be greater than or equal to the delegation_timestamp of
+      the preceding delegation record (the record at the next higher
+      array index), ensuring that timestamps are monotonically non-
+      increasing from index 0 (most recent) to index N (earliest);
+
+   *  It MUST be within the validity period of the delegator's token at
+      the time of the delegation request (i.e., greater than or equal to
+      the delegator token's iat and less than or equal to the delegator
+      token's exp).
+
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 12]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  At the time the AS processes the delegation request, the timestamp
+      SHOULD be within an acceptable freshness window relative to the
+      AS's current time.  A RECOMMENDED maximum skew is 5 minutes in
+      either direction.  Timestamps outside this window SHOULD be
+      rejected to mitigate replay attacks (see Section 10).
+
+   The as_signature, and the delegator_signature when present, MUST be
+   computed over the same set of fields using JSON Canonicalization
+   Scheme (JCS) as defined in [RFC8785]:
+
+   *  delegator_id
+
+   *  delegatee_id
+
+   *  delegation_timestamp
+
+   *  scope (if present)
+
+   *  delegated_policy (if present)
+
+   *  operation_summary (if present)
+
+   *  root_evidence_ref (if present)
+
+   Both signature fields MUST be excluded from their respective
+   signature computations.  The signatures MUST use detached JWS format
+   ([RFC7515] Appendix F) with appropriate algorithm identifiers (e.g.,
+   RS256, ES256).
+
+   When the delegator_signature is present (RECOMMENDED), it uses the
+   delegating agent's agent-identifier-bound private key, while
+   as_signature uses the Authorization Server's signing key.  This dual-
+   signature approach, when both signatures are present, ensures:
+
+   *  *Malicious AS Prevention:* A compromised AS cannot unilaterally
+      forge delegations without the delegator's consent;
+
+   *  *Non-Repudiation:* The delegator cannot deny having authorized the
+      delegation;
+
+   *  *Complete Trust Chain:* User → AS → Delegator → Delegatee.
+
+4.5.  Key Resolution for Agent Identifiers
+
+   The delegator_signature (and any verification of the delegatee's
+   identity) requires the relying party to resolve the agent identifier
+   to a verifiable public key.  The resolution mechanism depends on the
+   URI scheme used in the delegator_id or delegatee_id field:
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 13]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *wit://*: The WIT URI is resolved via the workload identity
+      provider's attestation bundle, which contains or references the
+      agent's public key (e.g., via SPIFFE bundle endpoints);
+
+   *  *spiffe://*: The SPIFFE ID is resolved via the SPIFFE Bundle
+      Endpoint protocol, which provides the agent's X.509-SVID or JWT-
+      SVID containing the public key.
+
+   Implementations SHOULD document the supported URI schemes and their
+   resolution mechanisms in deployment-specific configuration.  If the
+   relying party cannot resolve the agent identifier to a trusted public
+   key, it MUST treat the delegator_signature as unverifiable.
+
+4.6.  Chain Ordering
+
+   The array MUST be ordered from most recent delegation to earliest:
+
+   *  Index 0: Most recent delegation (delegator → current token holder)
+
+   *  Index N: Earliest delegation (first agent after human
+      authorization)
+
+   This ordering allows efficient validation starting from the immediate
+   delegator.
+
+5.  Delegation with User Interaction
+
+   This section defines the delegation flow with explicit user
+   interaction, used when the Authorization Server determines that user
+   consent is required before delegation.  This flow extends the JWT
+   Authorization Grant Interaction Response
+   ([I-D.parecki-oauth-jwt-grant-interaction-response]) to OAuth 2.0
+   Token Exchange requests ([RFC8693], grant_type=token-exchange).
+
+   The user interaction mechanism ensures that delegation decisions
+   remain under user control even in complex multi-agent scenarios.
+   When the Authorization Server determines that user interaction is
+   required, the flow includes an explicit consent step before token
+   issuance.
+
++--------+       +---------+       +--------+       +---------+       +---------+
+|  User  |       | Agent A |       |   AS   |       | Agent B |       |   RS    |
++--------+       +---------+       +--------+       +---------+       +---------+
+    |                 |                 |                |                 |
+    | (1) Initial     |                 |                |                 |
+    |  Authorization  |                 |                |                 |
+    |  (OAuth flow)   |                 |                |                 |
+    |---------------> |                 |                |                 |
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 14]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+    |                 |                 |                |                 |
+    |                 | (2) Token A     |                |                 |
+    |                 |  (root, no      |                |                 |
+    |                 |   chain)        |                |                 |
+    |                 |<----------------|                |                 |
+    |                 |                 |                |                 |
+    |                 | (3) Token Exchange (delegation)  |                 |
+    |                 |---------------->|                |                 |
+    |                 |  - subject_token                 |                 |
+    |                 |  - delegatee_id                  |                 |
+    |                 |  - authorization_details         |                 |
+    |                 |                 |                |                 |
+    |                 | (4) AS determines user interaction required        |
+    |                 |     interaction_required         |                 |
+    |                 |     interaction_uri              |                 |
+    |                 |     interval=5                   |                 |
+    |                 |<----------------|                |                 |
+    |                 |                 |                |                 |
+    | (5) Launch      |                 |                |                 |
+    |  interaction    |                 |                |                 |
+    |<----------------|                 |                |                 |
+    |                 |                 |                |                 |
+    | (6) Review &    |                 |                |                 |
+    |  Approve        |                 |                |                 |
+    |  delegation     |                 |                |                 |
+    |---------------------------------->|                |                 |
+    |                 |                 |                |                 |
+    |                 | (7) Redirect    |                |                 |
+    |                 |<----------------|                |                 |
+    |                 |                 |                |                 |
+    |                 | (8) Retry Token Exchange         |                 |
+    |                 |---------------->|                |                 |
+    |                 |                 |                |                 |
+    |                 |                 | (9) Validate   |                 |
+    |                 |                 | - Interaction  |                 |
+    |                 |                 |   completed    |                 |
+    |                 |                 | - Token A valid|                 |
+    |                 |                 | - Scope subset |                 |
+    |                 |                 |                |                 |
+    |                 |                 | (10) Issue Token B               |
+    |                 |                 |--------------->|                 |
+    |                 |                 | with delegation_chain            |
+    |                 |                 |                |                 |
+    |                 |                 |                | (11) API Request|
+    |                 |                 |                |---------------->|
+    |                 |                 |                |                 |
+    |                 |                 |                |  (12) Validate  |
+    |                 |                 |                |   chain         |
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 15]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+    |                 |                 |                |<----------------|
+
+                               Figure 2
+
+5.1.  Step 1-2: Initial Authorization
+
+   Agent A obtains authorization from the user through a standard OAuth
+   flow.  The resulting token does not contain a delegation_chain (it is
+   the root authorization).
+
+5.2.  Step 3: Delegation Request
+
+   Agent A initiates delegation using OAuth 2.0 Token Exchange
+   [RFC8693].  The request includes delegation-specific parameters to
+   identify the delegatee and the delegated policy.
+
+   The following example shows a delegation request with WIT-based agent
+   identity, client attestation, and a structured policy carried via
+   authorization_details:
+
+POST /token HTTP/1.1
+Host: as.example.com
+Content-Type: application/x-www-form-urlencoded
+OAuth-Client-Attestation: eyJ0eXAiOiJ3aXQrand0IiwiYWxnIjoiRVMyNTYifQ...
+OAuth-Client-Attestation-PoP: eyJ0eXAiOiJvYXV0aC1jbGllbnQtYXR0ZXN0...
+
+grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange
+&subject_token=eyJhbGciOiJSUzI1NiJ9...
+&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token
+&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token
+&scope=cart%3Aread
+&authorization_details=%5B%7B%22type%22%3A%22rego_policy%22%2C%22policy%22
+  %3A%7B%22type%22%3A%22rego%22%2C%22content%22%3A%22package+agent...%22%2C
+  %22entry_point%22%3A%22allow%22%7D%7D%5D
+&delegatee_id=wit%3A%2F%2Fagent-b.example%2Fsha256.bbb222...
+
+                               Figure 3
+
+   This specification defines the following extension parameter for use
+   with Token Exchange [RFC8693] requests:
+
+   delegatee_id:  REQUIRED for delegation requests.  A URI identifying
+      the agent receiving the delegated authorization.  Implementations
+      SHOULD use a WIT URI when workload identity attestation is
+      available, but MAY use other URI schemes (see Table 1).  The AS
+      uses this value to bind the issued token to the delegatee's
+      identity and to populate the delegatee_id field in the
+      delegation_chain record.
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 16]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   The standard and extension parameters in the request are:
+
+   *  subject_token: Agent A's current access token;
+
+   *  subject_token_type: urn:ietf:params:oauth:token-type:access_token;
+
+   *  authorization_details (OPTIONAL): Carries the delegated policy in
+      a structured format (e.g., type "rego_policy"), which MUST be
+      equal to or more restrictive than Agent A's policy;
+
+   *  delegatee_id: The agent identifier URI of the delegatee agent
+      (Agent B);
+
+   *  scope (OPTIONAL): Requested scope for the delegated token, which
+      MUST be a subset of Agent A's scope.
+
+   *  requested_token_type (OPTIONAL): Defaults to
+      urn:ietf:params:oauth:token-type:access_token.  Implementations
+      MAY request JWT format using urn:ietf:params:oauth:token-type:jwt.
+
+   *  resource (OPTIONAL): The identifier of the target Authorization
+      Server when the delegation crosses a trust domain boundary, as
+      defined in [I-D.ietf-oauth-identity-chaining].  When present, the
+      AS issues a JWT authorization grant suitable for presentation to
+      the target AS instead of a direct access token.
+
+   *  audience (OPTIONAL): A well-known or logical name of the target
+      Authorization Server, as an alternative to resource for cross-
+      domain delegation.  One of resource or audience is REQUIRED when
+      the delegation targets an agent in a different trust domain.
+
+   *  interaction_callback_uri (OPTIONAL): The URI to which the AS will
+      redirect the user's browser after a delegation interaction is
+      complete, as defined in
+      [I-D.parecki-oauth-jwt-grant-interaction-response].  This
+      parameter is used in conjunction with the interaction_required
+      response to signal the client that user interaction has been
+      completed.
+
+5.3.  Step 4: User Interaction Required
+
+   When the Authorization Server determines that user interaction is
+   required (see Section 5.9 for the decision criteria), the AS responds
+   with an interaction_required error containing:
+
+   *  interaction_uri: The URI where the user reviews and approves the
+      delegation;
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 17]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  interval: The minimum polling interval in seconds (default: 5);
+
+   *  expires_in: The number of seconds until the interaction session
+      expires.
+
+   [I-D.parecki-oauth-jwt-grant-interaction-response] defines the
+   interaction response mechanism for the JWT Authorization Grant (RFC
+   7523, grant_type=jwt-bearer).  This specification extends that
+   interaction response to apply to OAuth 2.0 Token Exchange requests
+   ([RFC8693], grant_type=token-exchange) used for delegation.  The same
+   response semantics are applicable to Token Exchange requests.  The AS
+   associates the interaction session with the Token Exchange request
+   parameters (including the subject_token, delegatee_id, and requested
+   delegation policy) so that upon user approval, the same Token
+   Exchange request can be retried to obtain the delegated token.
+
+5.4.  Steps 5-7: User Review and Approval
+
+   Agent A launches the interaction_uri in the user's browser, where the
+   AS presents the delegation details for user review:
+
+   *  Identity of the delegatee agent (Agent B)
+
+   *  Delegated policy and scope
+
+   *  Operation summary
+
+   *  Whether the delegation crosses trust domain boundaries
+
+   The user reviews the delegation details and approves or denies the
+   delegation request.  If the client provided an
+   interaction_callback_uri, the AS redirects the user's browser to that
+   URI as a signal that the interaction is complete.
+
+5.5.  Step 8: Retry Token Exchange
+
+   Agent A retries the original Token Exchange request (with the same
+   parameters).  The AS recognizes the associated interaction session
+   and proceeds with validation.
+
+   While the interaction is pending, subsequent Token Exchange requests
+   from Agent A with the same parameters SHOULD return an
+   interaction_pending error.  The agent MUST wait at least the number
+   of seconds specified by the interval parameter between polling
+   requests.
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 18]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+5.6.  Step 9: AS Validation
+
+   The AS MUST perform the following validations:
+
+   1.  Interaction Completion (CONDITIONAL): When user interaction was
+       required (see Section 5.3), verify that it has been completed and
+       approved for this delegation request.  This step is skipped when
+       the AS determines that no user interaction is needed.
+
+   2.  Token Validity: Verify Agent A's token is valid and not revoked.
+
+   3.  Delegation Permission: Confirm the token permits delegation
+       (e.g., includes a delegation scope or flag).
+
+   4.  Scope Subset: Verify the requested scope is a subset of Agent A's
+       authorized scope (equal to or narrower).
+
+   5.  Delegatee Authentication: Validate Agent B's agent identifier
+       (delegatee_id) to confirm the delegatee is authentic and
+       currently active.
+
+   6.  Chain Depth: Optionally enforce maximum delegation depth.
+
+   7.  Request Freshness: Reject the delegation request if the
+       delegation_timestamp in the proposal (or the request time as
+       observed by the AS) is outside an acceptable time window.  A
+       RECOMMENDED maximum skew is 5 minutes.  This prevents replay of
+       previously captured delegation requests.
+
+5.7.  Step 10: Token Issuance
+
+   Upon successful validation, the AS issues a new token for Agent B
+   with:
+
+   *  sub: The original user (unchanged)
+
+   *  act: Agent B's identity
+
+   *  delegation_chain: Extended with a new record for this hop
+
+   *  Reduced scope (as requested)
+
+5.8.  Steps 11-12: API Request and Validation
+
+   Agent B uses the delegated token to access resources at the Resource
+   Server (RS).  The RS validates the token and verifies the
+   delegation_chain as defined in Section 9.
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 19]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+5.9.  When to Require Interaction
+
+   The Authorization Server has discretion in determining when the
+   Delegation Interaction Phase is triggered.  The following guidance is
+   provided to help AS implementations make consistent decisions:
+
+   *  *First-time delegation to a new agent:* When the delegatee agent
+      has not been previously authorized by the user, interaction SHOULD
+      be required to ensure the user is aware of and consents to the new
+      delegation relationship.
+
+   *  *High-risk operations:* When the delegated policy includes
+      operations classified as high-risk (e.g., financial transactions,
+      data deletion, access to sensitive resources), interaction SHOULD
+      be required regardless of whether the agent has been previously
+      authorized.
+
+   *  *Cross-domain delegation:* When a delegation hop crosses a trust
+      domain boundary, interaction SHOULD be required unless a pre-
+      established cross-domain trust agreement covers the specific
+      delegation pattern.
+
+   *  *Standing authorization:* When the user has previously granted a
+      standing authorization that explicitly covers the delegation
+      pattern (e.g., "Agent A may delegate inventory operations to any
+      agent in the inventory.example.com domain"), interaction MAY be
+      skipped.
+
+   *  *Policy pre-approval:* When the delegated policy is equal to or
+      more restrictive than a previously user-approved policy for the
+      same delegatee, interaction MAY be skipped.
+
+6.  Delegation without User Interaction
+
+   In scenarios where user interaction is not required — for example,
+   when the delegation is covered by a standing authorization or the
+   policy has been pre-approved — the AS MAY skip the user interaction
+   step and proceed directly with token issuance.  This simplified flow
+   reduces latency and user friction for routine delegation scenarios.
+
+   When none of the conditions listed in Section 5.9 apply, the AS
+   responds to the Token Exchange request with a success response
+   containing the delegated token, bypassing the interaction_required
+   step.
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 20]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
++--------+       +---------+       +--------+       +---------+       +---------+
+|  User  |       | Agent A |       |   AS   |       | Agent B |       |   RS    |
++--------+       +---------+       +--------+       +---------+       +---------+
+    |                 |                 |                |                 |
+    | (1) Initial     |                 |                |                 |
+    |  Authorization  |                 |                |                 |
+    |  (OAuth flow)   |                 |                |                 |
+    |---------------->|                 |                |                 |
+    |                 |                 |                |                 |
+    |                 | (2) Token A     |                |                 |
+    |                 |  (root, no      |                |                 |
+    |                 |   chain)        |                |                 |
+    |                 |<----------------|                |                 |
+    |                 |                 |                |                 |
+    |                 | (3) Token Exchange (delegation)  |                 |
+    |                 |---------------->|                |                 |
+    |                 |  - subject_token                 |                 |
+    |                 |  - delegatee_id                  |                 |
+    |                 |  - authorization_details         |                 |
+    |                 |                 |                |                 |
+    |                 |                 | (4) Validate   |                 |
+    |                 |                 | - Token A valid|                 |
+    |                 |                 | - Scope subset |                 |
+    |                 |                 | - Standing auth|                 |
+    |                 |                 |   or pre-approved                |
+    |                 |                 |                |                 |
+    |                 |                 | (5) Issue Token B                |
+    |                 |                 |--------------->|                 |
+    |                 |                 | with delegation_chain            |
+    |                 |                 |                |                 |
+    |                 |                 |                |  (6) API Request|
+    |                 |                 |                |---------------->|
+    |                 |                 |                |                 |
+    |                 |                 |                |  (7) Validate   |
+    |                 |                 |                |   chain         |
+    |                 |                 |                |<----------------|
+
+                               Figure 4
+
+   The Token Exchange request format, parameters, and validation rules
+   are identical to those defined in Section 5.  The only difference is
+   that the AS does not require user interaction before issuing the
+   delegated token.
+
+   This simplified flow is appropriate when:
+
+   *  The delegation is covered by a standing authorization previously
+      granted by the user;
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 21]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  The delegated policy is equal to or more restrictive than a
+      previously user-approved policy;
+
+   *  The delegation does not cross trust domain boundaries;
+
+   *  The delegation does not involve high-risk operations;
+
+   *  No regulatory requirements mandate explicit user consent.
+
+   Authorization Servers SHOULD log all decisions to skip user
+   interaction as part of their audit trail.  Implementations using
+   structured authorization evidence (as described in
+   [I-D.liu-oauth-authorization-evidence] or a deployment-specific
+   model) SHOULD record the skip decision in the audit_trail claim;
+   other deployments MAY record it in an application-specific audit log.
+
+7.  Chain Extension
+
+   When the AS issues a delegated token, it extends the
+   delegation_chain:
+
+7.1.  Evidence Propagation
+
+   When the AS issues a delegated token within the same trust domain and
+   structured authorization evidence is used, it SHOULD propagate the
+   evidence and audit_trail claims from the subject token (or root
+   token) into the newly issued delegated token.  This ensures that
+   Resource Servers can verify the original user consent without needing
+   to retrieve the root token separately.  When evidence is propagated,
+   the root_evidence_ref field in each delegation record SHOULD match
+   the evidence.id value in the propagated evidence claim.  For cross-
+   domain evidence propagation, see Section 8.
+
+   Implementations not using structured authorization evidence are not
+   required to carry evidence or audit_trail claims.  In deployments
+   that do not use structured authorization evidence, the
+   root_evidence_ref field (when present) serves as an opaque reference
+   to the original authorization event, resolvable through deployment-
+   specific mechanisms such as an audit log query or a consent
+   management API.
+
+7.2.  For First Delegation
+
+   If Agent A's token has no delegation_chain (root authorization), the
+   AS creates a new chain with one entry.  The following shows an
+   *extended* first delegation record:
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 22]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+{
+  "delegation_chain": [
+    {
+      "delegator_id": "wit://agent-a.example/sha256.aaa111...",
+      "delegatee_id": "wit://agent-b.example/sha256.bbb222...",
+      "delegation_timestamp": 1734516900,
+      "root_evidence_ref": "evidence-root-abc123",
+      "delegated_policy": {
+        "type": "rego",
+        "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"cart_op\"\n}",
+        "entry_point": "allow"
+      },
+      "operation_summary": "Delegate cart operations",
+      "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..MEYCIQD...",
+      "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDx..."
+    }
+  ]
+}
+
+                               Figure 5
+
+   A minimal equivalent would carry only delegator_id, delegatee_id,
+   delegation_timestamp, operation_summary, and as_signature, with the
+   delegated scope expressed via the token's scope claim (e.g.,
+   cart:read).
+
+7.3.  For Subsequent Delegations
+
+   If Agent B further delegates to Agent C, the AS prepends a new
+   record.  The following shows an *extended* two-hop chain:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 23]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+{
+  "delegation_chain": [
+    {
+      "delegator_id": "wit://agent-b.example/sha256.bbb222...",
+      "delegatee_id": "wit://agent-c.example/sha256.ccc333...",
+      "delegation_timestamp": 1734517800,
+      "root_evidence_ref": "evidence-root-abc123",
+      "delegated_policy": {
+        "type": "rego",
+        "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n  input.item_id == \"123\"\n}",
+        "entry_point": "allow"
+      },
+      "operation_summary": "Check inventory for item 123",
+      "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..MEYCIQD...",
+      "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDx..."
+    },
+    {
+      "delegator_id": "wit://agent-a.example/sha256.aaa111...",
+      "delegatee_id": "wit://agent-b.example/sha256.bbb222...",
+      "delegation_timestamp": 1734516900,
+      "root_evidence_ref": "evidence-root-abc123",
+      "delegated_policy": {
+        "type": "rego",
+        "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"cart_op\"\n}",
+        "entry_point": "allow"
+      },
+      "operation_summary": "Delegate cart operations",
+      "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..MEYCIQD1...",
+      "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDx..."
+    }
+  ]
+}
+
+                               Figure 6
+
+   With scope-based delegation, the same two-hop chain would omit
+   delegated_policy, delegator_signature, and root_evidence_ref from
+   each record.  The scope narrowing (e.g., cart:read inventory:read to
+   inventory:read:item:123) is expressed solely via each delegated
+   token's scope claim.
+
+8.  Cross-Domain Delegation
+
+   When delegation hops span multiple trust domains — each with its own
+   Authorization Server — this specification combines the
+   delegation_chain mechanism with the cross-domain transport pattern
+   defined in [I-D.ietf-oauth-identity-chaining].
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 24]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+8.1.  Cross-Domain Delegation Flow
+
+   Consider an agent in Trust Domain A that needs to delegate a subset
+   of its authorization to an agent in Trust Domain B:
+
+ +-------+  +-------+  +-------+  +-------+  +-------+       +-------+
+ | User  |  |Agent A|  | AS-A  |  |Agent B|  | AS-B  |       | RS-B  |
+ +-------+  +-------+  +-------+  +-------+  +-------+       +-------+
+      |          |          |          |          |              |
+      | (1) Auth |          |          |          |              |
+      |--------->|          |          |          |              |
+      |          |          |          |          |              |
+      |          | (2) Token Exchange  |          |              |
+      |          |  (delegation +      |          |              |
+      |          |   resource=AS-B)    |          |              |
+      |          |--------->|          |          |              |
+      |          |          |          |          |              |
+      |          | (3) JWT  |          |          |              |
+      |          | Authoriz |          |          |              |
+      |          | Grant    |          |          |              |
+      |          |<---------|          |          |              |
+      |          |          |          |          |              |
+      |          | (3.5) Agent A transfers JWT Grant to Agent B  |
+      |          |------------------------------->|              |
+      |          |          |          |          |              |
+      |          |          |          |          |(4) Present JWT Grant
+      |          |          |          |          |------------->|
+      |          |          |          |          |              |
+      |          |          |          |          |(5) Validate  |
+      |          |          |          |          |- JWT signatur|
+      |          |          |          |          |- delegation  |
+      |          |          |          |          |- policy      |
+      |          |          |          |          |              |
+      |          |          |          |          |(6) Access    |
+      |          |          |          |          |  Token       |
+      |          |          |          |<---------|              |
+      |          |          |          |          |              |
+      |          |          |          |(7) API Req              |
+      |          |          |          |------------------------>|
+      |          |          |          |          |              |
+
+                                Figure 7
+
+   1.  Agent A obtains initial authorization from the user in Trust
+       Domain A (root authorization, no delegation_chain).
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 25]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   2.  Agent A initiates a delegation Token Exchange with AS-A,
+       including the resource parameter set to AS-B's identifier (as
+       defined in [I-D.ietf-oauth-identity-chaining]).  This signals
+       that the delegation targets an agent in Trust Domain B.
+
+   3.  AS-A validates the delegation, creates a delegation record, and
+       returns a JWT authorization grant containing the delegation_chain
+       claim.  If user interaction is required, the interaction flow
+       described in Section 5 is used before this step.
+
+   4.  Agent A transfers the JWT authorization grant to Agent B through
+       an out-of-band mechanism (e.g., a secure internal channel).
+       Agent B presents the JWT authorization grant to AS-B using the
+       JWT Bearer grant type ([RFC7523]), as defined in
+       [I-D.ietf-oauth-identity-chaining].
+
+   5.  AS-B validates the JWT grant signature, verifies the
+       delegation_chain (including AS-A's signature on each record), and
+       confirms policy narrowing constraints.
+
+   6.  AS-B issues an access token to Agent B for Trust Domain B,
+       preserving the delegation_chain claim from the JWT authorization
+       grant.
+
+   7.  Agent B uses the access token to access resources in Trust Domain
+       B.
+
+8.2.  Cross-Domain Trust Requirements
+
+   For cross-domain delegation to function, the following trust
+   requirements MUST be satisfied:
+
+   *  *AS Trust Relationship:* AS-B MUST trust AS-A's signing key to
+      verify as_signature on delegation records issued by AS-A.  This
+      trust relationship is typically established through key exchange
+      or by publishing AS-A's public keys via Authorization Server
+      Metadata ([RFC8414]).
+
+   *  *delegation_chain Propagation:* AS-B MUST propagate the
+      delegation_chain claim from the JWT authorization grant into the
+      access token it issues, so that Resource Servers in Trust Domain B
+      can validate the full delegation lineage.
+
+   *  *Evidence Propagation:* AS-B SHOULD propagate the evidence and
+      audit_trail claims from the JWT authorization grant, enabling
+      Resource Servers in Trust Domain B to verify the original user
+      consent without contacting AS-A.  This is a SHOULD rather than a
+      MUST because cross-domain evidence propagation may be constrained
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 26]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+      by data minimization policies, privacy regulations, or trust
+      agreements between domains.  When evidence is not propagated,
+      Resource Servers in Trust Domain B MUST rely on back-channel
+      verification with AS-A or AS-B to validate the original user
+      consent.
+
+   *  *Policy Enforcement:* AS-B MUST enforce that the delegated scope
+      is equal to or narrower than the scope in the JWT authorization
+      grant; scope expansion across domain boundaries is NOT permitted.
+      When the delegated_policy field is present, AS-B SHOULD
+      additionally verify that the policy has not been expanded.  The
+      mechanism for policy comparison is implementation- specific: for
+      simple policy representations, a structural comparison may
+      suffice; for expressive policy languages such as Rego or ALFA, the
+      receiving AS MAY rely on the originating AS's attestation (via
+      as_signature) rather than performing an independent policy-subset
+      check, which may be computationally intractable for arbitrary
+      policies.
+
+8.3.  Multi-Domain Chain Extension
+
+   When a delegation chain spans multiple domains, each domain's AS may
+   add delegation records to the chain.  The cross-domain transport uses
+   the identity chaining pattern (Token Exchange + JWT Bearer Grant) at
+   each domain boundary, while the delegation_chain accumulates records
+   from all domains.
+
+   Resource Servers validating a cross-domain delegation chain MUST:
+
+   *  Verify as_signature on each delegation record using the signing
+      key of the AS that issued that record (which may differ across
+      records);
+
+   *  Verify trust relationships between all ASes referenced in the
+      chain;
+
+   *  Verify chain continuity and policy narrowing across domain
+      boundaries.
+
+8.4.  Claims Transcription for Delegation
+
+   Section 2.5 of [I-D.ietf-oauth-identity-chaining] describes Claims
+   Transcription — the process by which Authorization Servers add,
+   change, or remove claims during cross-domain token flows — but leaves
+   the representation of transcribed claims undefined.  The
+   delegation_chain claim provides one such representation: when
+   delegation crosses a trust domain boundary, each delegation record
+   captures the transcribed policy (when present, delegated_policy), the
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 27]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   identity mapping (delegator and delegatee identifiers), and the
+   cryptographic evidence of both the transcribing AS (as_signature) and
+   — when present — the delegating agent (delegator_signature).
+
+   This enables the receiving domain's AS (AS-B) to verify not just
+   _what_ claims were transcribed but _who authorized the transcription_
+   and under what constraints — closing the representation gap left by
+   the base identity chaining specification.  AS-B SHOULD validate the
+   delegation_chain records from AS-A as part of its Claims
+   Transcription processing before issuing a local access token.
+
+9.  Resource Server Validation
+
+   Resource Servers validate the delegation_chain as follows:
+
+9.1.  Signature Verification
+
+   For each record in the chain, verify the as_signature using the AS's
+   public key.  This ensures:
+
+   *  The delegation was authorized by the AS;
+
+   *  The record has not been tampered with;
+
+   *  The delegation metadata is authentic.
+
+9.2.  Root Authorization Anchor
+
+   The last record in the chain (highest index) represents the earliest
+   delegation.  Its delegator_id identifies the agent that holds the
+   root authorization (the token directly authorized by the user).
+
+   The Resource Server SHOULD verify the root authorization anchor.
+   Since the RS typically observes only the delegated token (which
+   carries the delegation_chain), it does not have direct access to the
+   root token.  Verification can be performed through one or more of the
+   following means:
+
+   *  Using token introspection ([RFC7662]) to confirm that the earliest
+      delegator (identified by the delegator_id of the last chain
+      record) holds a valid, non-revoked root token issued by a trusted
+      AS;
+
+   *  Relying on the structural integrity of the delegation_chain itself
+      — the AS that issued the delegated token has already verified the
+      root token's validity at issuance time, and the as_signature on
+      each record attests to that verification.
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 28]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   In deployments using structured authorization evidence, the Resource
+   Server SHOULD additionally verify that the root token contains valid
+   evidence and audit_trail claims (as described in
+   [I-D.liu-oauth-authorization-evidence] or an equivalent structured
+   evidence model), providing cryptographic proof of user consent.
+   Deployments that do not carry structured evidence MAY rely on the
+   root_evidence_ref field as an opaque pointer to the original
+   authorization event, resolvable through deployment-specific
+   mechanisms.
+
+   If the RS cannot establish confidence in the root authorization
+   anchor through any available mechanism, it SHOULD reject the request.
+
+9.3.  Dual-Signature Verification
+
+   For each delegation record, the Resource Server MUST verify the
+   as_signature using the Authorization Server's public key.  When the
+   delegator_signature field is present, the Resource Server SHOULD
+   additionally verify it using the delegating agent's public key
+   (resolved as described in the Key Resolution section above).
+
+   *  *AS Signature (MUST):* Confirms the delegation was authorized by
+      the AS and the record has not been tampered with;
+
+   *  *Delegator Signature (SHOULD when present):* Confirms the
+      delegator explicitly consented to this delegation, providing non-
+      repudiation.
+
+   When both signatures are present and verified, the dual-signature
+   mechanism prevents:
+
+   *  A malicious AS from unilaterally forging delegations;
+
+   *  Delegators from denying authorized delegations (non-repudiation);
+
+   *  Unauthorized privilege escalation through compromised components.
+
+   Deployments that rely solely on as_signature accept the AS as the
+   single trust anchor for delegation records.  This is appropriate when
+   the AS is operated by a trusted authority and the deployment does not
+   require independent delegator non-repudiation.
+
+9.4.  Agent Identifier Status Validation
+
+   The Resource Server SHOULD verify the current status of all agent
+   identifiers referenced in the delegation_chain.  The verification
+   mechanism depends on the identifier scheme:
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 29]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *WIT URIs (wit://, spiffe://):* Check WIT revocation lists or
+      status endpoints, validate expiration timestamps, or query the
+      issuing identity provider for current status.
+
+   If any agent identifier in the chain has been revoked or its
+   associated key material has expired, the entire delegation_chain MUST
+   be considered invalid, even if individual records remain
+   cryptographically valid.
+
+9.5.  Chain Continuity
+
+   Verify the chain is continuous:
+
+   *  For each record at index i (where i > 0), record[i].delegator_id
+      MUST equal record[i-1].delegatee_id, ensuring that the agent who
+      received authorization in one hop is the same agent that delegates
+      in the next hop;
+
+   *  The delegatee_id of the most recent delegation record (index 0)
+      matches the token's act.sub;
+
+   *  Timestamps are in descending order.
+
+9.6.  Scope and Policy Validation
+
+   The Resource Server validates that authorization constraints have not
+   been expanded along the chain:
+
+   *  *Scope (MUST):* The scope of each delegated token MUST be equal to
+      or a subset of the scope of the preceding token in the chain.  The
+      final token's scope MUST cover the requested operation.  Scope
+      expansion at any hop invalidates the chain.
+
+   *  *Policy (CONDITIONAL):* When the delegated_policy field is
+      present, the Resource Server SHOULD verify that each hop's policy
+      is equal to or more restrictive than its predecessor's policy.
+      The mechanism for this comparison is implementation- specific.
+      For expressive policy languages where automated subset checking is
+      computationally expensive or undecidable, the RS MAY rely on the
+      AS's attestation (as_signature) as evidence that the AS already
+      performed policy narrowing validation at issuance time.
+
+10.  Security Considerations
+
+10.1.  Threat Model
+
+   This section describes the threat model underlying the
+   delegation_chain mechanism and the security properties it provides.
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 30]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *Trusted Entities:*
+
+   *  The Authorization Server (AS) is trusted to correctly validate
+      delegation requests, enforce policy narrowing, and sign delegation
+      records with its private key.  The AS is the central trust anchor
+      for the delegation chain.
+
+   *  The human principal (end user) is trusted to make informed
+      authorization decisions during consent and interaction flows.
+
+   *Adversary Capabilities:*
+
+   *  A *malicious delegatee agent* may attempt to present a token with
+      a forged or truncated delegation_chain to claim authorization it
+      does not possess.
+
+   *  A *malicious delegator agent* may attempt to delegate more
+      authorization than it was granted (privilege escalation), or may
+      deny having authorized a delegation (repudiation).
+
+   *  A *compromised AS* may attempt to forge delegation records without
+      the delegator's consent.  When the dual-signature mechanism
+      (delegator + AS) is used, it mitigates this threat; deployments
+      that rely solely on as_signature accept the AS as the sole trust
+      anchor and must ensure AS compromise detection through other
+      operational controls.
+
+   *  A *network attacker* may attempt to intercept or modify delegation
+      records in transit.  Standard TLS protections apply to all
+      protocol messages.
+
+   *  A *token thief* may attempt to steal a delegated access token
+      (e.g., by compromising an agent's storage, intercepting a token in
+      transit, or exploiting a side-channel) and present it to a
+      Resource Server as if it were the legitimate delegatee.  The thief
+      may also attempt to replay a previously captured delegation
+      request to obtain a new token.
+
+   *  A *credential thief* may attempt to steal an agent's workload
+      identity credentials (e.g., WIT signing key, SPIFFE SVID, or
+      client attestation key material) and impersonate the agent to
+      obtain unauthorized delegations from the AS.  This threat is
+      particularly severe in multi-hop chains, where a single
+      compromised agent identity can be used to initiate new delegation
+      paths.
+
+   *Security Objectives:* The delegation_chain claim provides the
+   following security properties:
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 31]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *Integrity:* Each delegation record is cryptographically signed by
+      the AS (and, when present, the delegator), preventing undetected
+      modification.
+
+   *  *Non-repudiation (CONDITIONAL):* When the delegator_signature is
+      present, it provides independent evidence that the delegation was
+      explicitly authorized by the delegator.  When omitted, deployments
+      rely on AS audit logs for non-repudiation.
+
+   *  *Scope compliance:* Mandatory scope narrowing at each hop prevents
+      privilege escalation through the chain.  When the delegated_policy
+      field is present, policy narrowing provides additional fine-
+      grained enforcement.
+
+   *  *Auditability:* The complete chain from the current actor back to
+      the original human principal enables end-to-end audit trail
+      reconstruction.
+
+10.2.  Privilege Escalation Prevention
+
+   The AS MUST ensure that delegation cannot expand privileges:
+
+   *  Delegated scope MUST be a subset of (equal to or narrower than)
+      delegator's scope;
+
+   *  Delegation depth MAY be limited;
+
+   *  Certain scopes MAY be marked non-delegatable.
+
+10.3.  Chain Integrity
+
+   The as_signature on each record, together with the token-level JWT
+   signature, ensures chain integrity through the following mechanisms:
+
+   *  *Forgery prevention:* Agents cannot forge delegation records
+      because the as_signature requires the AS's private signing key,
+      which agents do not possess.
+
+   *  *Tamper detection:* Agents cannot modify existing records because
+      any change to the signed fields (including delegator_id,
+      delegatee_id, scope, and delegated_policy) invalidates both the
+      record-level as_signature and the token-level JWT signature.
+
+   *  *Record removal detection:* Agents cannot remove records from the
+      chain because the token-level JWT signature covers the entire
+      delegation_chain claim as a single unit; any modification to the
+      array length or contents invalidates the token signature.
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 32]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *Reorder detection:* Agents cannot reorder records because the
+      token-level JWT signature covers the delegation_chain array in its
+      exact serialized form; any reordering invalidates the token
+      signature.
+
+   Additionally, the Resource Server SHOULD verify that the
+   delegation_timestamp on each record falls within a reasonable window
+   relative to the token's iat (issued-at) claim.  Timestamps that
+   significantly predate the token's issuance or fall in the future may
+   indicate a manipulated or replayed delegation record.
+
+10.4.  Chain Stripping Prevention
+
+   A malicious agent may attempt to present a token with a truncated or
+   empty delegation_chain to hide intermediate delegation hops.  For
+   example, an agent holding a token with chain [A→B→C] (three records:
+   C←B, B←A, User→A) could attempt to present only the most recent
+   record [C←B] or an empty chain, thereby concealing the earlier hops
+   from the Resource Server.
+
+   This attack is prevented by the following mechanisms:
+
+   *  *Token-level signature:* The AS signs the entire access token
+      (including the delegation_chain claim) using its private key.  Any
+      modification to the delegation_chain claim — including removal of
+      records or replacement with a shorter chain — invalidates the
+      token's signature.  The Resource Server MUST reject tokens whose
+      signature does not verify.
+
+   For opaque (non-JWT) access tokens, the Resource Server MUST use
+   token introspection ([RFC7662]) to retrieve the authoritative
+   delegation_chain from the AS, rather than trusting any client-
+   supplied chain data.
+
+10.5.  Token Protection
+
+   Delegated tokens are subject to replay and theft attacks.  The
+   following mitigations address both threats.
+
+   *Sender-constrained tokens:* Implementations SHOULD bind issued
+   access tokens to the delegatee's key material using one of the
+   following mechanisms:
+
+   *  *DPoP* ([RFC9449]): The delegatee presents a proof-of-possession
+      JWT alongside the access token.  The Resource Server verifies that
+      the DPoP proof's jkt thumbprint matches the key binding in the
+      access token.
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 33]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *Mutual TLS (mTLS):* The delegatee authenticates using a client
+      certificate whose subject or SAN is bound to the delegatee_id in
+      the delegation record.
+
+   When sender-constrained tokens are not used, the delegatee_id field
+   alone provides only application-level binding.  Deployments that
+   accept this weaker binding SHOULD compensate with shorter token
+   lifetimes and network-level controls.
+
+   *Delegation request replay:* An attacker replays a captured Token
+   Exchange request to the AS to obtain a new delegated token.
+   Mitigations include:
+
+   *  For the initial delegation hop, the AS enforces a freshness window
+      on the subject_token's iat claim (RECOMMENDED skew: 5 minutes);
+
+   *  Sender-constrained tokens on the delegating agent's access token
+      (e.g., DPoP ([RFC9449]) or OAuth-Client-Attestation) ensure that a
+      replayed request from a different endpoint fails client
+      authentication at the AS;
+
+   *  TLS protects all protocol messages from on-path capture.
+
+   *Token replay and theft:* An attacker presents a stolen delegated
+   token to a Resource Server.  Mitigations include:
+
+   *  *Short token lifetimes* (RECOMMENDED: 5 to 15 minutes) limit the
+      window during which a stolen or replayed token remains valid;
+
+   *  *Sender-constrained tokens* (DPoP or mTLS) ensure that a stolen
+      token cannot be used by a different party;
+
+   *  *Token introspection* ([RFC7662]) enables real-time revocation
+      status checking;
+
+   *  *Presenter verification:* The Resource Server MUST verify that the
+      presenter's authenticated identity matches delegatee_id of the
+      most recent delegation record (index 0);
+
+   *  *Revocation propagation:* When theft is detected, the AS SHOULD
+      revoke the compromised delegation hop, invalidating all downstream
+      tokens (see Section 10.8).
+
+
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 34]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   Implementations SHOULD use sender-constrained tokens for both the
+   delegation request and the issued delegated token, especially in
+   multi-hop chains where a stolen token could grant access across
+   multiple trust boundaries.  The delegation_chain claim additionally
+   enables post-incident forensic analysis by identifying the agents and
+   timestamps at each hop.
+
+10.6.  Delegation Depth Limits
+
+   Implementations SHOULD enforce maximum delegation depth to:
+
+   *  Prevent unbounded delegation chains;
+
+   *  Limit token size growth;
+
+   *  Simplify validation.
+
+   A RECOMMENDED default maximum depth is 5 hops.
+
+   When a delegation request would exceed the configured maximum depth,
+   the AS MUST reject the request with an OAuth 2.0 error response using
+   the error code invalid_grant and a human-readable error_description
+   indicating the maximum delegation depth has been reached.  If a
+   Resource Server receives a token whose delegation_chain length
+   exceeds its locally configured maximum depth, it SHOULD reject the
+   request regardless of signature validity, as excessively deep chains
+   may indicate a misconfigured or malicious delegation path.
+
+   Implementers should consider the impact of delegation chain depth on
+   token size.  Each delegation record typically adds 500 to 1000 bytes
+   to the token payload, including one or two detached JWS signatures
+   (approximately 200 bytes each for ES256) and, when present, the
+   structured policy content.  A 5-hop delegation chain may therefore
+   add 2.5 to 5 KB to the access token.  This can cause issues with:
+
+   *  HTTP header size limits (commonly 8 KB in default proxy
+      configurations);
+
+   *  TLS record size constraints;
+
+   *  Client and server memory consumption during token parsing.
+
+   To mitigate token size growth, implementations MAY use one or more of
+   the following strategies:
+
+   *  *Short-lived tokens with introspection:* Issue access tokens with
+      short expiration and rely on token introspection ([RFC7662]) to
+      retrieve the delegation_chain on demand;
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 35]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  *Chain by reference:* Instead of embedding the full
+      delegation_chain in the JWT, issue a compact token carrying only a
+      delegation_chain_ref — a URI pointing to the full chain stored at
+      the AS.  The Resource Server retrieves the chain via introspection
+      or a dedicated endpoint.  This approach keeps the token payload
+      constant regardless of chain depth, at the cost of an additional
+      round-trip for chain retrieval;
+
+   *  *Policy references:* Store policies in a shared policy store and
+      embed only a reference (URI) in the delegated_policy field rather
+      than the full policy content.
+
+10.7.  Cross-Domain Trust
+
+   When delegation chains span multiple trust domains, additional
+   security considerations apply:
+
+   *  *AS Key Trust and Record Attribution:* Resource Servers in each
+      trust domain must be able to verify as_signature on delegation
+      records issued by Authorization Servers in other trust domains.
+      To determine which AS signed each record, implementations SHOULD
+      use the token's iss claim to identify the AS that issued the
+      current token: during Claims Transcription at a domain boundary,
+      the receiving AS re-signs the upstream delegation records, so the
+      as_signature on all records in the chain can be verified using the
+      issuing AS's signing key.  Alternatively, deployments MAY
+      establish a mapping from agent identifier domains to AS domains
+      through deployment-specific configuration.  Cross-domain key trust
+      relationships may be established through key exchange agreements,
+      published JWKS endpoints ([RFC8414]), or a shared trust framework.
+      Failure to properly verify cross-domain AS signatures may allow
+      forged delegation records to be accepted.
+
+   *  *Claim Semantics Across Domains:* Claims such as sub, scope, and
+      policy identifiers may have different semantics across trust
+      domains.  Implementations MUST ensure that claim interpretation is
+      consistent or explicitly mapped at each domain boundary, following
+      the claims transcription guidance in
+      [I-D.ietf-oauth-identity-chaining].
+
+   *  *Revocation Propagation:* When the root authorization or any
+      intermediate delegation is revoked, all downstream delegated
+      tokens SHOULD be invalidated.  Within a single trust domain, the
+      AS can directly revoke delegated tokens.  Across trust domains,
+      implementations SHOULD mitigate the risk of stale delegated tokens
+      through one or more of the following approaches: issuing short-
+      lived delegated tokens to minimize the revocation window,
+      implementing back-channel revocation notifications between ASes
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 36]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+      (e.g., using Token Revocation [RFC7009] or a proprietary
+      notification mechanism), or requiring Resource Servers in the
+      downstream domain to perform token introspection ([RFC7662])
+      before accepting delegated tokens.
+
+   *  *Lateral Movement:* An attacker who compromises an agent in one
+      trust domain may attempt to use the delegation chain to move
+      laterally to other trust domains.  Cross-domain delegation SHOULD
+      be restricted by policy to only the trust domains explicitly
+      authorized by the original user consent.
+
+10.8.  Delegation Revocation
+
+   Revocation of delegated authorization is a critical security
+   operation.  This section defines the revocation semantics for
+   delegation chains.
+
+   *Revocation Scopes:*
+
+   *  *Root revocation:* When the original user revokes the root
+      authorization (the token without a delegation_chain), all
+      downstream delegated tokens derived from that root authorization
+      MUST be considered invalid.  Resource Servers validating a
+      delegation chain MUST verify that the root authorization remains
+      valid, either by checking the root token's status directly or by
+      using token introspection ([RFC7662]) on the root token.
+
+   *  *Intermediate hop revocation:* When a delegating agent revokes a
+      specific delegation hop (e.g., Agent A revokes its delegation to
+      Agent B), all tokens derived from that delegation — including
+      further downstream delegations (Agent B → Agent C → Agent D) —
+      MUST be considered invalid.  Resource Servers SHOULD verify that
+      no delegation record in the chain has been revoked.  Within a
+      single trust domain, this can be achieved by introspecting the
+      token associated with each hop.  In cross-domain or high-
+      throughput deployments, performing per-hop introspection may be
+      impractical; in such cases, Resource Servers MAY rely on short
+      token lifetimes combined with back-channel revocation
+      notifications to limit the window during which a revoked
+      delegation remains effective.
+
+   *  *Delegatee token revocation:* When a delegatee agent's own token
+      is revoked, only that specific token is affected.  The delegation
+      chain record itself remains valid for audit purposes, but the
+      delegatee can no longer use the delegated authorization.
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 37]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *Revocation Detection Mechanisms:* Resource Servers and downstream
+   Authorization Servers MUST implement at least one of the following
+   mechanisms to detect delegation revocation:
+
+   *  *Short-lived tokens:* Issue delegated tokens with short expiration
+      times (e.g., 5 to 15 minutes) to limit the window during which a
+      revoked delegation remains effective;
+
+   *  *Token introspection:* Perform token introspection ([RFC7662]) on
+      each token in the delegation chain before accepting the delegated
+      authorization, confirming that no token has been revoked;
+
+   *  *Back-channel revocation notifications:* Subscribe to revocation
+      events from upstream Authorization Servers using Token Revocation
+      ([RFC7009]) or a proprietary notification mechanism, enabling
+      proactive invalidation of downstream delegated tokens.
+
+   *Audit Trail Preservation:* Revocation does not retroactively modify
+   existing tokens.  Delegation records remain in previously issued
+   tokens for audit trail reconstruction purposes.  Resource Servers
+   MUST reject tokens containing revoked delegation hops (as detected
+   through the mechanisms above), but the historical record of the
+   delegation is preserved for forensic analysis.
+
+11.  Privacy Considerations
+
+   In addition to the privacy considerations outlined in [RFC8693] and
+   [RFC7519], the following privacy considerations apply to the
+   delegation_chain mechanism defined in this specification.
+
+11.1.  Data Minimization
+
+   The delegation_chain claim carries identity and authorization
+   information about the original user, all intermediate agents, and the
+   delegation policies.  As the chain grows with each hop, the amount of
+   information embedded in the token increases.  Implementations should
+   apply data minimization principles:
+
+   *  The operation_summary field is OPTIONAL and should contain only
+      the minimum information necessary for authorization decisions, not
+      detailed descriptions of user intent or behavior.
+
+   *  The delegated_policy should be scoped to the specific operations
+      being delegated, not include broader context about the user's
+      overall authorization.
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 38]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   *  Agent identifiers (delegator_id, delegatee_id) should be
+      pseudonymous where possible, avoiding direct exposure of
+      personally identifiable information.
+
+11.2.  Cross-Domain Information Leakage
+
+   When delegation chains cross trust domain boundaries, the
+   delegation_chain claim propagates user and agent identity information
+   from the originating domain to downstream domains.  This creates the
+   following privacy risks:
+
+   *  The sub claim reveals the original user's identity in the
+      originating domain to all downstream domains.  Implementations
+      should consider identifier mapping or pairwise pseudonymous
+      identifiers, following the claims transcription guidance in
+      [I-D.ietf-oauth-identity-chaining].
+
+   *  The evidence claim may contain details about the user's consent
+      interaction (e.g., displayed content, session context, channel).
+      Downstream domains receive this information.  ASes should minimize
+      the evidence payload or apply domain-specific filtering before
+      cross-domain propagation.
+
+   *  The complete delegation chain reveals the full topology of agent
+      relationships, which may be sensitive in competitive or multi-
+      tenant environments.
+
+11.3.  User Consent Transparency
+
+   When the Delegation Interaction Phase is triggered (as described in
+   Section 5), the user is presented with delegation details for review
+   and approval.  Implementations should ensure that the consent UI
+   clearly communicates:
+
+   *  The identity of the delegatee agent receiving the delegation;
+
+   *  The specific operations being delegated;
+
+   *  Whether the delegation crosses trust domain boundaries;
+
+   *  The user's ability to revoke the delegation at any time.
+
+12.  IANA Considerations
+
+12.1.  JWT Claims Registration
+
+   This specification registers the following claim in the "JSON Web
+   Token Claims" registry:
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 39]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   Claim Name:  delegation_chain
+
+   Claim Description:  An ordered array of AS-signed delegation records
+      tracing agent-to-agent authorization transfers, enabling end-to-
+      end validation of delegation lineage.
+
+   Change Controller:  IETF
+
+   Specification Document:  Section 4 of this document
+
+12.2.  OAuth Parameters Registration
+
+   This specification registers the following parameters in the "OAuth
+   Parameters" registry established by [RFC6749] Section 11.2:
+
+   Parameter Name:  delegatee_id
+
+   Parameter Usage Location:  token request
+
+   Change Controller:  IETF
+
+   Reference:  Section 5.2 of this document
+
+   The interaction_callback_uri parameter is used in the delegation
+   Token Exchange request context (Section 5.2) to receive a redirect
+   callback upon completion of user interaction.  The parameter is
+   defined and registered by
+   [I-D.parecki-oauth-jwt-grant-interaction-response]; this
+   specification extends its usage from the JWT Authorization Grant
+   (grant_type=jwt-bearer) to the Token Exchange grant type
+   (grant_type=token-exchange).  No additional IANA registration is
+   required.
+
+12.3.  OAuth Error Registration
+
+   This specification defines the following error codes for use in
+   delegation Token Exchange responses.  These errors extend the OAuth
+   2.0 error registry established by [RFC6749] Section 11.4:
+
+   invalid_delegation_chain:  The delegation_chain claim in the
+      presented token fails validation (e.g., broken chain continuity,
+      invalid signatures, or expired timestamps).  The AS MUST reject
+      the delegation request.
+
+   delegation_depth_exceeded:  The delegation chain has reached the
+      maximum number of hops permitted by the AS policy, and the
+      requested delegation would exceed this limit.
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 40]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   policy_expansion_detected:  The requested delegated_policy or scope
+      is broader than the delegator's authorized policy, violating the
+      policy narrowing constraint defined in Section 4.
+
+13.  References
+
+13.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
+              Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
+              2015, <https://www.rfc-editor.org/info/rfc7515>.
+
+   [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
+              (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
+              <https://www.rfc-editor.org/info/rfc7519>.
+
+   [RFC7523]  Jones, M., Campbell, B., and C. Mortimore, "JSON Web Token
+              (JWT) Profile for OAuth 2.0 Client Authentication and
+              Authorization Grants", RFC 7523, DOI 10.17487/RFC7523, May
+              2015, <https://www.rfc-editor.org/info/rfc7523>.
+
+   [RFC8693]  Jones, M., Nadalin, A., Campbell, B., Ed., Bradley, J.,
+              and C. Mortimore, "OAuth 2.0 Token Exchange", RFC 8693,
+              DOI 10.17487/RFC8693, January 2020,
+              <https://www.rfc-editor.org/info/rfc8693>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <https://www.rfc-editor.org/info/rfc6749>.
+
+   [RFC8785]  Rundgren, A., Jordan, B., and S. Erdtman, "JSON
+              Canonicalization Scheme (JCS)", RFC 8785,
+              DOI 10.17487/RFC8785, June 2020,
+              <https://www.rfc-editor.org/info/rfc8785>.
+
+   [RFC8414]  Jones, M., Sakimura, N., and J. Bradley, "OAuth 2.0
+              Authorization Server Metadata", RFC 8414,
+              DOI 10.17487/RFC8414, June 2018,
+              <https://www.rfc-editor.org/info/rfc8414>.
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 41]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   [I-D.ietf-oauth-identity-chaining]
+              Schwenkschuster, A., Kasselman, P., Burgin, K., Jenkins,
+              M. J., Campbell, B., and A. Parecki, "OAuth Identity and
+              Authorization Chaining Across Domains", Work in Progress,
+              Internet-Draft, draft-ietf-oauth-identity-chaining-14, 2
+              June 2026, <https://datatracker.ietf.org/doc/html/draft-
+              ietf-oauth-identity-chaining-14>.
+
+   [I-D.parecki-oauth-jwt-grant-interaction-response]
+              Parecki, A., Campbell, B., and D. Liu, "JWT Authorization
+              Grant Interaction Response", Work in Progress, Internet-
+              Draft, draft-parecki-oauth-jwt-grant-interaction-response-
+              00, 24 March 2026, <https://datatracker.ietf.org/doc/html/
+              draft-parecki-oauth-jwt-grant-interaction-response-00>.
+
+13.2.  Informative References
+
+   [RFC7009]  Lodderstedt, T., Ed., Dronia, S., and M. Scurtescu, "OAuth
+              2.0 Token Revocation", RFC 7009, DOI 10.17487/RFC7009,
+              August 2013, <https://www.rfc-editor.org/info/rfc7009>.
+
+   [RFC7662]  Richer, J., Ed., "OAuth 2.0 Token Introspection",
+              RFC 7662, DOI 10.17487/RFC7662, October 2015,
+              <https://www.rfc-editor.org/info/rfc7662>.
+
+   [RFC9449]  Fett, D., Campbell, B., Bradley, J., Lodderstedt, T.,
+              Jones, M., and D. Waite, "OAuth 2.0 Demonstrating Proof of
+              Possession (DPoP)", RFC 9449, DOI 10.17487/RFC9449,
+              September 2023, <https://www.rfc-editor.org/info/rfc9449>.
+
+   [I-D.liu-oauth-rego-policy]
+              Liu, D., "Rego Policy Language for OAuth 2.0", Work in
+              Progress, Internet-Draft, draft-liu-oauth-rego-policy,
+              March 2026, <https://maxpassion.github.io/IETF-Agent-
+              Operation-Authorization-draft/draft-liu-oauth-rego-policy-
+              00.html>.
+
+   [I-D.ietf-oauth-identity-assertion-authz-grant]
+              Ying, K. and B. Campbell, "OAuth 2.0 Identity Assertion
+              Authorization Grant", Work in Progress, Internet-Draft,
+              draft-ietf-oauth-identity-assertion-authz-grant, January
+              2026, <https://datatracker.ietf.org/doc/html/draft-ietf-
+              oauth-identity-assertion-authz-grant>.
+
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 42]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   [I-D.liu-oauth-authorization-evidence]
+              Liu, D., "Authorization Evidence for OAuth 2.0", Work in
+              Progress, Internet-Draft, draft-liu-oauth-authorization-
+              evidence, March 2026, <https://maxpassion.github.io/IETF-
+              Agent-Operation-Authorization-draft/draft-liu-oauth-
+              authorization-evidence-00.html>.
+
+Appendix A.  Complete Multi-Hop Example
+
+   The following shows an *extended* token held by Agent C after two
+   delegation hops (User → Agent A → Agent B → Agent C), using WIT-based
+   identifiers, structured policies, and authorization evidence:
+
+{
+  "iss": "https://as.example.com",
+  "sub": "user_12345",
+  "aud": "https://api.shop.example",
+  "exp": 1734520500,
+  "iat": 1734517800,
+  "act": {
+    "sub": "wit://agent-c.example/sha256.ccc333..."
+  },
+
+  "delegation_chain": [
+    {
+      "delegator_id": "wit://agent-b.example/sha256.bbb222...",
+      "delegatee_id": "wit://agent-c.example/sha256.ccc333...",
+      "delegation_timestamp": 1734517800,
+      "root_evidence_ref": "evidence-root",
+      "delegated_policy": {
+        "type": "rego",
+        "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n  input.item_id == \"123\"\n}",
+        "entry_point": "allow"
+      },
+      "operation_summary": "Check stock for item 123",
+      "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..MEYCIQD2...",
+      "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDy..."
+    },
+    {
+      "delegator_id": "wit://agent-a.example/sha256.aaa111...",
+      "delegatee_id": "wit://agent-b.example/sha256.bbb222...",
+      "delegation_timestamp": 1734516900,
+      "root_evidence_ref": "evidence-root",
+      "delegated_policy": {
+        "type": "rego",
+        "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"cart_op\"\n}\nallow {\n  input.action == \"inventory_op\"\n}",
+        "entry_point": "allow"
+      },
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 43]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+      "operation_summary": "Delegate inventory operations",
+      "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..MEYCIQD1...",
+      "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDx..."
+    }
+  ],
+
+  "evidence": {
+    "id": "evidence-root",
+    "user_confirmation": {
+      "displayed_content": "Allow shopping assistant to manage cart",
+      "user_action": "confirmed_via_button_click",
+      "timestamp": 1734516000,
+      "interface_version": "consent-ui-v2.1"
+    },
+    "session_context": {
+      "session_id": "session_xyz789",
+      "channel": "mobile-app"
+    },
+    "as_signature": "eyJhbGciOiJSUzI1NiJ9..MEUCIQDw..."
+  },
+
+  "audit_trail": {
+    "evidence_ref": "evidence-root",
+    "semantic_expansion_level": "medium",
+    "interpretation_notes": "User said 'manage cart', delegated to inventory operations"
+  }
+}
+
+                               Figure 8
+
+   This token shows:
+
+   *  Original user: user_12345
+
+   *  Current actor: Agent C
+
+   *  Delegation path: Agent A → Agent B → Agent C
+
+   *  Progressive policy narrowing: cart+inventory → inventory →
+      item:123
+
+   *  Original user consent evidence preserved
+
+
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 44]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   A scope-based equivalent of the same scenario would omit the
+   delegated_policy, delegator_signature, root_evidence_ref, evidence,
+   and audit_trail fields.  Each delegation record would carry only
+   delegator_id, delegatee_id, delegation_timestamp, operation_summary,
+   and as_signature.  The token's scope claim alone would express the
+   progressively narrowing authorization (e.g., cart:read inventory:read
+   → inventory:read → inventory:read:item:123).
+
+Appendix B.  Validation Checklist
+
+   This appendix provides a condensed checklist for implementers.  The
+   normative requirements are specified in Section 9 and Section 10;
+   this checklist is informative only.
+
+   Each delegation hop is represented as a separate JWT access token
+   issued and signed by the Authorization Server.  The delegating agent
+   MAY additionally provide a delegator_signature within the
+   delegation_chain record for dual-signature non-repudiation
+   (RECOMMENDED).
+
+   *Token structure (per hop):*
+
+   *  iss — Authorization Server identifier
+
+   *  sub — original user (preserved from root)
+
+   *  act.sub — delegatee agent identifier
+
+   *  delegation_chain — accumulated delegation records
+
+   *  Token signed by AS private key
+
+   *Resource Server validation steps:*
+
+   1.  Verify token-level JWT signature against iss
+
+   2.  Verify as_signature on each delegation record
+
+   3.  Verify delegator_signature when present (SHOULD)
+
+   4.  Check chain continuity: record[i].delegator_id ==
+       record[i-1].delegatee_id
+
+   5.  Check act.sub == record[0].delegatee_id
+
+   6.  Check timestamp ordering (descending, within validity)
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 45]
+
+Internet-Draft           OAuth Delegation Chain                June 2026
+
+
+   7.  Check scope narrowing (MUST); check policy narrowing when
+       delegated_policy present (SHOULD)
+
+   8.  Verify root authorization anchor (see Section 9)
+
+   9.  Check agent identifier status (revocation / expiration)
+
+   *Per-hop signing benefits:* independent non-repudiation per
+   delegator, flexible per-hop revocation, incremental chain updates,
+   and discrete audit events.
+
+Authors' Addresses
+
+   Dapeng Liu
+   Alibaba Group
+   Email: max.ldp@alibaba-inc.com
+
+
+   Hongru Zhu
+   Alibaba Group
+   Email: hongru.zhr@alibaba-inc.com
+
+
+   Suresh Krishnan
+   Cisco
+   Email: suresh.krishnan@gmail.com
+
+
+   Aaron Parecki
+   Okta
+   Email: aaron@parecki.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liu, et al.              Expires 8 December 2026               [Page 46]

--- a/interop/oauth-liu-composition/drafts/draft-liu-oauth-rego-policy-00.txt
+++ b/interop/oauth-liu-composition/drafts/draft-liu-oauth-rego-policy-00.txt
@@ -1,0 +1,1904 @@
+
+
+
+
+Web Authorization Protocol                                        D. Liu
+Internet-Draft                                                    H. Zhu
+Intended status: Standards Track                           Alibaba Group
+Expires: 11 December 2026                                    S. Krishnan
+                                                                   Cisco
+                                                              A. Parecki
+                                                                    Okta
+                                                                  H. Xue
+                                                           Alibaba Group
+                                                             9 June 2026
+
+
+            Rego Policy Language for OAuth 2.0 Authorization
+                     draft-liu-oauth-rego-policy-00
+
+Abstract
+
+   AI agents exhibit dynamic, unpredictable behavior that cannot be
+   fully described by traditional OAuth 2.0 scopes.  This specification
+   defines a behavioral authorization framework that enables clients,
+   particularly AI agents, to propose Rego policy-based behavioral
+   constraint contracts in OAuth 2.0 authorization flows using Rich
+   Authorization Requests (RAR).  It defines the rego_policy
+   authorization data type for carrying behavioral constraint contracts
+   in authorization_details, shifting the authorization model from
+   static permission sets to runtime behavioral verification.  It also
+   defines a reverse-guided authorization mechanism allowing resource
+   servers to return structured policy constraints in error responses,
+   enabling agents to dynamically adapt their behavior and construct
+   appropriate authorization requests.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 11 December 2026.
+
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 1]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+Copyright Notice
+
+   Copyright (c) 2026 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   5
+     1.2.  RAR Integration . . . . . . . . . . . . . . . . . . . . .   5
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   6
+   3.  RAR Authorization Data Type . . . . . . . . . . . . . . . . .   6
+     3.1.  rego_policy . . . . . . . . . . . . . . . . . . . . . . .   6
+       3.1.1.  Type Definition . . . . . . . . . . . . . . . . . . .   6
+       3.1.2.  Structure . . . . . . . . . . . . . . . . . . . . . .   7
+       3.1.3.  Policy Requirements . . . . . . . . . . . . . . . . .   8
+     3.2.  policy_ref Claim  . . . . . . . . . . . . . . . . . . . .   9
+       3.2.1.  Claim Definition  . . . . . . . . . . . . . . . . . .  10
+       3.2.2.  Structure . . . . . . . . . . . . . . . . . . . . . .  10
+     3.3.  Policy Context  . . . . . . . . . . . . . . . . . . . . .  10
+     3.4.  Extensibility . . . . . . . . . . . . . . . . . . . . . .  11
+   4.  Protocol Flow . . . . . . . . . . . . . . . . . . . . . . . .  11
+     4.1.  Step Details  . . . . . . . . . . . . . . . . . . . . . .  12
+   5.  Reverse-Guided Authorization  . . . . . . . . . . . . . . . .  13
+     5.1.  Error Response Format . . . . . . . . . . . . . . . . . .  14
+     5.2.  Relationship to insufficient_scope  . . . . . . . . . . .  15
+     5.3.  Rego Profile Structure  . . . . . . . . . . . . . . . . .  15
+     5.4.  Agent Adaptive Behavior . . . . . . . . . . . . . . . . .  16
+     5.5.  Security Considerations . . . . . . . . . . . . . . . . .  17
+   6.  Authorization Server Processing . . . . . . . . . . . . . . .  18
+     6.1.  Policy Validation . . . . . . . . . . . . . . . . . . . .  18
+     6.2.  Policy Registration . . . . . . . . . . . . . . . . . . .  18
+     6.3.  Error Responses . . . . . . . . . . . . . . . . . . . . .  19
+     6.4.  Policy Approval Basis . . . . . . . . . . . . . . . . . .  19
+   7.  Resource Server Enforcement . . . . . . . . . . . . . . . . .  20
+     7.1.  Policy Retrieval  . . . . . . . . . . . . . . . . . . . .  20
+     7.2.  Policy Engine Integration . . . . . . . . . . . . . . . .  21
+     7.3.  Enforcement Decision  . . . . . . . . . . . . . . . . . .  22
+   8.  Applicability to Different Authorization Flows  . . . . . . .  23
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 2]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+     8.1.  JWT Grant with Interaction Response . . . . . . . . . . .  23
+     8.2.  Client Credentials Grant  . . . . . . . . . . . . . . . .  24
+     8.3.  Token Exchange (RFC 8693) . . . . . . . . . . . . . . . .  24
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
+     9.1.  Policy Injection  . . . . . . . . . . . . . . . . . . . .  25
+     9.2.  Behavioral Boundary Evasion . . . . . . . . . . . . . . .  26
+     9.3.  Policy Integrity  . . . . . . . . . . . . . . . . . . . .  26
+     9.4.  Policy URI Fetching . . . . . . . . . . . . . . . . . . .  26
+     9.5.  Policy Size Limits  . . . . . . . . . . . . . . . . . . .  27
+     9.6.  Error Response Header Size  . . . . . . . . . . . . . . .  27
+     9.7.  Behavioral Audit  . . . . . . . . . . . . . . . . . . . .  27
+   10. Privacy Considerations  . . . . . . . . . . . . . . . . . . .  28
+   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  28
+     11.1.  RAR Authorization Data Type Registration . . . . . . . .  29
+     11.2.  JWT Access Token Claims Registration . . . . . . . . . .  29
+     11.3.  OAuth 2.0 Bearer Token Error Values Registration . . . .  29
+     11.4.  WWW-Authenticate Parameter Definition  . . . . . . . . .  30
+   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  30
+     12.1.  Normative References . . . . . . . . . . . . . . . . . .  30
+     12.2.  Informative References . . . . . . . . . . . . . . . . .  31
+   Appendix A.  Example Policies . . . . . . . . . . . . . . . . . .  32
+     A.1.  Amount-Based Authorization  . . . . . . . . . . . . . . .  32
+     A.2.  Time-Window Authorization . . . . . . . . . . . . . . . .  33
+     A.3.  Role-Based Authorization  . . . . . . . . . . . . . . . .  33
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  33
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  33
+
+1.  Introduction
+
+   AI agents differ fundamentally from traditional OAuth clients in that
+   their behavior space is dynamic and often unpredictable at
+   authorization time.  When a human delegates a task such as "help me
+   find and buy a laptop" to an AI agent, the specific sequence of
+   operations (product comparison, price checking, coupon search, cart
+   management, payment, shipping selection) emerges at runtime based on
+   available products, pricing, user preferences, and agent reasoning.
+   The agent's behavior cannot be fully enumerated in advance, which
+   creates a tension between two competing requirements: granting the
+   agent sufficient behavioral freedom to accomplish its task, and
+   constraining the agent to the principle of least privilege.
+
+   Traditional OAuth 2.0 authorization relies on scopes, pre-defined
+   static permission sets, to express what a client is allowed to do.
+   This model assumes that the client's behavior space is known and
+   enumerable at design time.  For AI agents, this assumption does not
+   hold: an overly broad scope grants unchecked power (violating least
+   privilege), while an overly narrow scope causes frequent
+   authorization failures that interrupt the agent's task execution.
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 3]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   Existing policy engine deployments (e.g., Open Policy Agent (OPA)
+   [OPA] sidecar patterns) address policy evaluation within a single
+   administrative domain where policies are centrally managed, but do
+   not solve the cross-organizational authorization problem where an
+   agent must carry its behavioral constraints across multiple resource
+   servers.
+
+   This specification builds on OAuth 2.0 [RFC6749] and Rich
+   Authorization Requests (RAR) [RFC9396] by introducing a *behavioral
+   authorization* framework: instead of requesting a fixed set of
+   permissions, the client (agent) proposes a Rego [Rego] policy that
+   serves as a *behavioral constraint contract*.  The Authorization
+   Server validates and approves this contract, and the Resource Server
+   evaluates each of the agent's runtime behaviors against it.  This
+   shifts the authorization model from "what resources can the client
+   access" to "within what behavioral boundaries can the client
+   operate," enabling the agent to act freely within approved
+   constraints while every individual behavior is verified at execution
+   time.
+
+   The Rego policy also serves as a formal expression of human intent:
+   when a human delegates a task to an agent, the policy encodes the
+   boundaries of that delegation in a machine-verifiable form.  The
+   agent retains behavioral autonomy: it decides _what_ to do and
+   _when_, but every action is constrained by the policy approved by the
+   Authorization Server.  This enables a balance between agent autonomy
+   and human oversight that is not achievable with static scope-based
+   authorization.
+
+   This specification enables:
+
+   *  Clients (agents) to propose behavioral constraint contracts as
+      Rego policies in authorization requests;
+
+   *  Authorization Servers to validate, register, and bind policies to
+      access tokens;
+
+   *  Resource Servers to evaluate each agent behavior against the
+      policy at runtime using a Rego-compatible policy engine;
+
+   *  Resource Servers to guide agents toward appropriate authorization
+      via structured error responses when behaviors exceed approved
+      constraints.
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 4]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   The rego_policy authorization data type can be used in conjunction
+   with the delegation_chain claim ([I-D.liu-oauth-chain-delegation]).
+   When a delegation hop carries a structured policy, the Rego
+   behavioral constraint contract defines the fine-grained authorization
+   constraints that were approved at that hop, complementing the
+   delegation lineage and attestation provided by delegation_chain.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals.
+
+1.2.  RAR Integration
+
+   This specification defines the rego_policy authorization data type
+   for use with Rich Authorization Requests (RAR) [RFC9396].  The
+   behavioral constraint contract is carried within the
+   authorization_details parameter as the primary mechanism.
+
+   Key aspects of the RAR integration:
+
+   *  *Authorization Data Type*: The rego_policy type is defined for use
+      with the authorization_details parameter per RFC 9396.  It
+      contains the behavioral constraint contract (Rego policy), entry
+      point, and optional context.
+
+   *  *Token Response*: Per RFC 9396 Section 7.1, the access token
+      includes enriched authorization_details as the primary mechanism
+      for carrying the behavioral constraint contract.  The policy_ref
+      claim MAY be included as a lightweight alternative (see
+      Section 3.2).
+
+   *  *Complementary Use*: RAR enables structured authorization requests
+      with type-specific details, while Rego Policy enables expressive
+      declarative policy definitions.  Implementations MAY combine
+      rego_policy with other RAR types.
+
+   Implementations SHOULD ensure consistency between
+   authorization_details requirements and Rego policy evaluations.  The
+   Authorization Server MAY use RAR types to determine applicable policy
+   templates or validation rules.
+
+   Resource Servers MAY advertise supported authorization details types
+   via the authorization_details_types_supported attribute in Protected
+   Resource Metadata ([RFC9728]), enabling clients to discover which
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 5]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   authorization details types are accepted before constructing
+   rego_policy authorization requests.  This discovery mechanism is
+   particularly valuable in multi-tenant or federated environments where
+   different resource servers may require different policy structures.
+
+2.  Terminology
+
+   Rego:  A declarative policy language designed for Open Policy Agent
+      (OPA).  Rego policies define rules that evaluate to allow or deny
+      decisions based on input data.
+
+   Open Policy Agent (OPA):  A general-purpose policy engine that
+      evaluates Rego policies against structured input data.
+
+   Rich Authorization Requests (RAR):  A framework defined in [RFC9396]
+      for expressing fine-grained authorization requirements through the
+      authorization_details parameter.
+
+   rego_policy:  An authorization data type for RAR that carries a Rego
+      behavioral constraint contract within the authorization_details
+      parameter.  The policy defines the behavioral boundaries within
+      which the client (agent) is permitted to operate, evaluated by the
+      Resource Server against each runtime behavior.
+
+   Policy Reference:  An identifier for a behavioral constraint contract
+      that has been validated and registered by the Authorization
+      Server, included in JWT [RFC7519] access tokens via the policy_ref
+      claim defined in this specification.
+
+3.  RAR Authorization Data Type
+
+   This specification defines the rego_policy authorization data type
+   for use with Rich Authorization Requests (RAR).
+
+3.1.  rego_policy
+
+   The rego_policy authorization data type carries a Rego behavioral
+   constraint contract within the authorization_details parameter.  It
+   enables clients (particularly AI agents) to propose behavioral
+   constraints as part of the authorization request.
+
+3.1.1.  Type Definition
+
+   Type Name:  rego_policy
+
+   Data Type:  Object
+
+   Usage:  authorization_details (RFC 9396)
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 6]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+3.1.2.  Structure
+
+   The following example shows the authorization_details request
+   parameter containing a rego_policy object:
+
+{
+  "authorization_details": [
+    {
+      "type": "rego_policy",
+      "policy": {
+        "type": "rego",
+        "content": "package agent\n\ndefault allow = false\n\nallow if {\n  input.user.tier == \"premium\"\n  input.action in {\"search_products\", \"add_to_cart\"}\n}",
+        "entry_point": "allow"
+      },
+      "actions": ["search_products", "add_to_cart"],
+      "locations": ["https://api.example.com/products"]
+    }
+  ]
+}
+
+                               Figure 1
+
+   In addition to the common fields defined in RFC 9396 Section 2 (such
+   as actions, locations, datatypes, and identifier), the rego_policy
+   authorization data type defines the following type-specific fields:
+
+   policy:  REQUIRED.  An object containing the Rego policy definition.
+
+   context:  OPTIONAL.  An object providing additional structured data
+      for behavior verification at resource access time.
+
+   The common RAR fields and the Rego policy serve different consumers
+   at different stages of the authorization flow.  The common fields
+   (actions, locations) provide a declarative upper bound on the
+   requested operations and resources, enabling the Authorization Server
+   to approve or reject the request without parsing Rego.  The Rego
+   policy defines the behavioral constraints that the Resource Server
+   evaluates against each agent behavior at runtime with contextual
+   input.  This layered design allows Authorization Server
+   implementations to function without embedding a Rego engine, while
+   the Resource Server performs per-behavior verification using the full
+   expressiveness of the policy.
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 7]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   The AS SHOULD verify that the policy does not exceed the scope
+   declared in the common fields.  Since this verification is based on
+   declarative RAR fields rather than full Rego AST analysis, it
+   provides an approximate upper-bound check; the Resource Server, as
+   the policy execution point, bears responsibility for ensuring the
+   evaluated policy behavior is consistent with the approved
+   authorization scope.
+
+   The policy object has the following fields:
+
+   type:  REQUIRED.  The policy language type.  MUST be "rego" for this
+      specification.  Future extensions MAY define additional types.
+
+   content:  REQUIRED (if uri is not present).  The Rego policy as a
+      string.  The policy MUST be syntactically valid Rego.  If both
+      content and uri are present, content takes precedence and uri is
+      ignored.
+
+   uri:  OPTIONAL.  A URI reference to an externally hosted policy.  If
+      provided, the AS MAY fetch the policy from this location.  The AS
+      MUST apply SSRF protections when fetching from this URI (see
+      Section 9).
+
+   entry_point:  OPTIONAL.  The rule name that serves as the policy
+      entry point.  Defaults to "allow".  For authorization decisions,
+      this SHOULD be "allow".  Future extensions MAY define additional
+      entry points for non-boolean evaluations.
+
+3.1.3.  Policy Requirements
+
+   Rego policies used with this specification MUST adhere to the
+   following requirements:
+
+   1.  Entry Point: The policy MUST define a rule matching the
+       entry_point field (defaulting to allow).  For authorization
+       decisions, this rule MUST evaluate to a boolean value.
+
+   2.  Package Declaration: The policy MUST include a package
+       declaration.  The recommended package name is "agent" or a
+       domain-specific namespace.
+
+   3.  Default Deny (best practice): Policies are recommended to include
+       default allow = false to ensure deny-by-default behavior.  This
+       is not enforced by AS validation but is considered a security
+       best practice for policy authors.
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 8]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   4.  Input Reference: The policy accesses data via the input object.
+       The structure and content of the input object are determined by
+       the evaluating party (AS or RS) and MAY include token claims, API
+       request parameters, resource attributes, and other contextual
+       data as agreed between the client and the resource server.
+
+   The policy syntax used in this specification follows Rego v1 as
+   defined in the OPA documentation [Rego].  Implementations of this
+   specification MUST use a policy engine that accepts Rego v1 syntax.
+   Policy engines MAY additionally support Rego v0 syntax through
+   backward compatibility mode to facilitate migration from existing v0
+   policy deployments.
+
+   package agent
+
+   default allow = false
+
+   allow if {
+     # Authorization rules here
+     input.action == "read"
+     input.resource.owner == input.user.id
+   }
+
+                                  Figure 2
+
+3.2.  policy_ref Claim
+
+   The policy_ref claim is an OPTIONAL shorthand mechanism for
+   referencing a behavioral constraint contract in access tokens.  When
+   the AS uses Rich Authorization Requests (RAR), the enriched
+   authorization_details array in the access token (per RFC 9396
+   Section 7.1) is the primary mechanism for carrying the behavioral
+   constraint contract.  The policy_ref claim MAY be used as a
+   lightweight alternative when:
+
+   *  The inline policy content would make the access token exceed
+      practical size limits (see Section 9);
+
+   *  The Resource Server already has a cached copy of the policy and
+      only needs an identifier to look it up;
+
+   *  The deployment uses opaque (non-JWT) access tokens where token
+      introspection [RFC7662] provides the policy content.
+
+   When policy_ref is used, the AS performs policy registration as
+   described in Section 6.
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026                [Page 9]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+3.2.1.  Claim Definition
+
+   Claim Name:  policy_ref
+
+   Claim Type:  Object
+
+   Usage:  JWT access tokens (the claim may also appear in introspection
+      responses for opaque tokens per [RFC7662])
+
+3.2.2.  Structure
+
+   {
+     "policy_ref": {
+       "id": "policy-abc123",
+       "version": "1",
+       "hash": "sha256-uU0NUZ5dVHk9qF3bT8aY1cP0nR7wE2xG4mK6iS8jH9oQ",
+       "endpoint": "https://as.example.com/policies/policy-abc123"
+     }
+   }
+
+                                  Figure 3
+
+   id:  REQUIRED.  A unique identifier for the registered policy,
+      assigned by the Authorization Server.
+
+   version:  OPTIONAL.  The version of the policy.  Useful for policy
+      updates.
+
+   hash:  OPTIONAL.  A cryptographic hash of the policy content using
+      the format algorithm-base64value (e.g., "sha256-...").  SHA-256
+      MUST be supported by all implementations.  The hash algorithm
+      identifier enables hash agility for future migration.  When
+      present, the Resource Server MUST verify that the fetched policy
+      content matches this hash before evaluating the policy.  This
+      prevents tampering with policy content during transmission.
+
+   endpoint:  OPTIONAL.  A URL where the Resource Server can fetch the
+      full policy content if needed.
+
+3.3.  Policy Context
+
+   The context field within rego_policy provides additional structured
+   data that the client wishes to include at authorization request time.
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 10]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   The input object used for policy evaluation is constructed by the
+   Resource Server (the evaluating party) and is not limited to the
+   context field.  When the RS constructs the input object, it SHOULD
+   merge the context data under a context key within input (e.g.,
+   input.context) to avoid key collisions with other input categories.
+   Common input categories include:
+
+   *  user: User identity and attributes (from token claims or AS data);
+
+   *  client: Client/agent identity and metadata (from client
+      registration);
+
+   *  action: Requested action details (from the API request);
+
+   *  resource: Target resource attributes (from the resource server);
+
+   *  environment: Contextual conditions (time, location, device).
+
+   The specific input structure is determined by bilateral agreement
+   between the client and the resource server, typically documented in
+   developer integration guides.
+
+3.4.  Extensibility
+
+   This specification focuses on Rego as a concrete and widely deployed
+   policy language.  The policy.type field (see Section 3.1) is designed
+   for extensibility: future specifications MAY define additional policy
+   language types that follow the same integration pattern within the
+   rego_policy authorization data type or define new authorization data
+   types with analogous structures.
+
+4.  Protocol Flow
+
+   +--------+       +--------+       +--------+       +--------+
+   | Client |       |   AS   |       |   RS   |       |Policy  |
+   |        |       |        |       |        |       |Engine  |
+   +--------+       +--------+       +--------+       +--------+
+       |                |                |                |
+       | (1) AuthZ Req  |                |                |
+       | with           |                |                |
+       | behavioral     |                |                |
+       | constraint     |                |                |
+       | contract       |                |                |
+       | (type=rego_    |                |                |
+       |  policy)       |                |                |
+       |--------------->|                |                |
+       |                |                |                |
+       |                | (2) Validate   |                |
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 11]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+       |                | policy syntax  |                |
+       |                |                |                |
+       |                | (3) Policy     |                |
+       |                | approval       |                |
+       |                |                |                |
+       |                |                |                |
+       | (4) Access     |                |                |
+       |    Token with  |                |                |
+       |    behavioral  |                |                |
+       |    constraint  |                |                |
+       |    contract    |                |                |
+       |<---------------|                |                |
+       |                |                |                |
+       | (5) Agent      |                |                |
+       |    Behavior    |                |                |
+       |    with token  |                |                |
+       |-------------------------------->|                |
+       |                |                |                |
+       |                |                | (6) Extract    |
+       |                |                | behavioral     |
+       |                |                | constraint     |
+       |                |                | contract       |
+       |                |                |                |
+       |                |                | (7) Verify     |
+       |                |                | behavior       |
+       |                |                | against policy |
+       |                |                |--------------->|
+       |                |                |                |
+       |                |                | (8) Allow/Deny |
+       |                |                |<---------------|
+       |                |                |                |
+       |                |                | (9) Enforce    |
+       |                |                | decision       |
+       |                |                |                |
+       | (10) Response  |                |                |
+       |<--------------------------------|                |
+
+                                  Figure 4
+
+4.1.  Step Details
+
+   1.   Behavioral Constraint Proposal: Client (agent) sends an
+        authorization request with authorization_details containing a
+        rego_policy object, a proposed behavioral constraint contract,
+        with policy and optional context fields.  This leverages RAR
+        (RFC 9396) for structured authorization requests.
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 12]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   2.   Policy Validation: AS validates that the Rego policy is
+        syntactically correct and safe to evaluate (see Section 6).
+
+   3.   Policy Approval: AS determines whether the proposed behavioral
+        boundaries are appropriate for the specific client and resource
+        owner, based on client registration metadata, organizational
+        authorization policies, resource owner consent, and token
+        binding context (see Section 6).  The AS does not perform full
+        runtime policy evaluation (which occurs at the RS on a per-
+        behavior basis).
+
+   4.   Token Binding: AS issues an access token with enriched
+        authorization_details array per RFC 9396 Section 7.1, binding
+        the approved behavioral constraint contract to the token.  The
+        AS MAY include additional metadata in the authorization_details
+        object (e.g., server-assigned identifiers or normalized policy
+        content) but MUST NOT alter the semantic meaning of the policy
+        without client consent.
+
+   5.   Behavior Execution: Client (agent) presents the token to the
+        Resource Server when performing a behavior.
+
+   6.   Policy Extraction: RS extracts the behavioral constraint
+        contract from the enriched authorization_details in the access
+        token.
+
+   7.   Behavior Verification: RS evaluates the agent's current behavior
+        (action, target resource, context) against the policy using a
+        Rego-compatible policy engine.
+
+   8.   Decision: The policy engine returns an allow/deny decision for
+        the specific behavior.
+
+   9.   Enforcement: RS enforces the per-behavior decision, allowing or
+        denying the agent's action.
+
+   10.  Response: RS returns the result to the client.
+
+5.  Reverse-Guided Authorization
+
+   Traditional OAuth error responses indicate authorization failure
+   without providing guidance on how to obtain valid authorization.  In
+   behavioral authorization, this is particularly important: when an
+   agent encounters *behavioral drift* (its next planned behavior falls
+   outside the approved constraint contract), the agent needs structured
+   guidance to recover autonomously.  Resource servers can provide this
+   guidance through structured error responses that enable agents to
+   construct appropriate authorization requests with updated behavioral
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 13]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   constraints.
+
+5.1.  Error Response Format
+
+   When an agent's request lacks sufficient authorization, the resource
+   server returns an HTTP 403 Forbidden response with a WWW-Authenticate
+   header containing the insufficient_authorization error code and a
+   rego_profile parameter.  This parameter provides machine-readable
+   guidance on the required authorization conditions.
+
+HTTP/1.1 403 Forbidden
+Content-Type: application/json
+WWW-Authenticate: Bearer error="insufficient_authorization",
+  rego_profile="eyJwcm9maWxlX3VyaSI6Imh0dHBzOi8vcmVzb3VyY2UuZXhhbXBsZS9..."
+
+{
+  "error": "insufficient_authorization",
+  "error_description": "Additional authorization required"
+}
+
+        Figure 5: Reverse-Guided Authorization Error Response
+
+   Per RFC 6750 [RFC6750] Section 3 and RFC 6749 [RFC6749] Section 5.2,
+   the error response includes both the WWW-Authenticate header with the
+   insufficient_authorization error code and a JSON error body.  The
+   rego_profile parameter in the WWW-Authenticate header provides
+   machine-readable guidance on the required authorization conditions.
+
+   The rego_profile parameter value is a base64url-encoded JSON object.
+   Implementations SHOULD use base64url encoding without padding (no
+   trailing = characters) per RFC 4648 [RFC4648] Section 5 to avoid
+   quoting issues in the WWW-Authenticate header.  The decoded object
+   has the following structure:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 14]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   {
+     "profile_uri": "https://resource.example/policies/purchase",
+     "required_scope": ["purchase.create"],
+     "required_claims": ["agent_id", "user_id"],
+     "constraints": {
+       "max_amount": {
+         "type": "number",
+         "description": "Maximum transaction amount in USD",
+         "required": true
+       },
+       "trigger_source": {
+         "type": "string",
+         "enum": ["user_initiated", "scheduled"],
+         "description": "Source of the operation trigger"
+       }
+     },
+     "confirmation_required": true,
+     "auth_server": "https://as.example.com"
+   }
+
+                       Figure 6: Decoded rego_profile
+
+5.2.  Relationship to insufficient_scope
+
+   RFC 6750 [RFC6750] defines the insufficient_scope error for cases
+   where the access token lacks the scopes required by the resource
+   server.  The insufficient_authorization error defined in this
+   specification addresses a broader condition: the token may include
+   adequate scopes but lack the policy-based authorization structure
+   (e.g., Rego constraints or user confirmation) required by the
+   resource server.
+
+   Resource servers SHOULD use insufficient_scope when the deficiency is
+   purely scope-based and insufficient_authorization when the deficiency
+   involves policy constraints that cannot be expressed as additional
+   scopes.
+
+5.3.  Rego Profile Structure
+
+   The rego_profile object contains the following fields:
+
+   profile_uri:  OPTIONAL.  URI identifying the authorization profile
+      for this resource.  This URI serves as an opaque identifier and
+      MAY be used as a cache key, audit reference, or pointer to
+      developer documentation.  The document at this URI is intended for
+      human consumption and is not machine-parsed by the agent.
+
+   required_scope:  OPTIONAL.  Array of scope values that the access
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 15]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+      token MUST include.
+
+   required_claims:  OPTIONAL.  Array of access token claim names (e.g.,
+      agent_id, user_id) that MUST be present in the access token issued
+      by the AS.
+
+   constraints:  OPTIONAL.  Object defining policy constraints that MUST
+      be satisfied.  Each key is a constraint name; the value is an
+      object with the following descriptors: type (data type),
+      description (human-readable explanation), enum (allowed values),
+      and required (boolean, whether the constraint must be provided).
+
+   confirmation_required:  OPTIONAL.  Boolean indicating whether
+      explicit user authorization is required for the requested
+      behavioral boundaries.  If true, the agent MUST initiate an OAuth
+      authorization flow to obtain the resource owner's explicit consent
+      for the proposed behavioral constraint contract.  This does not
+      mean local user confirmation (e.g., a modal dialog) is sufficient;
+      the authorization must be obtained through the AS to produce a
+      token with appropriate grants.  The specific interaction mechanism
+      depends on the OAuth flow in use (e.g., the interaction_required
+      error with JWT Grant Interaction Response
+      [I-D.parecki-oauth-jwt-grant-interaction-response], or the prompt
+      parameter in the authorization code flow).
+
+   auth_server:  REQUIRED.  Identifier of the authorization server
+      capable of issuing tokens that satisfy these requirements.  The
+      agent can discover the token endpoint and other metadata via OAuth
+      2.0 Authorization Server Metadata ([RFC8414]) or OAuth 2.0
+      Protected Resource Metadata ([RFC9728]) using this identifier.
+
+5.4.  Agent Adaptive Behavior
+
+   Upon receiving a reverse-guided authorization response, the AI agent
+   SHOULD:
+
+   1.  Parse the rego_profile to understand authorization requirements.
+
+   2.  Verify that the specified auth_server is trusted before
+       proceeding.
+
+   3.  Construct a new authorization request including required scopes,
+       a behavioral constraint contract that satisfies the constraints
+       specified in the rego_profile, and any additional parameters
+       required by the resource server.
+
+   4.  If confirmation_required is true, initiate user consent flow.
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 16]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   5.  Discover the token endpoint via the auth_server's metadata (RFC
+       8414) and submit the authorization request.
+
+   This adaptive approach enables agents to "learn" authorization
+   requirements dynamically, reducing the need for pre-programmed
+   knowledge of each resource server's policies.
+
+   During multi-step task execution, an agent may encounter *behavioral
+   drift*: situations where the next behavior in its plan falls outside
+   the approved policy constraints.  When this occurs, the agent has
+   three options: (1) request a new authorization with an updated policy
+   that accommodates the new behavior (using the reverse-guided
+   authorization mechanism described above); (2) degrade its behavior to
+   stay within the approved constraints (e.g., selecting an alternative,
+   less privileged action); or (3) request human confirmation to approve
+   an expanded behavioral boundary.  The choice among these options
+   depends on the agent's task context and the confirmation_required
+   signal from the resource server.  Implementations SHOULD prefer
+   degradation over re-authorization for minor boundary violations to
+   avoid excessive authorization round-trips in long-running agent
+   workflows.
+
+5.5.  Security Considerations
+
+   Implementations of reverse-guided authorization MUST consider the
+   following security aspects:
+
+   *  *Auth Server Verification*: Agents MUST verify that the
+      auth_server specified in the rego_profile is trusted before
+      submitting authorization requests.  Agents MUST use only the token
+      endpoint discovered from the auth_server's Authorization Server
+      Metadata ([RFC8414]).  Blindly following redirects could lead to
+      credential theft.
+
+   *  *Constraint Validation*: Agents SHOULD validate that constraint
+      values are reasonable before including them in authorization
+      requests.  Malicious resource servers might attempt to induce
+      agents to request excessive permissions.
+
+   *  *Information Disclosure*: The rego_profile reveals authorization
+      requirements, which is acceptable as it only exposes "what is
+      needed" not "why it is needed."  This is analogous to OAuth scope
+      definitions.
+
+   *  *TLS Protection*: All communications MUST use TLS to prevent man-
+      in-the-middle attacks on the error response.
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 17]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+6.  Authorization Server Processing
+
+6.1.  Policy Validation
+
+   Upon receiving an authorization_details request containing the
+   rego_policy type, the AS MUST perform the following validation steps:
+
+   1.  Syntax Check: Parse the Rego policy and verify it is
+       syntactically valid.
+
+   2.  Entry Point Check: Verify the policy defines the rule specified
+       by the entry_point field (defaulting to allow if not specified).
+
+   3.  Safety Check: Ensure the policy does not contain dangerous
+       operations (e.g., external HTTP calls via http.send, excessive
+       resource consumption).
+
+   4.  Behavioral Boundary Check: Verify that the RAR common fields
+       (actions, locations) do not exceed the client's registered
+       permissions.  This check provides an approximate upper-bound
+       enforcement based on declarative fields rather than full Rego AST
+       analysis.  The AS MAY perform lightweight static analysis of the
+       Rego policy (e.g., extracting referenced input.action values) to
+       detect obvious inconsistencies between the policy content and the
+       declared RAR fields.
+
+6.2.  Policy Registration
+
+   When the AS issues a policy_ref claim instead of embedding the full
+   policy in authorization_details, the AS MUST register the policy:
+
+   1.  Assign a unique policy identifier;
+
+   2.  Store the policy content;
+
+   3.  Associate the policy with the authorization session;
+
+   4.  Optionally, pre-compile the policy for faster evaluation.
+
+   When the AS embeds the validated policy directly in the enriched
+   authorization_details (the primary path), explicit registration is
+   not required; the policy travels with the token.
+
+   Policy registration in this specification is dynamic and on-demand.
+   The Authorization Server does not need to maintain a pre-configured
+   catalog of policies.  When an agent proposes a behavioral constraint
+   contract, the AS evaluates it against pre-established approval
+   principles (see Section 6) and registers it only if approved.  This
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 18]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   eliminates the operational burden of pre-deploying policies for every
+   anticipated agent behavior, which is impractical given the dynamic
+   and unpredictable nature of AI agent workflows.
+
+   Deployments MAY also pre-register policies for well-known agent
+   workflows (e.g., automated reconciliation, scheduled reporting) where
+   the behavioral boundaries are stable and known in advance.  In such
+   cases, the agent can reference the pre-registered policy by
+   identifier rather than submitting the full policy content in each
+   authorization request.  Both modes are supported: dynamic
+   registration is the default for exploratory agent tasks, while pre-
+   registration is an optimization for predictable workflows.
+
+6.3.  Error Responses
+
+   If policy validation fails, the AS MUST return an error:
+
+   {
+     "error": "invalid_request",
+     "error_description": "Invalid Rego policy: syntax error at line 5"
+   }
+
+                                  Figure 7
+
+   The following error conditions MUST be handled:
+
+   *  If neither content nor uri is present in the policy object, the AS
+      MUST return invalid_request with a description indicating the
+      missing policy source.
+
+   *  If only uri is present and the AS fails to fetch the policy
+      content (e.g., network timeout, HTTP error, or invalid response),
+      the AS MUST return invalid_request with a description indicating
+      the fetch failure.
+
+   *  If only uri is present and the AS policy prohibits external URI
+      fetching, the AS MUST return invalid_request with a description
+      suggesting the client use inline content instead.
+
+6.4.  Policy Approval Basis
+
+   The Authorization Server's approval of a behavioral constraint
+   contract is not limited to syntactic validation.  The AS determines
+   whether the proposed behavioral boundaries are appropriate for the
+   specific client and resource owner based on the following factors:
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 19]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   *  *Client registration metadata*: Pre-registered client
+      capabilities, allowed scopes, and trust level established during
+      OAuth 2.0 Dynamic Client Registration [RFC7591] or out-of-band
+      provisioning.
+
+   *  *Organizational authorization policies*: Administrative rules
+      defining which behavioral patterns are permitted for specific
+      client types, user roles, or resource classes within the
+      deployment.
+
+   *  *Resource owner consent*: Explicit authorization from the resource
+      owner approving the agent's proposed behavioral boundaries,
+      obtained through the OAuth 2.0 authorization interaction (e.g.,
+      the consent screen in the authorization code flow, or the
+      interaction_uri mechanism in JWT Grant Interaction Response).
+
+   *  *Token binding context*: The authorization grant type, requested
+      scopes, and other token request parameters that establish the
+      context in which the behavioral constraint contract is evaluated.
+
+   For example, the AS MAY maintain a per-client allowlist of approved
+   behavioral patterns (e.g., permitted actions, maximum transaction
+   limits, allowed resource classes).  When a client proposes a new
+   behavioral constraint contract, the AS verifies that the declared RAR
+   common fields (actions, locations) fall within the client's pre-
+   approved boundaries.  If the proposed contract exceeds these
+   boundaries, the AS SHOULD return invalid_scope when the behavioral
+   boundaries exceed the client's registered permissions, or
+   invalid_request for other policy violations.  Alternatively, the AS
+   MAY escalate to the resource owner for explicit consent before
+   issuing the token.
+
+   This layered approval model ensures that the behavioral constraint
+   contract carried in the access token is trusted not only for its
+   syntactic correctness but also for its alignment with the
+   authorization policies governing the client-resource owner
+   relationship.  The Resource Server can rely on this trust when
+   evaluating each agent behavior against the approved contract at
+   runtime.
+
+7.  Resource Server Enforcement
+
+7.1.  Policy Retrieval
+
+   The RS obtains the Rego policy from the access token.  The primary
+   mechanism is to extract the policy from the enriched
+   authorization_details array included in the token per RFC 9396
+   Section 7.1.
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 20]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   The binding between the policy and the access token depends on the
+   token type.  For JWT access tokens, the policy content or policy_ref
+   claim is integrity-protected by the token signature.  For opaque
+   tokens, the binding is established through token introspection
+   [RFC7662] or a shared back-channel between the AS and RS.
+
+   When the token uses the policy_ref claim instead of inline policy
+   content, the RS retrieves the policy using one of the following
+   methods:
+
+   *  Fetch from AS: Use the endpoint URL in the policy_ref to retrieve
+      the policy.
+
+   *  Local Cache: Use a cached copy if available and not expired.
+
+   *  Introspection: Include policy content in token introspection
+      [RFC7662] response.
+
+7.2.  Policy Engine Integration
+
+   After extracting the Rego policy from the token, the RS MUST load the
+   policy into a Rego-compatible policy engine before querying it.
+   Common loading mechanisms include:
+
+   *  OPA REST API: PUT /v1/policies/{id} to register the policy, then
+      query the Data API;
+
+   *  OPA Go Library: Load the policy programmatically using the
+      embedded OPA SDK;
+
+   *  OPA Compile API: Submit the policy and input together for ad-hoc
+      evaluation.
+
+   Once loaded, the RS queries the policy engine with the request
+   context as input:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 21]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   POST /v1/data/agent/allow HTTP/1.1
+   Host: opa.example.com
+   Content-Type: application/json
+
+   {
+     "input": {
+       "user": {
+         "id": "user_12345",
+         "tier": "premium"
+       },
+       "action": "search_products",
+       "resource": {
+         "type": "product",
+         "id": "product_001"
+       }
+     }
+   }
+
+                                  Figure 8
+
+   {
+     "result": true
+   }
+
+                                  Figure 9
+
+7.3.  Enforcement Decision
+
+   Based on the policy engine's response:
+
+   *  If result is true: Allow the agent's behavior;
+
+   *  If result is false: Deny the behavior with 403 Forbidden;
+
+   *  If result is undefined (OPA returns an empty object with no result
+      field): Deny with 403 Forbidden.  Note that policies following the
+      RECOMMENDED default allow = false pattern (see Section 3.1.3) will
+      always produce a defined boolean result, so undefined only occurs
+      when the default declaration is omitted;
+
+   *  If the policy engine is unreachable or encounters an internal
+      error: Deny with 500 Internal Server Error.
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 22]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+8.  Applicability to Different Authorization Flows
+
+   The rego_policy authorization data type defined in this specification
+   can be used with any OAuth 2.0 authorization flow that supports Rich
+   Authorization Requests (RAR) [RFC9396].  This section illustrates
+   usage with flows that are particularly relevant to AI agent
+   scenarios.
+
+8.1.  JWT Grant with Interaction Response
+
+   The JWT Authorization Grant Interaction Response
+   [I-D.parecki-oauth-jwt-grant-interaction-response] is the RECOMMENDED
+   flow for AI agent scenarios.  In this flow, an agent presents a JWT
+   assertion to the token endpoint.  If user interaction (e.g., consent)
+   is required before the token can be issued, the AS returns an
+   interaction_required error with an interaction_uri where the user can
+   complete the interaction.  The agent then polls for the token.
+
+   When combined with Rego Policy, the agent includes
+   authorization_details containing the rego_policy type in the JWT
+   grant request.  The AS validates the behavioral constraint contract,
+   performs behavioral boundary checks, and determines whether user
+   consent is needed before issuing the token.
+
+ POST /token HTTP/1.1
+ Host: as.example.com
+ Content-Type: application/x-www-form-urlencoded
+
+ grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
+ &assertion=eyJhbGciOiJSUzI1NiJ9...
+ &authorization_details=%5B%7B%22type%22%3A%22rego_policy%22%2C
+   %22policy%22%3A%7B%22type%22%3A%22rego%22%2C
+   %22content%22%3A%22package%20agent%5Cn...
+   %22entry_point%22%3A%22allow%22%7D%2C
+   %22actions%22%3A%5B%22search_products%22%2C%22add_to_cart%22%5D%7D%5D
+
+             Figure 10: JWT Grant Request with Rego Policy
+
+   HTTP/1.1 400 Bad Request
+   Content-Type: application/json
+
+   {
+     "error": "interaction_required",
+     "interaction_uri": "https://as.example.com/interact/abc123",
+     "interval": 5,
+     "expires_in": 600
+   }
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 23]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+                  Figure 11: Interaction Required Response
+
+   After the user completes the interaction, the agent retries the same
+   JWT grant request.  The AS then issues the access token with the
+   enriched authorization_details containing the validated Rego policy.
+
+8.2.  Client Credentials Grant
+
+   In machine-to-machine scenarios using client credentials, the
+   behavioral constraint contract can be included in the token request:
+
+POST /token HTTP/1.1
+Host: as.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=spiffe%3A%2F%2Fagent.example%2Fagent
+&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+&client_assertion=eyJhbGciOiJSUzI1NiIs...
+&authorization_details=%5B%7B%22type%22%3A%22rego_policy%22%2C
+  %22policy%22%3A%7B%22type%22%3A%22rego%22%2C%22content%22%3A%22...%22%2C
+  %22entry_point%22%3A%22allow%22%7D%7D%5D
+
+                              Figure 12
+
+8.3.  Token Exchange (RFC 8693)
+
+   When exchanging tokens [RFC8693], a new behavioral constraint
+   contract can be provided to refine or restrict the approved
+   behavioral boundaries:
+
+POST /token HTTP/1.1
+Host: as.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange
+&subject_token=eyJhbGciOiJSUzI1NiJ9...
+&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token
+&authorization_details=%5B%7B%22type%22%3A%22rego_policy%22%2C
+  %22policy%22%3A%7B%22type%22%3A%22rego%22%2C%22content%22%3A%22...%22%2C
+  %22entry_point%22%3A%22allow%22%7D%7D%5D
+
+                              Figure 13
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 24]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   The resulting access token MUST include the new behavioral constraint
+   contract.  The AS SHOULD verify that the new policy does not appear
+   to grant permissions exceeding those of the original token.  The AS
+   MAY use the RAR common fields (actions, locations) as an
+   approximation, since comparing two Rego policies for semantic subset
+   containment is undecidable in the general case.
+
+   Token Exchange is a common trigger for *behavioral drift*: when an
+   agent's next planned behavior falls outside the approved policy
+   constraints, the Resource Server can return an
+   insufficient_authorization error with a rego_profile (as defined in
+   Section 5), guiding the agent toward constructing an appropriate
+   Token Exchange request with an updated behavioral constraint
+   contract.  This enables multi-hop delegation scenarios where each hop
+   progressively refines the behavioral boundaries to match the
+   delegatee's specific task requirements.
+
+9.  Security Considerations
+
+9.1.  Policy Injection
+
+   Rego policies submitted by clients are evaluable policy definitions.
+   Although Rego is a declarative language, it supports recursive rules,
+   regular expressions, and built-in functions that may lead to non-
+   terminating or resource-intensive evaluations.  Maliciously crafted
+   policies can exploit catastrophic backtracking in regular expressions
+   (e.g., regex.match("^(a+)+$", "aaa...!")) or trigger combinatorial
+   explosion in set operations, leading to denial of service at the
+   Resource Server's policy engine.  The AS and RS MUST:
+
+   *  Validate policy syntax before registration;
+
+   *  Evaluate policies in sandboxed environments;
+
+   *  Limit policy evaluation time and resource usage;
+
+   *  Restrict dangerous built-in functions (e.g., http.send);
+
+   *  Restrict or sanitize regular expressions in policies to prevent
+      catastrophic backtracking (ReDoS);
+
+   *  Enforce recursion depth limits and set size bounds.
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 25]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+9.2.  Behavioral Boundary Evasion
+
+   In a behavioral authorization framework, the client (agent) proposes
+   the behavioral constraint policy.  A malicious agent could craft a
+   policy that appears restrictive in its Rego structure but contains
+   subtle permissiveness.  For example, using negation-by-failure to
+   create unintended allow paths, or embedding wildcard conditions that
+   match broader behavior sets than the RAR common fields suggest.  The
+   AS SHOULD perform lightweight static analysis (e.g., extracting
+   referenced input.action values, detecting unbounded wildcards) to
+   detect obvious inconsistencies.  The Resource Server, as the policy
+   execution point, bears final responsibility for ensuring each agent
+   behavior is verified against the approved constraints.
+
+9.3.  Policy Integrity
+
+   The policy_ref in access tokens MUST reference policies stored
+   securely by the AS.  Resource Servers MUST fetch policies only from
+   trusted sources.
+
+   When retrieving policy content from the policy_ref.endpoint URL, the
+   Resource Server SHOULD authenticate to the AS policy endpoint using
+   mutually authenticated TLS (mTLS) or a pre-shared service token.
+   Anonymous retrieval of policy content SHOULD NOT be performed, as it
+   allows any party that discovers the endpoint URL to obtain the policy
+   content.  The hash field in policy_ref provides integrity
+   verification of the retrieved content but does not authenticate the
+   retrieval channel itself.
+
+   Resource Servers SHOULD invalidate cached policy content when the
+   associated access token expires.  If the AS revokes a registered
+   policy before the token expires, the RS MUST treat subsequent policy
+   evaluations as failed (deny-by-default).  The AS MAY signal policy
+   revocation via token introspection [RFC7662] (indicating the token is
+   no longer active) or through a deployment-specific notification
+   mechanism.
+
+9.4.  Policy URI Fetching
+
+   When the uri field within the policy object is present, the AS
+   fetches policy content from a client-provided URI.  This introduces
+   Server-Side Request Forgery (SSRF) risks.  The AS MUST:
+
+   *  Reject URIs pointing to private/internal network addresses
+      (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16,
+      127.0.0.0/8, ::1, and link-local addresses);
+
+   *  Enforce HTTPS for all policy URIs;
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 26]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   *  Set strict timeouts and size limits on fetched content;
+
+   *  Validate that the fetched content is syntactically valid Rego
+      before any evaluation.
+
+9.5.  Policy Size Limits
+
+   Rego policies embedded inline within authorization_details can
+   significantly increase token request and access token size.
+   Implementations MUST enforce limits on:
+
+   *  Maximum policy source size (RECOMMENDED limit: 4 KB for inline
+      policies).  Note that JWT access tokens are typically carried in
+      HTTP Authorization headers, where many proxies and load balancers
+      enforce an 8 KB total header size limit;
+
+   *  Maximum policy complexity (e.g., nesting depth, number of rules);
+
+   *  Total authorization_details payload size in token requests.
+
+   For policies exceeding these limits, clients SHOULD use pre-
+   registered policies referenced via policy_ref rather than inline
+   policy content.
+
+9.6.  Error Response Header Size
+
+   The rego_profile parameter carried in the WWW-Authenticate header
+   (see Section 5) is a base64url-encoded JSON object that can include
+   multiple constraint definitions, required claims, and scope arrays.
+   Implementations MUST enforce size limits on the rego_profile value to
+   avoid exceeding HTTP header size limits imposed by intermediaries.  A
+   RECOMMENDED limit is 2 KB for the base64url-encoded rego_profile
+   value.  Resource servers that require larger profiles SHOULD consider
+   returning only a profile_uri reference and having clients fetch the
+   full profile separately.
+
+9.7.  Behavioral Audit
+
+   In behavioral authorization, the policy defines _what behaviors are
+   permitted_, but compliance requires evidence of _what behaviors were
+   actually performed_. This is especially critical in AI agent
+   scenarios where the agent operates autonomously and may execute long
+   sequences of behaviors without direct human oversight.
+
+   Resource Servers SHOULD log each policy evaluation event including:
+   the policy identifier (policy_ref.id), a hash or summary of the
+   evaluated input, the allow/deny result, and the evaluation timestamp.
+   These audit logs enable post-incident analysis of agent behavior,
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 27]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   detection of behavioral drift patterns, and compliance reporting.
+   Audit logs SHOULD be protected against tampering and retained
+   according to the deployment's data retention policy.  Authorization
+   Servers MAY also log behavioral constraint proposals received from
+   clients to detect repeated boundary-testing behavior by malicious
+   agents.
+
+10.  Privacy Considerations
+
+   Implementations of this specification MUST consider the following
+   privacy aspects per BCP 188 [RFC6973]:
+
+   *  *Policy Content Privacy*: Rego policies embedded in
+      authorization_details may reference user attributes (e.g.,
+      input.user.tier, input.user.role).  When policies are carried in
+      JWT access tokens, these attribute references are visible to any
+      party that can decode the token.  Implementations SHOULD avoid
+      embedding personally identifiable information (PII) directly in
+      policy content and instead reference abstract attribute names that
+      the Resource Server resolves at evaluation time.
+
+   *  *Constraint Disclosure*: The rego_profile returned in error
+      responses reveals authorization policy constraints to the
+      requesting client.  While this disclosure is necessary for the
+      reverse-guided authorization flow, resource servers SHOULD limit
+      the information to what is strictly needed for the client to
+      construct a valid authorization request, and MUST NOT include
+      internal implementation details, database schemas, or
+      infrastructure information.
+
+   *  *Policy Endpoint Exposure*: The policy_ref.endpoint field and the
+      auth_server field in rego_profile reveal internal URLs of the
+      Authorization Server.  Deployments SHOULD use well-known or
+      abstract endpoint identifiers rather than exposing internal
+      service URLs.
+
+   *  *Behavioral Profiling*: The sequence of rego_policy behavioral
+      constraint proposals submitted by a client may reveal the client's
+      intent, capabilities, or decision-making patterns.  Authorization
+      Servers SHOULD treat behavioral constraint proposals with the same
+      confidentiality as other authorization request parameters and MUST
+      NOT use them for purposes beyond authorization decision-making
+      without explicit consent.
+
+11.  IANA Considerations
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 28]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+11.1.  RAR Authorization Data Type Registration
+
+   This specification defines the following authorization data type for
+   use with the authorization_details parameter defined in RFC 9396:
+
+   Type Name:  rego_policy
+
+   Description:  A Rego behavioral constraint contract for per-behavior
+      authorization verification, including policy content, entry point,
+      and optional evaluation context.
+
+   Change Controller:  IETF
+
+   Specification Document:  Section 3 of this document
+
+11.2.  JWT Access Token Claims Registration
+
+   This specification registers the following claim in the "JWT Access
+   Token JWT Claims" registry established by [RFC9068]:
+
+   Claim Name:  policy_ref
+
+   Claim Description:  A reference to a registered Rego behavioral
+      constraint contract in JWT access tokens.
+
+   Change Controller:  IETF
+
+   Specification Document:  Section 3.2 of this document
+
+11.3.  OAuth 2.0 Bearer Token Error Values Registration
+
+   This specification registers the following error code in the "OAuth
+   2.0 Bearer Token Error Values" registry established by [RFC6750]:
+
+   Name:  insufficient_authorization
+
+   Error Usage Location:  Resource server error response using the WWW-
+      Authenticate header per [RFC6750].
+
+   Related Error Codes:  The existing insufficient_scope error defined
+      in [RFC6750] addresses scope insufficiency.
+      insufficient_authorization (this specification) addresses the case
+      where the resource server returns structured policy constraints
+      (rego_profile) for clients capable of constructing policy-based
+      authorization requests.
+
+   Reference:  Section 5 of this document
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 29]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+11.4.  WWW-Authenticate Parameter Definition
+
+   This specification defines a new parameter for use in the WWW-
+   Authenticate header field with the Bearer authentication scheme, as
+   defined in [RFC6750].
+
+   Parameter Name:  rego_profile
+
+   Parameter Usage Location:  WWW-Authenticate response header field,
+      used in resource server error responses per [RFC6750] Section 3.
+
+   Parameter Description:  A base64url-encoded JSON object containing
+      structured policy constraints and authorization requirements that
+      guide the client toward obtaining sufficient authorization.  The
+      structure is defined in Section 5 of this document.
+
+   Change Controller:  IETF
+
+   Specification Document:  Section 5 of this document
+
+   RFC 6750 does not establish an IANA sub-registry for Bearer
+   authentication scheme parameters.  This section serves as the
+   specification reference for the rego_profile parameter.
+
+12.  References
+
+12.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <https://www.rfc-editor.org/info/rfc4648>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <https://www.rfc-editor.org/info/rfc6749>.
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 30]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   [RFC6750]  Jones, M. and D. Hardt, "The OAuth 2.0 Authorization
+              Framework: Bearer Token Usage", RFC 6750,
+              DOI 10.17487/RFC6750, October 2012,
+              <https://www.rfc-editor.org/info/rfc6750>.
+
+   [RFC6973]  Cooper, A., Tschofenig, H., Aboba, B., Peterson, J.,
+              Morris, J., Hansen, M., and R. Smith, "Privacy
+              Considerations for Internet Protocols", RFC 6973,
+              DOI 10.17487/RFC6973, July 2013,
+              <https://www.rfc-editor.org/info/rfc6973>.
+
+   [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
+              (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
+              <https://www.rfc-editor.org/info/rfc7519>.
+
+   [RFC9068]  Bertocci, V., "JSON Web Token (JWT) Profile for OAuth 2.0
+              Access Tokens", RFC 9068, DOI 10.17487/RFC9068, October
+              2021, <https://www.rfc-editor.org/info/rfc9068>.
+
+   [RFC9396]  Lodderstedt, T., Richer, J., and B. Campbell, "OAuth 2.0
+              Rich Authorization Requests", RFC 9396,
+              DOI 10.17487/RFC9396, May 2023,
+              <https://www.rfc-editor.org/info/rfc9396>.
+
+12.2.  Informative References
+
+   [RFC8414]  Jones, M., Sakimura, N., and J. Bradley, "OAuth 2.0
+              Authorization Server Metadata", RFC 8414,
+              DOI 10.17487/RFC8414, June 2018,
+              <https://www.rfc-editor.org/info/rfc8414>.
+
+   [RFC9728]  Jones, M.B., Hunt, P., and A. Parecki, "OAuth 2.0
+              Protected Resource Metadata", RFC 9728,
+              DOI 10.17487/RFC9728, April 2025,
+              <https://www.rfc-editor.org/info/rfc9728>.
+
+   [RFC8693]  Jones, M., Nadalin, A., Campbell, B., Ed., Bradley, J.,
+              and C. Mortimore, "OAuth 2.0 Token Exchange", RFC 8693,
+              DOI 10.17487/RFC8693, January 2020,
+              <https://www.rfc-editor.org/info/rfc8693>.
+
+   [RFC7662]  Richer, J., Ed., "OAuth 2.0 Token Introspection",
+              RFC 7662, DOI 10.17487/RFC7662, October 2015,
+              <https://www.rfc-editor.org/info/rfc7662>.
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 31]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   [RFC7591]  Richer, J., Ed., Jones, M., Bradley, J., Machulak, M., and
+              P. Hunt, "OAuth 2.0 Dynamic Client Registration Protocol",
+              RFC 7591, DOI 10.17487/RFC7591, July 2015,
+              <https://www.rfc-editor.org/info/rfc7591>.
+
+   [I-D.parecki-oauth-jwt-grant-interaction-response]
+              Parecki, A., Campbell, B., and D. Liu, "JWT Authorization
+              Grant Interaction Response", Work in Progress, Internet-
+              Draft, draft-parecki-oauth-jwt-grant-interaction-response-
+              00, 24 March 2026, <https://datatracker.ietf.org/doc/html/
+              draft-parecki-oauth-jwt-grant-interaction-response-00>.
+
+   [OPA]      Cloud Native Computing Foundation, "Open Policy Agent",
+              2024, <https://www.openpolicyagent.org/>.
+
+   [Rego]     Open Policy Agent, "Rego Policy Language", 2024,
+              <https://www.openpolicyagent.org/docs/latest/policy-
+              language/>.
+
+   [I-D.liu-oauth-chain-delegation]
+              Liu, D., Zhu, H., Krishnan, S., and A. Parecki,
+              "Delegation Chain for OAuth 2.0", Work in Progress,
+              Internet-Draft, draft-liu-oauth-chain-delegation, June
+              2026, <https://datatracker.ietf.org/doc/html/draft-liu-
+              oauth-chain-delegation>.
+
+Appendix A.  Example Policies
+
+A.1.  Amount-Based Authorization
+
+   package agent
+
+   default allow = false
+
+   # Allow transactions up to $50
+   allow if {
+     input.action == "purchase"
+     input.amount <= 50.0
+   }
+
+   # Allow cart modifications without amount limit
+   allow if {
+     input.action == "add_to_cart"
+   }
+
+                                 Figure 14
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 32]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+A.2.  Time-Window Authorization
+
+   package agent
+
+   default allow = false
+
+   # Allow during business hours
+   allow if {
+     input.action == "submit_order"
+     hour := time.clock(time.now_ns())[0]
+     hour >= 9
+     hour < 18
+   }
+
+                                 Figure 15
+
+A.3.  Role-Based Authorization
+
+   package agent
+
+   default allow = false
+
+   # Premium users can access all features
+   allow if {
+     input.user.tier == "premium"
+   }
+
+   # Standard users limited to basic actions
+   allow if {
+     input.user.tier == "standard"
+     input.action == "read"
+   }
+
+                                 Figure 16
+
+Acknowledgments
+
+   The authors would like to thank Brian Campbell for his valuable
+   feedback and insightful discussions during the development of this
+   specification.  His contributions helped shape key design decisions.
+
+Authors' Addresses
+
+   Dapeng Liu
+   Alibaba Group
+   Email: max.ldp@alibaba-inc.com
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 33]
+
+Internet-Draft            Rego Policy in OAuth                 June 2026
+
+
+   Hongru Zhu
+   Alibaba Group
+   Email: hongru.zhr@alibaba-inc.com
+
+
+   Suresh Krishnan
+   Cisco
+   Email: suresh.krishnan@gmail.com
+
+
+   Aaron Parecki
+   Okta
+   Email: aaron@parecki.com
+
+
+   Hui Xue
+   Alibaba Group
+   Email: hui.xueh@alibaba-inc.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Liu, et al.             Expires 11 December 2026               [Page 34]

--- a/interop/oauth-liu-composition/emit-vectors.ts
+++ b/interop/oauth-liu-composition/emit-vectors.ts
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+//
+// Emits the three Liu composition vectors through SDK APIs only. Inputs are
+// the Liu-shaped fixtures in vectors/*/input.json (their field names, see
+// drafts/EXTRACTED-FIELDS.md); outputs are signed APS records in record.json
+// plus a keys.json sidecar carrying the public half of the fresh test keys.
+// Existing record shapes only: ReceiptV1 (profile aps-receipt-v1) for the
+// permit and denial, SignedRevocationObservation for the observation. Keys are
+// fixed test keys derived from published seeds; DIDs and agent ids are
+// synthetic throughout.
+
+import { createHash, createPrivateKey, createPublicKey } from 'node:crypto'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { strictJCS } from '../../src/v2/receipt-core/jcs.js'
+import { createReceiptV1 } from '../../src/v2/receipt-core/receipt.js'
+import { buildDecisionRefV1, computeDecisionComponentRefV1 } from '../../src/v2/receipt-core/decision-ref.js'
+import type { CoreDecisionOutputV1, EvidenceRefV1, JsonValue, ReceiptV1 } from '../../src/v2/receipt-core/types.js'
+import { computeActionRefV2, createActionReferenceInputV2 } from '../../src/v2/action-reference/v2.js'
+import { buildRevocationObservation } from '../../src/v2/revocation-enforcement/observation.js'
+import { LocalEd25519Signer } from '../../src/adapters/remote-signer/local-signer.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf8').digest('hex')
+const digestOf = (value: JsonValue): string => sha256Hex(strictJCS(value))
+
+// DETERMINISTIC TEST KEYS, publish-safe by design. The committed vector
+// records must be byte-stable across re-runs, so both signing keys derive
+// from fixed ASCII seeds instead of fresh randomness. These are TEST keys,
+// published intentionally with the vectors; never use them for any real
+// identity and never reuse them outside this harness.
+const TEST_SEED_ISSUER = Buffer.from('APS-test-issuer-seed-00000000001', 'utf8').toString('hex')
+const TEST_SEED_OBSERVER = Buffer.from('APS-test-observer-seed-000000001', 'utf8').toString('hex')
+const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex')
+
+function testKeyPairFromSeed(seedHex: string): { privateKey: string; publicKey: string } {
+  if (seedHex.length !== 64) throw new Error('test seed must be 32 bytes of hex')
+  const priv = createPrivateKey({
+    key: Buffer.concat([ED25519_PKCS8_PREFIX, Buffer.from(seedHex, 'hex')]),
+    format: 'der',
+    type: 'pkcs8'
+  })
+  const spki = createPublicKey(priv).export({ format: 'der', type: 'spki' }) as Buffer
+  return { privateKey: seedHex, publicKey: spki.subarray(spki.length - 32).toString('hex') }
+}
+
+// Fixed timestamps and fixed test keys together make every emitted byte
+// reproducible; re-running emit rewrites identical files.
+const ISSUED_AT = '2026-07-18T19:30:00.000Z'
+const OBSERVED_AT = '2026-07-18T19:31:00.000Z'
+
+interface LiuHop {
+  delegator_id: string
+  delegatee_id: string
+  delegation_timestamp: number
+  root_evidence_ref: string
+  delegated_policy: { type: string; content: string; entry_point: string }
+  operation_summary: string
+  delegator_signature: string
+  as_signature: string
+  [k: string]: JsonValue
+}
+
+/** Actions a hop's rego policy allows, read from the draft's own clause form
+ *  `input.action == "<name>"` (chain-delegation-00 Figure 1 uses exactly this). */
+export function allowedActions(hop: LiuHop): Set<string> {
+  const out = new Set<string>()
+  for (const m of hop.delegated_policy.content.matchAll(/input\.action == "([^"]+)"/g)) out.add(m[1])
+  return out
+}
+
+/** The chain's narrowed subset is the final hop's allowed set. The harness also
+ *  checks the Liu narrowing invariant: every hop's set is a subset of its
+ *  parent's. */
+export function narrowedSubset(chain: LiuHop[]): { narrowed: Set<string>; monotonic: boolean } {
+  let monotonic = true
+  for (let i = 1; i < chain.length; i++) {
+    const parent = allowedActions(chain[i - 1])
+    for (const a of allowedActions(chain[i])) if (!parent.has(a)) monotonic = false
+  }
+  return { narrowed: allowedActions(chain[chain.length - 1]), monotonic }
+}
+
+function loadInput(vector: string): Record<string, JsonValue> {
+  return JSON.parse(readFileSync(join(HERE, 'vectors', vector, 'input.json'), 'utf8'))
+}
+
+function emitDecisionReceipt(vector: 'v1-permit' | 'v2-denial'): void {
+  const input = loadInput(vector)
+  const chain = input.delegation_chain as unknown as LiuHop[]
+  const authorizationDetails = input.authorization_details as JsonValue
+  const ctx = input.rego_decision_context as {
+    policy_ref: { id: string; version: string; hash: string }
+    evaluated_input: { action: string; item_id: string; agent: string }
+    input_hash: string
+    result: 'allow' | 'deny'
+    evaluation_timestamp: number
+  }
+
+  // Fill the 9.7 tuple's input hash from the actual evaluated input, and pin
+  // policy_ref.hash to the final hop's rego content in the draft's
+  // algorithm-base64value format.
+  const finalHop = chain[chain.length - 1]
+  ctx.input_hash = `sha256:${digestOf(ctx.evaluated_input as unknown as JsonValue)}`
+  ctx.policy_ref.hash = `sha256-${Buffer.from(sha256Hex(finalHop.delegated_policy.content), 'hex').toString('base64')}`
+
+  const { narrowed, monotonic } = narrowedSubset(chain)
+  if (!monotonic) throw new Error(`${vector}: fixture violates the narrowing invariant`)
+  const requested = ctx.evaluated_input.action
+  const inSubset = narrowed.has(requested)
+  const expectDeny = vector === 'v2-denial'
+  if (expectDeny === inSubset) throw new Error(`${vector}: fixture scope does not match its intent`)
+  if ((ctx.result === 'allow') !== inSubset) throw new Error(`${vector}: rego result disagrees with the subset check`)
+
+  const subject = finalHop.delegatee_id
+  const actionRefInput = createActionReferenceInputV2({
+    agent_id: subject,
+    action_type: requested,
+    target: `item:${ctx.evaluated_input.item_id}`,
+    payload_ref: digestOf(ctx.evaluated_input as unknown as JsonValue),
+    scope_required: [requested],
+    issued_at: ISSUED_AT,
+    // 32 lowercase hex chars, deterministic per vector so re-emits are comparable.
+    nonce: sha256Hex(`liu-composition-${vector}`).slice(0, 32),
+  })
+  const action_ref = computeActionRefV2(actionRefInput)
+
+  const chainState = { delegation_chain: chain } as unknown as JsonValue
+  const decisionOutput: CoreDecisionOutputV1 = ctx.result === 'allow'
+    ? { profile: 'aps-core-decision-output-v1', verdict: 'permit',
+        effective_authority_ref: computeDecisionComponentRefV1('authority', chainState),
+        constraints: [...narrowed].sort() }
+    : { profile: 'aps-core-decision-output-v1', verdict: 'deny',
+        effective_authority_ref: null,
+        constraints: [`requested_action_outside_narrowed_subset:${requested}`] }
+
+  const { decision_ref } = buildDecisionRefV1({
+    action_ref,
+    authority_state: chainState,
+    policy_input: ctx.policy_ref as unknown as JsonValue,
+    decision_context: {
+      policy_ref: ctx.policy_ref, input_hash: ctx.input_hash,
+      result: ctx.result, evaluation_timestamp: ctx.evaluation_timestamp,
+    } as unknown as JsonValue,
+    decision_output: decisionOutput as unknown as JsonValue,
+  })
+
+  const evidence_refs: EvidenceRefV1[] = [
+    { artifact_type: 'liu-oauth-authorization-evidence-01/authorization_details', sha256: digestOf(authorizationDetails) },
+    { artifact_type: 'liu-oauth-chain-delegation-00/delegation_chain', sha256: digestOf(chainState) },
+  ]
+
+  const issuerKeys = testKeyPairFromSeed(TEST_SEED_ISSUER)
+  const issuer = 'did:aps:test:liu-composition-issuer'
+  const receipt: ReceiptV1 = createReceiptV1({
+    profile: 'aps-receipt-v1',
+    receipt_type: 'policy-decision',
+    issuer,
+    subject_agent: subject,
+    action_ref,
+    delegation_ref: `liu-chain:sha256:${digestOf(chainState)}`,
+    decision_ref,
+    issued_at: ISSUED_AT,
+    evidence_refs,
+    result: ctx.result === 'allow'
+      ? { decision: 'allow', policy_id: ctx.policy_ref.id, narrowed_subset: [...narrowed].sort() }
+      : { decision: 'deny', policy_id: ctx.policy_ref.id,
+          reason: 'requested_action_outside_narrowed_subset',
+          requested_action: requested, narrowed_subset: [...narrowed].sort() },
+  }, [{ signer: issuer, key_id: 'test-key-1', private_key: issuerKeys.privateKey }])
+
+  writeFileSync(join(HERE, 'vectors', vector, 'record.json'), JSON.stringify(receipt, null, 1) + '\n')
+  writeFileSync(join(HERE, 'vectors', vector, 'keys.json'), JSON.stringify({
+    signer: issuer, key_id: 'test-key-1', public_key_hex: issuerKeys.publicKey,
+  }, null, 1) + '\n')
+  console.log(`${vector}: receipt ${receipt.receipt_id} (${ctx.result})`)
+}
+
+async function emitObservation(): Promise<void> {
+  const input = loadInput('v3-observation')
+  const chain = input.delegation_chain as unknown as LiuHop[]
+  const signal = input.revocation_signal as {
+    set_jti: string
+    revoked_hop: { delegator_id: string; delegatee_id: string }
+    revoked_at: string
+  }
+  const { narrowed } = narrowedSubset(chain)
+  const keys = testKeyPairFromSeed(TEST_SEED_OBSERVER)
+  const signer = new LocalEd25519Signer({ privateKeyHex: keys.privateKey, keyId: 'observer-key-1' })
+  const record = await buildRevocationObservation({
+    authority_ref: `liu-chain-hop:${signal.revoked_hop.delegator_id}->${signal.revoked_hop.delegatee_id}`,
+    status_source: { kind: 'set', jti: signal.set_jti },
+    revoked_at: signal.revoked_at,
+    observed_at: OBSERVED_AT,
+    maximum_staleness_ms: 300000,
+    affected_scope: [...narrowed].sort().join(' '),
+    decision: { effect: 'deny' },
+  }, signer)
+  writeFileSync(join(HERE, 'vectors', 'v3-observation', 'record.json'), JSON.stringify(record, null, 1) + '\n')
+  console.log(`v3-observation: observation signed by ${record.observer_key_id}`)
+}
+
+export async function emitAll(): Promise<void> {
+  emitDecisionReceipt('v1-permit')
+  emitDecisionReceipt('v2-denial')
+  await emitObservation()
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  emitAll().then(() => console.log('all vectors emitted')).catch(err => { console.error(err); process.exit(1) })
+}

--- a/interop/oauth-liu-composition/independent-verify.mjs
+++ b/interop/oauth-liu-composition/independent-verify.mjs
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+//
+// Independent verifier: no SDK imports. Recomputes the strict JCS (RFC 8785)
+// canonical form, the tagged digests, and the Ed25519 signatures for all three
+// committed vectors using node builtins only, and prints PASS or FAIL per
+// check. A third party holding record.json and the public key can reproduce
+// exactly this.
+//
+// Payload constructions mirrored here (from the SDK's published tags):
+//   receipt id:   sha256("APS-RECEIPT-ID-V1" \0 JCS(receipt minus receipt_id, signatures))
+//   receipt sig:  Ed25519 over "APS-RECEIPT-SIG-V1" \0 JCS({receipt: minus signatures, signer: descriptor})
+//   observation:  Ed25519 over JCS(record minus signature)
+
+import { createHash, verify as cryptoVerify, createPublicKey } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const load = (...p) => JSON.parse(readFileSync(join(HERE, ...p), 'utf8'))
+
+// Minimal RFC 8785 JCS: sorted keys by UTF-16 code units, JSON.stringify
+// number/string semantics. Rejects non-finite numbers and undefined.
+function jcs(value) {
+  if (value === null || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('jcs: non-finite number')
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(jcs).join(',')}]`
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort()
+    return `{${keys.map(k => `${JSON.stringify(k)}:${jcs(value[k])}`).join(',')}}`
+  }
+  throw new Error(`jcs: unsupported type ${typeof value}`)
+}
+
+const sha256Hex = s => createHash('sha256').update(s, 'utf8').digest('hex')
+
+// Raw 32-byte Ed25519 public key hex to a KeyObject via SPKI DER framing.
+function ed25519Key(publicKeyHex) {
+  const raw = Buffer.from(publicKeyHex, 'hex')
+  if (raw.length !== 32) throw new Error('public key must be 32 bytes')
+  const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw])
+  return createPublicKey({ key: spki, format: 'der', type: 'spki' })
+}
+
+function ed25519Verify(message, signatureHex, publicKeyHex) {
+  return cryptoVerify(null, Buffer.from(message, 'utf8'), ed25519Key(publicKeyHex), Buffer.from(signatureHex, 'hex'))
+}
+
+let failures = 0
+function report(name, ok, detail = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'} ${name}${detail ? ` (${detail})` : ''}`)
+  if (!ok) failures++
+}
+
+for (const vector of ['v1-permit', 'v2-denial']) {
+  const receipt = load('vectors', vector, 'record.json')
+  const keys = load('vectors', vector, 'keys.json')
+
+  const { receipt_id, signatures, ...idBody } = receipt
+  const idPayload = `APS-RECEIPT-ID-V1\0${jcs(idBody)}`
+  report(`${vector} receipt_id recomputes`, sha256Hex(idPayload) === receipt_id)
+
+  const { signatures: _s, ...sigBody } = receipt
+  for (const proof of signatures) {
+    const { value, ...descriptor } = proof
+    const payload = `APS-RECEIPT-SIG-V1\0${jcs({ receipt: sigBody, signer: descriptor })}`
+    const keyOk = proof.signer === keys.signer && proof.key_id === keys.key_id
+    report(`${vector} signature by ${proof.key_id}`, keyOk && ed25519Verify(payload, value, keys.public_key_hex))
+  }
+}
+
+{
+  const record = load('vectors', 'v3-observation', 'record.json')
+  const { signature, ...body } = record
+  report('v3-observation signature', ed25519Verify(jcs(body), signature, record.observer_key),
+    `observer ${record.observer_key_id}`)
+  report('v3-observation status_source is a SET reference',
+    record.status_source && record.status_source.kind === 'set' && typeof record.status_source.jti === 'string')
+}
+
+process.exit(failures === 0 ? 0 : 1)

--- a/interop/oauth-liu-composition/independent-verify.mjs
+++ b/interop/oauth-liu-composition/independent-verify.mjs
@@ -2,15 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Independent verifier: no SDK imports. Recomputes the strict JCS (RFC 8785)
-// canonical form, the tagged digests, and the Ed25519 signatures for all three
-// committed vectors using node builtins only, and prints PASS or FAIL per
-// check. A third party holding record.json and the public key can reproduce
-// exactly this.
+// canonical form, the tagged digests, the evidence tie-back digests from the
+// input fixtures, and the Ed25519 signatures for all three committed vectors
+// using node builtins only, and prints PASS or FAIL per check. A third party
+// holding record.json, input.json and the public key can reproduce exactly
+// this.
 //
 // Payload constructions mirrored here (from the SDK's published tags):
 //   receipt id:   sha256("APS-RECEIPT-ID-V1" \0 JCS(receipt minus receipt_id, signatures))
 //   receipt sig:  Ed25519 over "APS-RECEIPT-SIG-V1" \0 JCS({receipt: minus signatures, signer: descriptor})
 //   observation:  Ed25519 over JCS(record minus signature)
+//   evidence ref: sha256(JCS(input artifact)) must equal the committed evidence_refs entry
 
 import { createHash, verify as cryptoVerify, createPublicKey } from 'node:crypto'
 import { readFileSync } from 'node:fs'
@@ -60,6 +62,7 @@ function report(name, ok, detail = '') {
 for (const vector of ['v1-permit', 'v2-denial']) {
   const receipt = load('vectors', vector, 'record.json')
   const keys = load('vectors', vector, 'keys.json')
+  const input = load('vectors', vector, 'input.json')
 
   const { receipt_id, signatures, ...idBody } = receipt
   const idPayload = `APS-RECEIPT-ID-V1\0${jcs(idBody)}`
@@ -72,15 +75,29 @@ for (const vector of ['v1-permit', 'v2-denial']) {
     const keyOk = proof.signer === keys.signer && proof.key_id === keys.key_id
     report(`${vector} signature by ${proof.key_id}`, keyOk && ed25519Verify(payload, value, keys.public_key_hex))
   }
+
+  // Tie-back: the receipt's evidence digests must equal digests recomputed
+  // here from the Liu artifacts in input.json, so record and input cannot
+  // drift apart silently.
+  const wantEvidence = sha256Hex(jcs(input.authorization_details))
+  const wantChain = sha256Hex(jcs({ delegation_chain: input.delegation_chain }))
+  const byType = new Map(receipt.evidence_refs.map(r => [r.artifact_type, r.sha256]))
+  report(`${vector} authorization_details digest ties back to input.json`,
+    byType.get('liu-oauth-authorization-evidence-01/authorization_details') === wantEvidence)
+  report(`${vector} delegation_chain digest ties back to input.json`,
+    byType.get('liu-oauth-chain-delegation-00/delegation_chain') === wantChain)
 }
 
 {
   const record = load('vectors', 'v3-observation', 'record.json')
+  const input = load('vectors', 'v3-observation', 'input.json')
   const { signature, ...body } = record
   report('v3-observation signature', ed25519Verify(jcs(body), signature, record.observer_key),
     `observer ${record.observer_key_id}`)
   report('v3-observation status_source is a SET reference',
     record.status_source && record.status_source.kind === 'set' && typeof record.status_source.jti === 'string')
+  report('v3-observation SET jti ties back to input.json',
+    record.status_source.jti === input.revocation_signal.set_jti)
 }
 
 process.exit(failures === 0 ? 0 : 1)

--- a/interop/oauth-liu-composition/test.ts
+++ b/interop/oauth-liu-composition/test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+//
+// node --test suite for the Liu composition vectors: emit, verify, tie-back,
+// and tamper cases. Tamper mutations run on in-memory copies of the committed
+// records; nothing on disk is modified by this suite.
+
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { verifyReceiptV1 } from '../../src/v2/receipt-core/receipt.js'
+import type { ReceiptV1 } from '../../src/v2/receipt-core/types.js'
+import { verifyRevocationObservation } from '../../src/v2/revocation-enforcement/observation.js'
+import type { SignedRevocationObservation } from '../../src/v2/revocation-enforcement/types.js'
+import { emitAll } from './emit-vectors.js'
+import { verifyAll, verifyReceiptVector, verifyObservationVector } from './verify-vectors.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const load = (...p: string[]): unknown => JSON.parse(readFileSync(join(HERE, ...p), 'utf8'))
+const flipHexNibble = (hex: string, at: number): string =>
+  hex.slice(0, at) + ((parseInt(hex[at], 16) ^ 0x1).toString(16)) + hex.slice(at + 1)
+
+function receiptResolver(vector: string) {
+  const keys = load('vectors', vector, 'keys.json') as { signer: string; key_id: string; public_key_hex: string }
+  return (signer: string, keyId: string): string | undefined =>
+    signer === keys.signer && keyId === keys.key_id ? keys.public_key_hex : undefined
+}
+
+describe('liu composition vectors: emit and verify', () => {
+  before(async () => {
+    // Re-emit so the suite always exercises the full emit path. Keys and
+    // timestamps are pinned, so emitted bytes are stable across runs.
+    await emitAll()
+  })
+
+  it('emitted vectors are byte-stable across re-runs', async () => {
+    const files = [
+      ['vectors', 'v1-permit', 'record.json'], ['vectors', 'v1-permit', 'keys.json'],
+      ['vectors', 'v2-denial', 'record.json'], ['vectors', 'v2-denial', 'keys.json'],
+      ['vectors', 'v3-observation', 'record.json']
+    ]
+    const first = files.map(p => readFileSync(join(HERE, ...p), 'utf8'))
+    await emitAll()
+    const second = files.map(p => readFileSync(join(HERE, ...p), 'utf8'))
+    assert.deepEqual(second, first)
+  })
+
+  it('all three vectors verify through the SDK path', () => {
+    const results = verifyAll()
+    for (const r of results) assert.equal(r.valid, true, `${r.vector}: ${r.detail}`)
+  })
+
+  it('v1 permit records an allow tied to the evidence and chain state', () => {
+    const receipt = load('vectors', 'v1-permit', 'record.json') as ReceiptV1
+    assert.equal(receipt.receipt_type, 'policy-decision')
+    assert.equal(receipt.result.decision, 'allow')
+    assert.ok(receipt.decision_ref, 'decision_ref present')
+    assert.equal(receipt.evidence_refs.length, 2)
+    assert.equal(verifyReceiptVector('v1-permit').valid, true)
+  })
+
+  it('v2 denial records the subset violation', () => {
+    const receipt = load('vectors', 'v2-denial', 'record.json') as ReceiptV1
+    assert.equal(receipt.result.decision, 'deny')
+    assert.equal(receipt.result.reason, 'requested_action_outside_narrowed_subset')
+    assert.equal(receipt.result.requested_action, 'cart_add')
+    assert.deepEqual(receipt.result.narrowed_subset, ['inventory_check'])
+    assert.equal(verifyReceiptVector('v2-denial').valid, true)
+  })
+
+  it('v3 observation carries the SET reference and the deny that followed', () => {
+    const record = load('vectors', 'v3-observation', 'record.json') as SignedRevocationObservation
+    assert.equal(record.status_source.kind, 'set')
+    assert.equal(record.decision.effect, 'deny')
+    assert.equal(record.maximum_staleness_ms, 300000)
+    assert.equal(record.affected_scope, 'inventory_check')
+    assert.equal(verifyObservationVector().valid, true)
+  })
+})
+
+describe('liu composition vectors: tamper cases', () => {
+  it('flipping one signature nibble on the permit receipt fails loud', () => {
+    const receipt = structuredClone(load('vectors', 'v1-permit', 'record.json')) as ReceiptV1
+    receipt.signatures[0].value = flipHexNibble(receipt.signatures[0].value, 3)
+    const res = verifyReceiptV1(receipt, receiptResolver('v1-permit'))
+    assert.equal(res.valid, false)
+    assert.ok(res.errors.includes('signature_invalid'), `errors: ${res.errors.join(',')}`)
+  })
+
+  it('mutating one evidence_refs digest fails loud', () => {
+    const receipt = structuredClone(load('vectors', 'v1-permit', 'record.json')) as ReceiptV1
+    receipt.evidence_refs[0].sha256 = flipHexNibble(receipt.evidence_refs[0].sha256, 0)
+    const res = verifyReceiptV1(receipt, receiptResolver('v1-permit'))
+    // The receipt_id commits to evidence_refs, so the mutation breaks both the
+    // id and every signature.
+    assert.equal(res.valid, false)
+    assert.ok(res.errors.includes('receipt_id_mismatch'), `errors: ${res.errors.join(',')}`)
+  })
+
+  it('flipping one signature nibble on the observation fails loud', () => {
+    const record = structuredClone(load('vectors', 'v3-observation', 'record.json')) as SignedRevocationObservation
+    record.signature = flipHexNibble(record.signature, 5)
+    const res = verifyRevocationObservation(record, { expectedObserverKey: record.observer_key })
+    assert.equal(res.valid, false)
+  })
+
+  it('denial asserts the subset violation, not a generic deny', () => {
+    const receipt = load('vectors', 'v2-denial', 'record.json') as ReceiptV1
+    assert.equal(receipt.result.reason, 'requested_action_outside_narrowed_subset')
+    assert.ok(!(receipt.result.narrowed_subset as string[]).includes(receipt.result.requested_action as string))
+  })
+})

--- a/interop/oauth-liu-composition/vectors/v1-permit/input.json
+++ b/interop/oauth-liu-composition/vectors/v1-permit/input.json
@@ -1,0 +1,65 @@
+{
+ "delegation_chain": [
+  {
+   "delegator_id": "wit://agent-a.test.invalid/sha256.aaa111synthetic",
+   "delegatee_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegation_timestamp": 1752868800,
+   "root_evidence_ref": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+   "delegated_policy": {
+    "type": "rego",
+    "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n}\n\nallow {\n  input.action == \"cart_add\"\n}",
+    "entry_point": "allow"
+   },
+   "operation_summary": "Delegate inventory check and cart add for the storefront session",
+   "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-delegator-sig-hop1",
+   "as_signature": "eyJhbGciOiJSUzI1NiJ9..synthetic-as-sig-hop1"
+  },
+  {
+   "delegator_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegatee_id": "wit://agent-c.test.invalid/sha256.ccc333synthetic",
+   "delegation_timestamp": 1752868860,
+   "root_evidence_ref": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+   "delegated_policy": {
+    "type": "rego",
+    "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n}",
+    "entry_point": "allow"
+   },
+   "operation_summary": "Narrow to inventory check only",
+   "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-delegator-sig-hop2",
+   "as_signature": "eyJhbGciOiJSUzI1NiJ9..synthetic-as-sig-hop2"
+  }
+ ],
+ "authorization_details": [
+  {
+   "type": "authorization_evidence",
+   "evidence": {
+    "id": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+    "user_confirmation": {
+     "displayed_content": "Allow the storefront agents to check inventory and add items to the cart",
+     "user_action": "confirmed_via_button_click",
+     "timestamp": 1752868740
+    },
+    "as_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-as-evidence-sig",
+    "audit_trail": {
+     "semantic_expansion_level": "medium",
+     "proposal_ref": "urn:uuid:proposal-synthetic-001"
+    }
+   }
+  }
+ ],
+ "rego_decision_context": {
+  "policy_ref": {
+   "id": "policy-storefront-narrowed",
+   "version": "1",
+   "hash": "sha256-placeholder-filled-by-emitter"
+  },
+  "evaluated_input": {
+   "action": "inventory_check",
+   "item_id": "123",
+   "agent": "wit://agent-c.test.invalid/sha256.ccc333synthetic"
+  },
+  "input_hash": "",
+  "result": "allow",
+  "evaluation_timestamp": 1752868920
+ }
+}

--- a/interop/oauth-liu-composition/vectors/v1-permit/keys.json
+++ b/interop/oauth-liu-composition/vectors/v1-permit/keys.json
@@ -1,0 +1,5 @@
+{
+ "signer": "did:aps:test:liu-composition-issuer",
+ "key_id": "test-key-1",
+ "public_key_hex": "137ed55258f893bd06cc4f9256f8cc0db3244ad55dcabe81816236aadb3b84d3"
+}

--- a/interop/oauth-liu-composition/vectors/v1-permit/record.json
+++ b/interop/oauth-liu-composition/vectors/v1-permit/record.json
@@ -1,0 +1,36 @@
+{
+ "profile": "aps-receipt-v1",
+ "receipt_type": "policy-decision",
+ "issuer": "did:aps:test:liu-composition-issuer",
+ "subject_agent": "wit://agent-c.test.invalid/sha256.ccc333synthetic",
+ "action_ref": "8a36264ba332d909a9799af44bf44a4948a804e2cb6b74feca3ae283659a0f34",
+ "delegation_ref": "liu-chain:sha256:686e0c331d00e9c15ed2544ecbd2f2873c09a1e7545af9e35bfe824a85967258",
+ "decision_ref": "60537aad5517665e61d0f5ae4c6f5182b4bcc49d18586622cf7c11470ddf7352",
+ "issued_at": "2026-07-18T19:30:00.000Z",
+ "evidence_refs": [
+  {
+   "artifact_type": "liu-oauth-authorization-evidence-01/authorization_details",
+   "sha256": "4150640f42ad625018cbf3b814e566aac48efd873a606dc9da0c9ada0af6d32a"
+  },
+  {
+   "artifact_type": "liu-oauth-chain-delegation-00/delegation_chain",
+   "sha256": "686e0c331d00e9c15ed2544ecbd2f2873c09a1e7545af9e35bfe824a85967258"
+  }
+ ],
+ "result": {
+  "decision": "allow",
+  "policy_id": "policy-storefront-narrowed",
+  "narrowed_subset": [
+   "inventory_check"
+  ]
+ },
+ "receipt_id": "d9a67a03131b380dbaaee24d4b9e8ddf89a58151e779b5fa56b63733f23cad56",
+ "signatures": [
+  {
+   "signer": "did:aps:test:liu-composition-issuer",
+   "key_id": "test-key-1",
+   "alg": "Ed25519",
+   "value": "c2c16da04fefadaba02fa327169e80645d7453338e71129a59fa391dac14502b71203704cdaf7d96cebf7d06e431926f19de2af9d4291be90fd57cd7f83d0803"
+  }
+ ]
+}

--- a/interop/oauth-liu-composition/vectors/v2-denial/input.json
+++ b/interop/oauth-liu-composition/vectors/v2-denial/input.json
@@ -1,0 +1,65 @@
+{
+ "delegation_chain": [
+  {
+   "delegator_id": "wit://agent-a.test.invalid/sha256.aaa111synthetic",
+   "delegatee_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegation_timestamp": 1752868800,
+   "root_evidence_ref": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+   "delegated_policy": {
+    "type": "rego",
+    "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n}\n\nallow {\n  input.action == \"cart_add\"\n}",
+    "entry_point": "allow"
+   },
+   "operation_summary": "Delegate inventory check and cart add for the storefront session",
+   "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-delegator-sig-hop1",
+   "as_signature": "eyJhbGciOiJSUzI1NiJ9..synthetic-as-sig-hop1"
+  },
+  {
+   "delegator_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegatee_id": "wit://agent-c.test.invalid/sha256.ccc333synthetic",
+   "delegation_timestamp": 1752868860,
+   "root_evidence_ref": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+   "delegated_policy": {
+    "type": "rego",
+    "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n}",
+    "entry_point": "allow"
+   },
+   "operation_summary": "Narrow to inventory check only",
+   "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-delegator-sig-hop2",
+   "as_signature": "eyJhbGciOiJSUzI1NiJ9..synthetic-as-sig-hop2"
+  }
+ ],
+ "authorization_details": [
+  {
+   "type": "authorization_evidence",
+   "evidence": {
+    "id": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+    "user_confirmation": {
+     "displayed_content": "Allow the storefront agents to check inventory and add items to the cart",
+     "user_action": "confirmed_via_button_click",
+     "timestamp": 1752868740
+    },
+    "as_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-as-evidence-sig",
+    "audit_trail": {
+     "semantic_expansion_level": "medium",
+     "proposal_ref": "urn:uuid:proposal-synthetic-001"
+    }
+   }
+  }
+ ],
+ "rego_decision_context": {
+  "policy_ref": {
+   "id": "policy-storefront-narrowed",
+   "version": "1",
+   "hash": "sha256-placeholder-filled-by-emitter"
+  },
+  "evaluated_input": {
+   "action": "cart_add",
+   "item_id": "123",
+   "agent": "wit://agent-c.test.invalid/sha256.ccc333synthetic"
+  },
+  "input_hash": "",
+  "result": "deny",
+  "evaluation_timestamp": 1752868920
+ }
+}

--- a/interop/oauth-liu-composition/vectors/v2-denial/keys.json
+++ b/interop/oauth-liu-composition/vectors/v2-denial/keys.json
@@ -1,0 +1,5 @@
+{
+ "signer": "did:aps:test:liu-composition-issuer",
+ "key_id": "test-key-1",
+ "public_key_hex": "137ed55258f893bd06cc4f9256f8cc0db3244ad55dcabe81816236aadb3b84d3"
+}

--- a/interop/oauth-liu-composition/vectors/v2-denial/record.json
+++ b/interop/oauth-liu-composition/vectors/v2-denial/record.json
@@ -1,0 +1,38 @@
+{
+ "profile": "aps-receipt-v1",
+ "receipt_type": "policy-decision",
+ "issuer": "did:aps:test:liu-composition-issuer",
+ "subject_agent": "wit://agent-c.test.invalid/sha256.ccc333synthetic",
+ "action_ref": "121ac01c18e828db22a29f7e635876721d90854194f5e2794e7cf71d97828e87",
+ "delegation_ref": "liu-chain:sha256:686e0c331d00e9c15ed2544ecbd2f2873c09a1e7545af9e35bfe824a85967258",
+ "decision_ref": "4938ba8d3f65a35b4fc673988fda8bf00c69345517b7f62798b2e4b00a71b379",
+ "issued_at": "2026-07-18T19:30:00.000Z",
+ "evidence_refs": [
+  {
+   "artifact_type": "liu-oauth-authorization-evidence-01/authorization_details",
+   "sha256": "4150640f42ad625018cbf3b814e566aac48efd873a606dc9da0c9ada0af6d32a"
+  },
+  {
+   "artifact_type": "liu-oauth-chain-delegation-00/delegation_chain",
+   "sha256": "686e0c331d00e9c15ed2544ecbd2f2873c09a1e7545af9e35bfe824a85967258"
+  }
+ ],
+ "result": {
+  "decision": "deny",
+  "policy_id": "policy-storefront-narrowed",
+  "reason": "requested_action_outside_narrowed_subset",
+  "requested_action": "cart_add",
+  "narrowed_subset": [
+   "inventory_check"
+  ]
+ },
+ "receipt_id": "06b9c031e31c209fc8da52d94c08bd2612785d66d658f8a0f74452f019469097",
+ "signatures": [
+  {
+   "signer": "did:aps:test:liu-composition-issuer",
+   "key_id": "test-key-1",
+   "alg": "Ed25519",
+   "value": "e2ecd1f0a29345036f747d9a1088cac7d0fe6cac0fcad24035cb3977d67f02148cbef4c91b5659f3659e9e588621a002b2caf48f28ec1cb0dd0add1e93ba4001"
+  }
+ ]
+}

--- a/interop/oauth-liu-composition/vectors/v3-observation/input.json
+++ b/interop/oauth-liu-composition/vectors/v3-observation/input.json
@@ -1,0 +1,40 @@
+{
+ "delegation_chain": [
+  {
+   "delegator_id": "wit://agent-a.test.invalid/sha256.aaa111synthetic",
+   "delegatee_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegation_timestamp": 1752868800,
+   "root_evidence_ref": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+   "delegated_policy": {
+    "type": "rego",
+    "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n}\n\nallow {\n  input.action == \"cart_add\"\n}",
+    "entry_point": "allow"
+   },
+   "operation_summary": "Delegate inventory check and cart add for the storefront session",
+   "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-delegator-sig-hop1",
+   "as_signature": "eyJhbGciOiJSUzI1NiJ9..synthetic-as-sig-hop1"
+  },
+  {
+   "delegator_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegatee_id": "wit://agent-c.test.invalid/sha256.ccc333synthetic",
+   "delegation_timestamp": 1752868860,
+   "root_evidence_ref": "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+   "delegated_policy": {
+    "type": "rego",
+    "content": "package agent\ndefault allow = false\n\nallow {\n  input.action == \"inventory_check\"\n}",
+    "entry_point": "allow"
+   },
+   "operation_summary": "Narrow to inventory check only",
+   "delegator_signature": "eyJhbGciOiJFUzI1NiJ9..synthetic-delegator-sig-hop2",
+   "as_signature": "eyJhbGciOiJSUzI1NiJ9..synthetic-as-sig-hop2"
+  }
+ ],
+ "revocation_signal": {
+  "set_jti": "set-jti-synthetic-9f2c1a",
+  "revoked_hop": {
+   "delegator_id": "wit://agent-b.test.invalid/sha256.bbb222synthetic",
+   "delegatee_id": "wit://agent-c.test.invalid/sha256.ccc333synthetic"
+  },
+  "revoked_at": "2026-07-18T19:25:00.000Z"
+ }
+}

--- a/interop/oauth-liu-composition/vectors/v3-observation/record.json
+++ b/interop/oauth-liu-composition/vectors/v3-observation/record.json
@@ -1,0 +1,17 @@
+{
+ "authority_ref": "liu-chain-hop:wit://agent-b.test.invalid/sha256.bbb222synthetic->wit://agent-c.test.invalid/sha256.ccc333synthetic",
+ "status_source": {
+  "kind": "set",
+  "jti": "set-jti-synthetic-9f2c1a"
+ },
+ "observed_at": "2026-07-18T19:31:00.000Z",
+ "maximum_staleness_ms": 300000,
+ "decision": {
+  "effect": "deny"
+ },
+ "revoked_at": "2026-07-18T19:25:00.000Z",
+ "affected_scope": "inventory_check",
+ "observer_key": "12da0a8eb7683ab63bdfc3f8fb6061513f306f8e8474c5f0512581eca674b5ba",
+ "observer_key_id": "observer-key-1",
+ "signature": "4d5680059d7bcf06e070a265b2c4a4357b8176f006cf67f4d9f717ef39833b65b6c5aa75ef2bc9f82635b9c12cbf8459654de6dbbe006dc8e84ff03362d7110e"
+}

--- a/interop/oauth-liu-composition/verify-vectors.ts
+++ b/interop/oauth-liu-composition/verify-vectors.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+//
+// Re-verifies every committed record.json through the SDK verify path, as a
+// third party would: the receipt vectors via verifyReceiptV1 with the key from
+// the keys.json sidecar, the observation via verifyRevocationObservation with
+// the record's own bound observer key. Also re-checks that each receipt's
+// evidence_refs digests match the input.json artifacts they claim to tie to,
+// so a vector whose record and input drift apart fails loud.
+
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { strictJCS } from '../../src/v2/receipt-core/jcs.js'
+import { verifyReceiptV1 } from '../../src/v2/receipt-core/receipt.js'
+import type { JsonValue, ReceiptV1 } from '../../src/v2/receipt-core/types.js'
+import { verifyRevocationObservation } from '../../src/v2/revocation-enforcement/observation.js'
+import type { SignedRevocationObservation } from '../../src/v2/revocation-enforcement/types.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf8').digest('hex')
+const digestOf = (value: JsonValue): string => sha256Hex(strictJCS(value))
+const load = (...p: string[]): unknown => JSON.parse(readFileSync(join(HERE, ...p), 'utf8'))
+
+export interface VectorResult {
+  vector: string
+  valid: boolean
+  detail: string
+}
+
+export function verifyReceiptVector(vector: 'v1-permit' | 'v2-denial'): VectorResult {
+  const receipt = load('vectors', vector, 'record.json') as ReceiptV1
+  const keys = load('vectors', vector, 'keys.json') as { signer: string; key_id: string; public_key_hex: string }
+  const input = load('vectors', vector, 'input.json') as Record<string, JsonValue>
+
+  const verification = verifyReceiptV1(receipt, (signer, keyId) =>
+    signer === keys.signer && keyId === keys.key_id ? keys.public_key_hex : undefined)
+  if (!verification.valid) {
+    return { vector, valid: false, detail: `sdk verify failed: ${verification.errors.join(', ')}` }
+  }
+
+  // Tie-back: the receipt's evidence digests must equal the digests of the Liu
+  // artifacts in the input fixture.
+  const wantEvidence = digestOf(input.authorization_details as JsonValue)
+  const wantChain = digestOf({ delegation_chain: input.delegation_chain } as unknown as JsonValue)
+  const byType = new Map(receipt.evidence_refs.map(r => [r.artifact_type, r.sha256]))
+  if (byType.get('liu-oauth-authorization-evidence-01/authorization_details') !== wantEvidence) {
+    return { vector, valid: false, detail: 'authorization_evidence digest does not tie back to input.json' }
+  }
+  if (byType.get('liu-oauth-chain-delegation-00/delegation_chain') !== wantChain) {
+    return { vector, valid: false, detail: 'delegation_chain digest does not tie back to input.json' }
+  }
+  if (!receipt.decision_ref) {
+    return { vector, valid: false, detail: 'decision_ref missing on a policy-decision receipt' }
+  }
+  return { vector, valid: true, detail: `receipt_id ${receipt.receipt_id} verified, evidence ties back` }
+}
+
+export function verifyObservationVector(): VectorResult {
+  const record = load('vectors', 'v3-observation', 'record.json') as SignedRevocationObservation
+  const result = verifyRevocationObservation(record, { expectedObserverKey: record.observer_key })
+  if (!result.valid) return { vector: 'v3-observation', valid: false, detail: `sdk verify failed: ${result.reason}` }
+  if (record.status_source.kind !== 'set') {
+    return { vector: 'v3-observation', valid: false, detail: 'status_source is not a SET reference' }
+  }
+  const input = load('vectors', 'v3-observation', 'input.json') as { revocation_signal: { set_jti: string } }
+  if (record.status_source.jti !== input.revocation_signal.set_jti) {
+    return { vector: 'v3-observation', valid: false, detail: 'SET jti does not tie back to input.json' }
+  }
+  return { vector: 'v3-observation', valid: true, detail: `observation verified, jti ${record.status_source.jti}` }
+}
+
+export function verifyAll(): VectorResult[] {
+  return [verifyReceiptVector('v1-permit'), verifyReceiptVector('v2-denial'), verifyObservationVector()]
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const results = verifyAll()
+  for (const r of results) console.log(`${r.valid ? 'PASS' : 'FAIL'} ${r.vector}: ${r.detail}`)
+  if (results.some(r => !r.valid)) process.exit(1)
+}

--- a/src/adapters/oauth-id-jag/import-v1.ts
+++ b/src/adapters/oauth-id-jag/import-v1.ts
@@ -1,0 +1,388 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import type { HistoricalKeyResolver } from '../../v2/identity-binding/types.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertSortedUnique,
+  assertUtcMilliseconds,
+  sortedUnique,
+} from '../../v2/identity-binding/validation.js'
+import type { IdJagClaims } from './types.js'
+import { IDJAG_DRAFT } from './types.js'
+
+const GRANT_DOMAIN = 'APS-IDJAG-GRANT-V1\0'
+const ACTOR_BINDING_DOMAIN = 'APS-IDJAG-ACTOR-BINDING-V1\0'
+const DECISION_DOMAIN = 'APS-IDJAG-GRANT-DECISION-V1\0'
+const IMPORT_SIGNATURE_DOMAIN = 'APS-IDJAG-IMPORT-SIG-V1\0'
+
+export type IdJagActorBindingV1 =
+  | {
+      method: 'cnf.jkt'
+      agent_id: string
+      verification_method: string
+      jwk_thumbprint: string
+    }
+  | {
+      method: 'dual_signature'
+      agent_id: string
+      verification_method: string
+      signature: string
+    }
+
+export interface IdJagImportV1 {
+  profile: 'aps-id-jag-import-v1'
+  draft: string
+  grant_ref: string
+  grant_decision_ref: string
+  delegation_chain_root: string
+  issuer: string
+  subject: string
+  client_id: string
+  audience: string[]
+  agent_id: string
+  actor_binding: IdJagActorBindingV1
+  verified_by: string
+  verification_method: string
+  grant_key_id: string
+  verified_at: string
+  issued_at: string
+  signature: string
+}
+
+export interface VerifiedCompactIdJagGrantV1 {
+  compact_jws: string
+  claims: IdJagClaims & { cnf?: { jkt?: string } }
+  verification: {
+    status: 'verified'
+    verified_by: string
+    verification_method: string
+    grant_key_id: string
+    verified_at: string
+  }
+}
+
+export interface IdJagImportVerificationV1 {
+  state: 'valid' | 'invalid' | 'indeterminate'
+  code: string
+  grant_bytes: 'matched' | 'mismatch'
+  importer_signature: 'verified' | 'rejected' | 'unresolved'
+  actor_binding: 'verified' | 'rejected' | 'unresolved'
+}
+
+export function computeIdJagGrantRefV1(compactJws: string): string {
+  validateCompactJws(compactJws)
+  return digest(GRANT_DOMAIN + compactJws)
+}
+
+export function createIdJagActorBindingSignatureV1(
+  grantRef: string,
+  agentId: string,
+  verificationMethod: string,
+  agentPrivateKeyHex: string,
+): string {
+  assertHex(grantRef, 64, 'grant_ref')
+  const body = { agent_id: agentId, grant_ref: grantRef, verification_method: verificationMethod }
+  return sign(ACTOR_BINDING_DOMAIN + canonicalizeJCS(body), agentPrivateKeyHex)
+}
+
+export async function createIdJagImportV1(input: {
+  grant: VerifiedCompactIdJagGrantV1
+  delegation_chain_root: string
+  agent_binding: IdJagActorBindingV1
+  importer_private_key_hex: string
+  issued_at: string
+  resolve_agent_key?: HistoricalKeyResolver
+  resolve_agent_jwk_thumbprint?: (
+    agentId: string,
+    verificationMethod: string,
+    at: string,
+  ) => string | undefined | Promise<string | undefined>
+}): Promise<IdJagImportV1> {
+  validateVerifiedGrant(input.grant)
+  assertHex(input.delegation_chain_root, 64, 'delegation_chain_root')
+  assertUtcMilliseconds(input.issued_at, 'issued_at')
+  const grantRef = computeIdJagGrantRefV1(input.grant.compact_jws)
+  await verifyActorBindingOrThrow(
+    input.grant,
+    grantRef,
+    input.agent_binding,
+    input.resolve_agent_key,
+    input.resolve_agent_jwk_thumbprint,
+  )
+  const audiences = normalizeAudience(input.grant.claims.aud, input.grant.claims.resource)
+  const decisionInput = grantDecisionInput(
+    grantRef,
+    input.grant,
+    input.agent_binding,
+    input.delegation_chain_root,
+    audiences,
+  )
+  const grantDecisionRef = digest(DECISION_DOMAIN + canonicalizeJCS(decisionInput))
+  const unsigned: Omit<IdJagImportV1, 'signature'> = {
+    profile: 'aps-id-jag-import-v1',
+    draft: IDJAG_DRAFT,
+    grant_ref: grantRef,
+    grant_decision_ref: grantDecisionRef,
+    delegation_chain_root: input.delegation_chain_root,
+    issuer: input.grant.claims.iss,
+    subject: input.grant.claims.sub,
+    client_id: input.grant.claims.client_id,
+    audience: audiences,
+    agent_id: input.agent_binding.agent_id,
+    actor_binding: input.agent_binding,
+    verified_by: input.grant.verification.verified_by,
+    verification_method: input.grant.verification.verification_method,
+    grant_key_id: input.grant.verification.grant_key_id,
+    verified_at: input.grant.verification.verified_at,
+    issued_at: input.issued_at,
+  }
+  validateImportUnsigned(unsigned)
+  return {
+    ...unsigned,
+    signature: sign(IMPORT_SIGNATURE_DOMAIN + canonicalizeJCS(unsigned), input.importer_private_key_hex),
+  }
+}
+
+export async function verifyIdJagImportV1(
+  candidate: unknown,
+  source: { compact_jws: string; claims: VerifiedCompactIdJagGrantV1['claims'] },
+  options: {
+    resolve_importer_key: HistoricalKeyResolver
+    resolve_agent_key?: HistoricalKeyResolver
+    resolve_agent_jwk_thumbprint?: (
+      agentId: string,
+      verificationMethod: string,
+      at: string,
+    ) => string | undefined | Promise<string | undefined>
+  },
+): Promise<IdJagImportVerificationV1> {
+  let record: IdJagImportV1
+  try {
+    record = validateImport(candidate)
+    validateClaimsMatchCompactJws(source.compact_jws, source.claims)
+  } catch {
+    return outcome('invalid', 'IDJAG_IMPORT_MALFORMED', 'mismatch', 'rejected', 'rejected')
+  }
+  const grantRef = computeIdJagGrantRefV1(source.compact_jws)
+  if (grantRef !== record.grant_ref || !claimsMatchRecord(source.claims, record)) {
+    return outcome('invalid', 'IDJAG_GRANT_BYTES_MISMATCH', 'mismatch', 'rejected', 'rejected')
+  }
+  const syntheticGrant: VerifiedCompactIdJagGrantV1 = {
+    compact_jws: source.compact_jws,
+    claims: source.claims,
+    verification: {
+      status: 'verified',
+      verified_by: record.verified_by,
+      verification_method: record.verification_method,
+      grant_key_id: record.grant_key_id,
+      verified_at: record.verified_at,
+    },
+  }
+  const decisionRef = digest(DECISION_DOMAIN + canonicalizeJCS(grantDecisionInput(
+    grantRef,
+    syntheticGrant,
+    record.actor_binding,
+    record.delegation_chain_root,
+    record.audience,
+  )))
+  if (decisionRef !== record.grant_decision_ref) {
+    return outcome('invalid', 'IDJAG_GRANT_DECISION_MISMATCH', 'matched', 'rejected', 'rejected')
+  }
+  const importerResolution = await options.resolve_importer_key({
+    controller: record.verified_by,
+    verification_method: record.verification_method,
+    at: record.issued_at,
+  })
+  if (importerResolution.state !== 'resolved' || !importerResolution.public_key_hex) {
+    const unresolved = importerResolution.state === 'unreachable'
+    return outcome(
+      unresolved ? 'indeterminate' : 'invalid',
+      `IDJAG_IMPORTER_KEY_${importerResolution.state.toUpperCase()}`,
+      'matched', unresolved ? 'unresolved' : 'rejected', 'unresolved',
+    )
+  }
+  const unsigned = omit(record, ['signature'])
+  if (!verify(
+    IMPORT_SIGNATURE_DOMAIN + canonicalizeJCS(unsigned),
+    record.signature,
+    importerResolution.public_key_hex,
+  )) return outcome('invalid', 'IDJAG_IMPORTER_SIGNATURE_INVALID', 'matched', 'rejected', 'unresolved')
+
+  try {
+    await verifyActorBindingOrThrow(
+      syntheticGrant,
+      grantRef,
+      record.actor_binding,
+      options.resolve_agent_key,
+      options.resolve_agent_jwk_thumbprint,
+    )
+  } catch (error) {
+    const unresolved = error instanceof Error && error.message.includes('unresolved')
+    return outcome(
+      unresolved ? 'indeterminate' : 'invalid',
+      unresolved ? 'IDJAG_ACTOR_BINDING_UNRESOLVED' : 'IDJAG_ACTOR_BINDING_INVALID',
+      'matched', 'verified', unresolved ? 'unresolved' : 'rejected',
+    )
+  }
+  return outcome('valid', 'OK', 'matched', 'verified', 'verified')
+}
+
+function validateVerifiedGrant(grant: VerifiedCompactIdJagGrantV1): void {
+  validateClaimsMatchCompactJws(grant.compact_jws, grant.claims)
+  if (grant.verification.status !== 'verified') throw new Error('grant not verified')
+  if (!grant.verification.verified_by || !grant.verification.verification_method || !grant.verification.grant_key_id) {
+    throw new Error('grant verification metadata incomplete')
+  }
+  if (!grant.verification.verification_method.startsWith(`${grant.verification.verified_by}#`)) {
+    throw new Error('grant verifier key/controller mismatch')
+  }
+  assertUtcMilliseconds(grant.verification.verified_at, 'verified_at')
+}
+
+function validateClaimsMatchCompactJws(compactJws: string, claims: IdJagClaims): void {
+  validateCompactJws(compactJws)
+  assertIJson(claims)
+  const payload = JSON.parse(Buffer.from(compactJws.split('.')[1], 'base64url').toString('utf8')) as unknown
+  assertIJson(payload)
+  if (canonicalizeJCS(payload) !== canonicalizeJCS(claims)) throw new Error('decoded claims do not match compact JWS')
+}
+
+async function verifyActorBindingOrThrow(
+  grant: VerifiedCompactIdJagGrantV1,
+  grantRef: string,
+  binding: IdJagActorBindingV1,
+  resolveAgentKey?: HistoricalKeyResolver,
+  resolveThumbprint?: (agentId: string, verificationMethod: string, at: string) => string | undefined | Promise<string | undefined>,
+): Promise<void> {
+  validateActorBinding(binding)
+  if (binding.method === 'cnf.jkt') {
+    if (grant.claims.cnf?.jkt !== binding.jwk_thumbprint) throw new Error('cnf.jkt mismatch')
+    if (!resolveThumbprint) throw new Error('actor binding unresolved')
+    const resolved = await resolveThumbprint(binding.agent_id, binding.verification_method, grant.verification.verified_at)
+    if (!resolved) throw new Error('actor binding unresolved')
+    if (resolved !== binding.jwk_thumbprint) throw new Error('agent key thumbprint mismatch')
+    return
+  }
+  if (!resolveAgentKey) throw new Error('actor binding unresolved')
+  const resolution = await resolveAgentKey({
+    controller: binding.agent_id,
+    verification_method: binding.verification_method,
+    at: grant.verification.verified_at,
+  })
+  if (resolution.state !== 'resolved' || !resolution.public_key_hex) throw new Error('actor binding unresolved')
+  const body = {
+    agent_id: binding.agent_id,
+    grant_ref: grantRef,
+    verification_method: binding.verification_method,
+  }
+  if (!verify(
+    ACTOR_BINDING_DOMAIN + canonicalizeJCS(body),
+    binding.signature,
+    resolution.public_key_hex,
+  )) throw new Error('actor signature invalid')
+}
+
+function validateActorBinding(binding: IdJagActorBindingV1): void {
+  assertPlainRecord(binding, 'actor binding')
+  if (!/^did:[a-z0-9]+:.+$/.test(binding.agent_id)) throw new Error('actor agent_id')
+  if (!binding.verification_method.startsWith(`${binding.agent_id}#`)) throw new Error('actor verification_method')
+  if (binding.method === 'cnf.jkt') {
+    assertExactKeys(binding, ['method', 'agent_id', 'verification_method', 'jwk_thumbprint'], [], 'actor binding')
+    if (!/^[A-Za-z0-9_-]{43}$/.test(binding.jwk_thumbprint)) throw new Error('actor jwk thumbprint')
+  } else if (binding.method === 'dual_signature') {
+    assertExactKeys(binding, ['method', 'agent_id', 'verification_method', 'signature'], [], 'actor binding')
+    assertHex(binding.signature, 128, 'actor signature')
+  } else throw new Error('actor binding method')
+}
+
+function grantDecisionInput(
+  grantRef: string,
+  grant: VerifiedCompactIdJagGrantV1,
+  binding: IdJagActorBindingV1,
+  chainRoot: string,
+  audience: string[],
+): Record<string, unknown> {
+  return {
+    profile: 'aps-id-jag-grant-decision-v1',
+    grant_ref: grantRef,
+    delegation_chain_root: chainRoot,
+    audience,
+    actor_binding: binding,
+    verified_by: grant.verification.verified_by,
+    verification_method: grant.verification.verification_method,
+    grant_key_id: grant.verification.grant_key_id,
+    verified_at: grant.verification.verified_at,
+  }
+}
+
+function validateImport(value: unknown): IdJagImportV1 {
+  assertPlainRecord(value, 'ID-JAG import')
+  assertExactKeys(value, [
+    'profile', 'draft', 'grant_ref', 'grant_decision_ref', 'delegation_chain_root',
+    'issuer', 'subject', 'client_id', 'audience', 'agent_id', 'actor_binding',
+    'verified_by', 'verification_method', 'grant_key_id', 'verified_at', 'issued_at', 'signature',
+  ], [], 'ID-JAG import')
+  validateImportUnsigned(omit(value, ['signature']) as unknown as Omit<IdJagImportV1, 'signature'>)
+  assertHex(String(value.signature), 128, 'signature')
+  return value as unknown as IdJagImportV1
+}
+
+function validateImportUnsigned(value: Omit<IdJagImportV1, 'signature'>): void {
+  assertIJson(value)
+  if (value.profile !== 'aps-id-jag-import-v1' || value.draft !== IDJAG_DRAFT) throw new Error('ID-JAG profile')
+  assertHex(value.grant_ref, 64, 'grant_ref')
+  assertHex(value.grant_decision_ref, 64, 'grant_decision_ref')
+  assertHex(value.delegation_chain_root, 64, 'delegation_chain_root')
+  if (!value.issuer || !value.subject || !value.client_id || !value.grant_key_id) throw new Error('ID-JAG identifiers')
+  if (!Array.isArray(value.audience) || value.audience.length === 0) throw new Error('audience')
+  assertSortedUnique(value.audience, 'audience')
+  validateActorBinding(value.actor_binding)
+  if (value.agent_id !== value.actor_binding.agent_id) throw new Error('agent_id mismatch')
+  if (!value.verification_method.startsWith(`${value.verified_by}#`)) throw new Error('importer verification method')
+  assertUtcMilliseconds(value.verified_at, 'verified_at')
+  assertUtcMilliseconds(value.issued_at, 'issued_at')
+}
+
+function normalizeAudience(aud: string, resource?: string): string[] {
+  return sortedUnique([aud, ...(resource === undefined ? [] : [resource])], 'audience')
+}
+
+function claimsMatchRecord(claims: IdJagClaims, record: IdJagImportV1): boolean {
+  return claims.iss === record.issuer && claims.sub === record.subject &&
+    claims.client_id === record.client_id &&
+    canonicalizeJCS(normalizeAudience(claims.aud, claims.resource)) === canonicalizeJCS(record.audience)
+}
+
+function validateCompactJws(value: string): void {
+  if (typeof value !== 'string' || value.length > 131072 ||
+      !/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value)) {
+    throw new Error('invalid compact JWS')
+  }
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+function omit(value: object, keys: readonly string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) if (!keys.includes(key)) result[key] = entry
+  return result
+}
+
+function outcome(
+  state: IdJagImportVerificationV1['state'],
+  code: string,
+  grant: IdJagImportVerificationV1['grant_bytes'],
+  importer: IdJagImportVerificationV1['importer_signature'],
+  actor: IdJagImportVerificationV1['actor_binding'],
+): IdJagImportVerificationV1 {
+  return { state, code, grant_bytes: grant, importer_signature: importer, actor_binding: actor }
+}

--- a/src/profiles/a2a/identity-v1.ts
+++ b/src/profiles/a2a/identity-v1.ts
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import type { HistoricalKeyResolver } from '../../v2/identity-binding/types.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertUtcMilliseconds,
+} from '../../v2/identity-binding/validation.js'
+
+export const APS_A2A_IDENTITY_EXTENSION = 'https://agent-passport.org/a2a/extensions/identity/v1'
+
+export interface A2AApsIdentityParamsV1 {
+  agent_id: string
+  passport_uri: string
+  passport_sha256: string
+  principal_binding_uri?: string
+  principal_binding_sha256?: string
+  issued_at: string
+  expires_at: string
+}
+
+export interface A2AAgentCardSignature {
+  protected: string
+  signature: string
+  header?: Record<string, unknown>
+}
+
+export type A2AAgentCardObject = Record<string, unknown> & {
+  capabilities: Record<string, unknown> & { extensions?: unknown[] }
+  signatures?: A2AAgentCardSignature[]
+}
+
+export interface A2AApsIdentityVerification {
+  state: 'valid' | 'invalid' | 'indeterminate' | 'unsupported'
+  code: string
+  agent_id?: string
+  card_signature: 'verified' | 'rejected' | 'unresolved'
+  passport: 'resolved' | 'mismatch' | 'unresolved'
+  principal_binding: 'resolved' | 'mismatch' | 'unresolved' | 'absent'
+}
+
+export function attachApsIdentityExtensionV1(
+  card: A2AAgentCardObject,
+  params: A2AApsIdentityParamsV1,
+  required = false,
+): A2AAgentCardObject {
+  validateParams(params)
+  const existing = Array.isArray(card.capabilities.extensions)
+    ? card.capabilities.extensions.filter((entry) =>
+      !isExtensionWithUri(entry, APS_A2A_IDENTITY_EXTENSION))
+    : []
+  const result: A2AAgentCardObject = {
+    ...card,
+    capabilities: {
+      ...card.capabilities,
+      extensions: [...existing, {
+        uri: APS_A2A_IDENTITY_EXTENSION,
+        description: 'APS verifiable agent identity and principal-binding references',
+        required,
+        params,
+      }],
+    },
+  }
+  delete result.signatures
+  assertIJson(result)
+  return result
+}
+
+export function signA2AAgentCardV1(
+  card: A2AAgentCardObject,
+  privateKeyHex: string,
+  kid: string,
+): A2AAgentCardObject {
+  const unsigned = withoutSignatures(card)
+  assertIJson(unsigned)
+  const extension = getApsIdentityParamsV1(unsigned)
+  if (!kid.startsWith(`${extension.agent_id}#`)) throw new Error('A2A signature kid is not controlled by agent_id')
+  const protectedHeader = canonicalizeJCS({ alg: 'EdDSA', kid, typ: 'JOSE' })
+  const protectedB64 = base64url(Buffer.from(protectedHeader, 'utf8'))
+  const payloadB64 = base64url(Buffer.from(canonicalizeJCS(unsigned), 'utf8'))
+  const signatureHex = sign(`${protectedB64}.${payloadB64}`, privateKeyHex)
+  const signature: A2AAgentCardSignature = {
+    protected: protectedB64,
+    signature: base64url(Buffer.from(signatureHex, 'hex')),
+  }
+  return { ...unsigned, signatures: [signature] }
+}
+
+export async function verifyApsA2AAgentCardV1(
+  candidate: unknown,
+  options: {
+    resolve_key: HistoricalKeyResolver
+    resolve_artifact?: (uri: string) => Uint8Array | Promise<Uint8Array>
+    now?: string
+  },
+): Promise<A2AApsIdentityVerification> {
+  let card: A2AAgentCardObject
+  let params: A2AApsIdentityParamsV1
+  try {
+    assertPlainRecord(candidate, 'Agent Card')
+    card = candidate as A2AAgentCardObject
+    assertIJson(card)
+    params = getApsIdentityParamsV1(card)
+    if (!Array.isArray(card.signatures) || card.signatures.length === 0) throw new Error('missing signatures')
+  } catch {
+    return result('invalid', 'A2A_CARD_MALFORMED', 'rejected')
+  }
+
+  const now = options.now ?? new Date().toISOString()
+  if (now < params.issued_at || now >= params.expires_at) {
+    return result('invalid', 'A2A_IDENTITY_EXTENSION_NOT_CURRENT', 'rejected', params.agent_id)
+  }
+
+  const unsigned = withoutSignatures(card)
+  const payloadB64 = base64url(Buffer.from(canonicalizeJCS(unsigned), 'utf8'))
+  let unresolvedKey = false
+  let verifiedSignature = false
+  for (const signature of card.signatures ?? []) {
+    let header: Record<string, unknown>
+    try {
+      const raw = Buffer.from(signature.protected, 'base64url').toString('utf8')
+      header = JSON.parse(raw) as Record<string, unknown>
+      assertExactKeys(header, ['alg', 'kid', 'typ'], [], 'JWS protected header')
+      if (header.alg !== 'EdDSA' || header.typ !== 'JOSE' || typeof header.kid !== 'string') continue
+      if (!header.kid.startsWith(`${params.agent_id}#`)) continue
+    } catch {
+      continue
+    }
+    const resolution = await options.resolve_key({
+      controller: params.agent_id,
+      verification_method: String(header.kid),
+      at: params.issued_at,
+    })
+    if (resolution.state === 'unreachable') unresolvedKey = true
+    if (resolution.state !== 'resolved' || !resolution.public_key_hex) continue
+    let signatureHex: string
+    try {
+      signatureHex = Buffer.from(signature.signature, 'base64url').toString('hex')
+    } catch {
+      continue
+    }
+    if (verify(`${signature.protected}.${payloadB64}`, signatureHex, resolution.public_key_hex)) {
+      verifiedSignature = true
+      break
+    }
+  }
+  if (!verifiedSignature) {
+    return result(
+      unresolvedKey ? 'indeterminate' : 'invalid',
+      unresolvedKey ? 'A2A_SIGNING_KEY_UNREACHABLE' : 'A2A_SIGNATURE_INVALID',
+      unresolvedKey ? 'unresolved' : 'rejected',
+      params.agent_id,
+    )
+  }
+
+  if (!options.resolve_artifact) {
+    return {
+      ...result('indeterminate', 'A2A_IDENTITY_ARTIFACTS_UNRESOLVED', 'verified', params.agent_id),
+      passport: 'unresolved',
+      principal_binding: params.principal_binding_uri ? 'unresolved' : 'absent',
+    }
+  }
+  const passport = await resolveDigest(options.resolve_artifact, params.passport_uri, params.passport_sha256)
+  const principal = params.principal_binding_uri && params.principal_binding_sha256
+    ? await resolveDigest(options.resolve_artifact, params.principal_binding_uri, params.principal_binding_sha256)
+    : 'absent'
+  if (passport === 'mismatch' || principal === 'mismatch') {
+    return {
+      ...result('invalid', 'A2A_IDENTITY_ARTIFACT_DIGEST_MISMATCH', 'verified', params.agent_id),
+      passport,
+      principal_binding: principal,
+    }
+  }
+  if (passport === 'unresolved' || principal === 'unresolved') {
+    return {
+      ...result('indeterminate', 'A2A_IDENTITY_ARTIFACT_UNREACHABLE', 'verified', params.agent_id),
+      passport,
+      principal_binding: principal,
+    }
+  }
+  return {
+    state: 'valid',
+    code: 'OK',
+    agent_id: params.agent_id,
+    card_signature: 'verified',
+    passport,
+    principal_binding: principal,
+  }
+}
+
+/** Legacy custom fields do not carry the A2A JWS payload and cannot verify. */
+export function assessLegacyAgentPassportExtension(_candidate: unknown): {
+  state: 'legacy_unverifiable'
+  code: 'A2A_LEGACY_EXTENSION_UNSIGNED_PROJECTION'
+} {
+  return { state: 'legacy_unverifiable', code: 'A2A_LEGACY_EXTENSION_UNSIGNED_PROJECTION' }
+}
+
+export function getApsIdentityParamsV1(card: A2AAgentCardObject): A2AApsIdentityParamsV1 {
+  const extensions = card.capabilities?.extensions
+  if (!Array.isArray(extensions)) throw new Error('A2A Agent Card has no extensions')
+  const matches = extensions.filter((entry) => isExtensionWithUri(entry, APS_A2A_IDENTITY_EXTENSION))
+  if (matches.length !== 1) throw new Error('A2A Agent Card must carry exactly one APS identity extension')
+  const extension = matches[0] as Record<string, unknown>
+  validateParams(extension.params)
+  return extension.params as unknown as A2AApsIdentityParamsV1
+}
+
+function validateParams(value: unknown): asserts value is A2AApsIdentityParamsV1 {
+  assertPlainRecord(value, 'APS A2A identity params')
+  assertExactKeys(value, [
+    'agent_id', 'passport_uri', 'passport_sha256', 'issued_at', 'expires_at',
+  ], ['principal_binding_uri', 'principal_binding_sha256'], 'APS A2A identity params')
+  if (typeof value.agent_id !== 'string' || !value.agent_id.startsWith('did:')) throw new Error('agent_id')
+  if (typeof value.passport_uri !== 'string' || !/^https:\/\//.test(value.passport_uri)) throw new Error('passport_uri')
+  assertHex(String(value.passport_sha256), 64, 'passport_sha256')
+  const hasBindingUri = typeof value.principal_binding_uri === 'string'
+  const hasBindingHash = typeof value.principal_binding_sha256 === 'string'
+  if (hasBindingUri !== hasBindingHash) throw new Error('principal binding URI and digest must appear together')
+  if (hasBindingUri && !/^https:\/\//.test(String(value.principal_binding_uri))) throw new Error('principal_binding_uri')
+  if (hasBindingHash) assertHex(String(value.principal_binding_sha256), 64, 'principal_binding_sha256')
+  assertUtcMilliseconds(String(value.issued_at), 'issued_at')
+  assertUtcMilliseconds(String(value.expires_at), 'expires_at')
+  if (String(value.issued_at) >= String(value.expires_at)) throw new Error('A2A extension time window')
+}
+
+function withoutSignatures(card: A2AAgentCardObject): A2AAgentCardObject {
+  const { signatures: _signatures, ...unsigned } = card
+  return structuredClone(unsigned) as A2AAgentCardObject
+}
+
+function isExtensionWithUri(value: unknown, uri: string): boolean {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) &&
+    (value as Record<string, unknown>).uri === uri
+}
+
+async function resolveDigest(
+  resolve: (uri: string) => Uint8Array | Promise<Uint8Array>,
+  uri: string,
+  expected: string,
+): Promise<'resolved' | 'mismatch' | 'unresolved'> {
+  try {
+    const bytes = await resolve(uri)
+    const actual = createHash('sha256').update(bytes).digest('hex')
+    return actual === expected ? 'resolved' : 'mismatch'
+  } catch {
+    return 'unresolved'
+  }
+}
+
+function base64url(value: Uint8Array): string {
+  return Buffer.from(value).toString('base64url')
+}
+
+function result(
+  state: A2AApsIdentityVerification['state'],
+  code: string,
+  signature: A2AApsIdentityVerification['card_signature'],
+  agentId?: string,
+): A2AApsIdentityVerification {
+  return {
+    state,
+    code,
+    ...(agentId === undefined ? {} : { agent_id: agentId }),
+    card_signature: signature,
+    passport: 'unresolved',
+    principal_binding: 'unresolved',
+  }
+}

--- a/src/profiles/a2a/index.ts
+++ b/src/profiles/a2a/index.ts
@@ -1,0 +1,1 @@
+export * from './identity-v1.js'

--- a/src/profiles/mcp/authorization-v1.ts
+++ b/src/profiles/mcp/authorization-v1.ts
@@ -1,0 +1,309 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import {
+  computeActionRefV2,
+  createActionReferenceInputV2,
+} from '../../v2/action-reference/v2.js'
+import type { HistoricalKeyResolver } from '../../v2/identity-binding/types.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertSortedUnique,
+  assertUtcMilliseconds,
+  sortedUnique,
+} from '../../v2/identity-binding/validation.js'
+
+export const APS_MCP_AUTHORIZATION_META = 'org.agent-passport/authorization'
+export const APS_MCP_RECEIPT_META = 'org.agent-passport/receipt'
+const INTENT_DOMAIN = 'APS-MCP-INTENT-V1\0'
+const ARGUMENTS_DOMAIN = 'APS-MCP-ARGUMENTS-V1\0'
+
+export interface ApsMcpSpendV1 {
+  unit: string
+  amount: string
+}
+
+export interface ApsMcpAuthorizationV1 {
+  profile: 'aps-mcp-1'
+  agent_id: string
+  verification_method: string
+  delegation_ref: string
+  mcp_server: string
+  method: 'tools/call'
+  tool_name: string
+  arguments_hash: string
+  scope_required: string[]
+  spend?: ApsMcpSpendV1
+  nonce: string
+  issued_at: string
+  expires_at: string
+  action_ref: string
+  signature: string
+}
+
+export interface McpToolCallRequest {
+  method: 'tools/call'
+  params: {
+    name: string
+    arguments?: Record<string, unknown>
+    _meta?: Record<string, unknown>
+  }
+}
+
+export interface McpToolCallResult extends Record<string, unknown> {
+  _meta?: Record<string, unknown>
+}
+
+export interface ApsMcpAuthorityDecision {
+  state: 'permit' | 'deny' | 'indeterminate'
+  code: string
+  decision_ref?: string
+}
+
+export interface ApsMcpMiddlewareContext {
+  /** Set only after MCP transport OAuth/resource validation has succeeded. */
+  transport_authenticated: boolean
+}
+
+export class ApsMcpAuthorizationError extends Error {
+  constructor(readonly code: string) {
+    super(code)
+    this.name = 'ApsMcpAuthorizationError'
+  }
+}
+
+export function computeMcpArgumentsHashV1(argumentsValue: Record<string, unknown>): string {
+  assertIJson(argumentsValue)
+  return createHash('sha256')
+    .update(ARGUMENTS_DOMAIN + canonicalizeJCS(argumentsValue), 'utf8')
+    .digest('hex')
+}
+
+export function issueApsMcpAuthorizationV1(input: {
+  agent_id: string
+  verification_method: string
+  delegation_ref: string
+  mcp_server: string
+  tool_name: string
+  arguments: Record<string, unknown>
+  scope_required: readonly string[]
+  spend?: ApsMcpSpendV1
+  nonce: string
+  issued_at: string
+  expires_at: string
+  private_key_hex: string
+}): ApsMcpAuthorizationV1 {
+  const server = canonicalMcpServerUri(input.mcp_server)
+  const argumentsHash = computeMcpArgumentsHashV1(input.arguments)
+  const scopes = sortedUnique(
+    input.scope_required.map((scope) => scope.normalize('NFC')),
+    'scope_required',
+  )
+  const actionRef = computeActionRefV2(createActionReferenceInputV2({
+    agent_id: input.agent_id,
+    action_type: 'mcp:tools/call',
+    target: `${server}#tool=${encodeURIComponent(input.tool_name)}`,
+    payload_ref: argumentsHash,
+    scope_required: scopes,
+    issued_at: input.issued_at,
+    nonce: input.nonce,
+  }))
+  const unsigned: Omit<ApsMcpAuthorizationV1, 'signature'> = {
+    profile: 'aps-mcp-1',
+    agent_id: input.agent_id,
+    verification_method: input.verification_method,
+    delegation_ref: input.delegation_ref,
+    mcp_server: server,
+    method: 'tools/call',
+    tool_name: input.tool_name,
+    arguments_hash: argumentsHash,
+    scope_required: scopes,
+    ...(input.spend === undefined ? {} : { spend: input.spend }),
+    nonce: input.nonce,
+    issued_at: input.issued_at,
+    expires_at: input.expires_at,
+    action_ref: actionRef,
+  }
+  validateAuthorizationUnsigned(unsigned)
+  return {
+    ...unsigned,
+    signature: sign(INTENT_DOMAIN + canonicalizeJCS(unsigned), input.private_key_hex),
+  }
+}
+
+export async function verifyApsMcpAuthorizationV1(
+  candidate: unknown,
+  expected: {
+    mcp_server: string
+    tool_name: string
+    arguments: Record<string, unknown>
+    now?: string
+    resolve_key: HistoricalKeyResolver
+  },
+): Promise<{ state: 'valid' | 'invalid' | 'indeterminate'; code: string; authorization?: ApsMcpAuthorizationV1 }> {
+  let authorization: ApsMcpAuthorizationV1
+  try {
+    authorization = validateAuthorization(candidate)
+  } catch {
+    return { state: 'invalid', code: 'MCP_AUTHORIZATION_MALFORMED' }
+  }
+  const expectedServer = canonicalMcpServerUri(expected.mcp_server)
+  if (authorization.mcp_server !== expectedServer || authorization.tool_name !== expected.tool_name) {
+    return { state: 'invalid', code: 'MCP_TARGET_MISMATCH' }
+  }
+  const argumentsHash = computeMcpArgumentsHashV1(expected.arguments)
+  if (argumentsHash !== authorization.arguments_hash) {
+    return { state: 'invalid', code: 'MCP_ARGUMENTS_MISMATCH' }
+  }
+  const recomputedActionRef = computeActionRefV2(createActionReferenceInputV2({
+    agent_id: authorization.agent_id,
+    action_type: 'mcp:tools/call',
+    target: `${authorization.mcp_server}#tool=${encodeURIComponent(authorization.tool_name)}`,
+    payload_ref: authorization.arguments_hash,
+    scope_required: authorization.scope_required,
+    issued_at: authorization.issued_at,
+    nonce: authorization.nonce,
+  }))
+  if (recomputedActionRef !== authorization.action_ref) {
+    return { state: 'invalid', code: 'MCP_ACTION_REF_MISMATCH' }
+  }
+  const now = expected.now ?? new Date().toISOString()
+  if (now < authorization.issued_at || now >= authorization.expires_at) {
+    return { state: 'invalid', code: 'MCP_AUTHORIZATION_NOT_CURRENT' }
+  }
+  const resolution = await expected.resolve_key({
+    controller: authorization.agent_id,
+    verification_method: authorization.verification_method,
+    at: authorization.issued_at,
+  })
+  if (resolution.state !== 'resolved' || !resolution.public_key_hex) {
+    return {
+      state: resolution.state === 'unreachable' ? 'indeterminate' : 'invalid',
+      code: `MCP_SIGNING_KEY_${resolution.state.toUpperCase()}`,
+    }
+  }
+  const unsigned = omit(authorization, ['signature'])
+  if (!verify(INTENT_DOMAIN + canonicalizeJCS(unsigned), authorization.signature, resolution.public_key_hex)) {
+    return { state: 'invalid', code: 'MCP_SIGNATURE_INVALID' }
+  }
+  return { state: 'valid', code: 'OK', authorization }
+}
+
+/**
+ * Creates an unavoidable pre-dispatch guard for an MCP tools/call handler.
+ * Transport OAuth is checked first. The APS intent, replay claim, authority
+ * decision, and budget reservation all complete before dispatch is invoked.
+ */
+export function createApsMcpToolCallMiddleware(options: {
+  mcp_server: string
+  resolve_key: HistoricalKeyResolver
+  consume_action_ref: (actionRef: string, expiresAt: string) => boolean | Promise<boolean>
+  evaluate_authority: (
+    authorization: ApsMcpAuthorizationV1,
+    request: McpToolCallRequest,
+  ) => ApsMcpAuthorityDecision | Promise<ApsMcpAuthorityDecision>
+  emit_receipt: (
+    authorization: ApsMcpAuthorizationV1,
+    authority: ApsMcpAuthorityDecision,
+    result: McpToolCallResult,
+  ) => unknown | Promise<unknown>
+}) {
+  return async function apsMcpToolCall(
+    request: McpToolCallRequest,
+    context: ApsMcpMiddlewareContext,
+    dispatch: (request: McpToolCallRequest) => McpToolCallResult | Promise<McpToolCallResult>,
+  ): Promise<McpToolCallResult> {
+    if (!context.transport_authenticated) throw new ApsMcpAuthorizationError('MCP_TRANSPORT_UNAUTHENTICATED')
+    if (request.method !== 'tools/call') throw new ApsMcpAuthorizationError('MCP_METHOD_UNSUPPORTED')
+    const metadata = request.params._meta
+    const candidate = metadata?.[APS_MCP_AUTHORIZATION_META]
+    const verification = await verifyApsMcpAuthorizationV1(candidate, {
+      mcp_server: options.mcp_server,
+      tool_name: request.params.name,
+      arguments: request.params.arguments ?? {},
+      resolve_key: options.resolve_key,
+    })
+    if (verification.state !== 'valid' || !verification.authorization) {
+      throw new ApsMcpAuthorizationError(verification.code)
+    }
+    if (!await options.consume_action_ref(
+      verification.authorization.action_ref,
+      verification.authorization.expires_at,
+    )) throw new ApsMcpAuthorizationError('MCP_ACTION_REPLAY')
+
+    const authority = await options.evaluate_authority(verification.authorization, request)
+    if (authority.state !== 'permit') throw new ApsMcpAuthorizationError(authority.code)
+
+    const dispatched = await dispatch(request)
+    const receipt = await options.emit_receipt(verification.authorization, authority, dispatched)
+    return {
+      ...dispatched,
+      _meta: {
+        ...(dispatched._meta ?? {}),
+        [APS_MCP_RECEIPT_META]: receipt,
+      },
+    }
+  }
+}
+
+export function canonicalMcpServerUri(value: string): string {
+  const parsed = new URL(value)
+  if (!['https:', 'http:'].includes(parsed.protocol) || parsed.username || parsed.password || parsed.hash) {
+    throw new Error('Invalid MCP server resource URI')
+  }
+  if (parsed.protocol === 'http:' && !['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname)) {
+    throw new Error('MCP server resource URI requires HTTPS outside localhost')
+  }
+  if (parsed.pathname === '/' && !parsed.search) parsed.pathname = ''
+  return parsed.toString().replace(/\/$/, '')
+}
+
+function validateAuthorization(candidate: unknown): ApsMcpAuthorizationV1 {
+  assertPlainRecord(candidate, 'MCP authorization')
+  assertExactKeys(candidate, [
+    'profile', 'agent_id', 'verification_method', 'delegation_ref', 'mcp_server',
+    'method', 'tool_name', 'arguments_hash', 'scope_required', 'nonce',
+    'issued_at', 'expires_at', 'action_ref', 'signature',
+  ], ['spend'], 'MCP authorization')
+  const unsigned = omit(candidate, ['signature']) as unknown as Omit<ApsMcpAuthorizationV1, 'signature'>
+  validateAuthorizationUnsigned(unsigned)
+  assertHex(String(candidate.signature), 128, 'signature')
+  return candidate as unknown as ApsMcpAuthorizationV1
+}
+
+function validateAuthorizationUnsigned(value: Omit<ApsMcpAuthorizationV1, 'signature'>): void {
+  assertIJson(value)
+  if (value.profile !== 'aps-mcp-1' || value.method !== 'tools/call') throw new Error('MCP profile')
+  if (!/^did:[a-z0-9]+:.+$/.test(value.agent_id)) throw new Error('agent_id')
+  if (!value.verification_method.startsWith(`${value.agent_id}#`)) throw new Error('verification_method')
+  if (typeof value.delegation_ref !== 'string' || value.delegation_ref.length === 0) throw new Error('delegation_ref')
+  if (canonicalMcpServerUri(value.mcp_server) !== value.mcp_server) throw new Error('non-canonical mcp_server')
+  if (!/^[A-Za-z0-9_.-]{1,128}$/.test(value.tool_name)) throw new Error('tool_name')
+  assertHex(value.arguments_hash, 64, 'arguments_hash')
+  if (!Array.isArray(value.scope_required)) throw new Error('scope_required')
+  assertSortedUnique(value.scope_required, 'scope_required')
+  for (const scope of value.scope_required) if (scope !== scope.normalize('NFC')) throw new Error('scope_required NFC')
+  if (value.spend !== undefined) {
+    assertPlainRecord(value.spend, 'spend')
+    assertExactKeys(value.spend, ['unit', 'amount'], [], 'spend')
+    if (!/^[A-Za-z0-9:._-]{1,64}$/.test(value.spend.unit)) throw new Error('spend unit')
+    if (!/^(0|[1-9]\d{0,18})$/.test(value.spend.amount)) throw new Error('spend amount')
+  }
+  assertHex(value.nonce, 32, 'nonce')
+  assertUtcMilliseconds(value.issued_at, 'issued_at')
+  assertUtcMilliseconds(value.expires_at, 'expires_at')
+  if (value.issued_at >= value.expires_at) throw new Error('authorization time window')
+  assertHex(value.action_ref, 64, 'action_ref')
+}
+
+function omit(value: object, keys: readonly string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) if (!keys.includes(key)) result[key] = entry
+  return result
+}

--- a/src/profiles/mcp/index.ts
+++ b/src/profiles/mcp/index.ts
@@ -1,0 +1,1 @@
+export * from './authorization-v1.js'

--- a/src/v2/action-reference/index.ts
+++ b/src/v2/action-reference/index.ts
@@ -1,0 +1,1 @@
+export * from './v2.js'

--- a/src/v2/action-reference/v2.ts
+++ b/src/v2/action-reference/v2.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertSortedUnique,
+  assertUtcMilliseconds,
+  sortedUnique,
+} from '../identity-binding/validation.js'
+
+const DOMAIN = 'APS-ACTION-REF-V2\0'
+
+export interface ActionReferenceInputV2 {
+  profile: 'aps-action-ref-v2'
+  agent_id: string
+  action_type: string
+  target: string
+  payload_ref: string
+  scope_required: string[]
+  issued_at: string
+  nonce: string
+}
+
+export function createActionReferenceInputV2(input: {
+  agent_id: string
+  action_type: string
+  target: string
+  payload_ref: string
+  scope_required: readonly string[]
+  issued_at: string
+  nonce: string
+}): ActionReferenceInputV2 {
+  const value: ActionReferenceInputV2 = {
+    profile: 'aps-action-ref-v2',
+    agent_id: input.agent_id,
+    action_type: input.action_type,
+    target: input.target,
+    payload_ref: input.payload_ref,
+    scope_required: sortedUnique(
+      input.scope_required.map((scope) => scope.normalize('NFC')),
+      'scope_required',
+    ),
+    issued_at: input.issued_at,
+    nonce: input.nonce,
+  }
+  validateActionReferenceInputV2(value)
+  return value
+}
+
+export function computeActionRefV2(input: ActionReferenceInputV2): string {
+  validateActionReferenceInputV2(input)
+  return createHash('sha256').update(DOMAIN + canonicalizeJCS(input), 'utf8').digest('hex')
+}
+
+export function computePayloadRefV1(payload: unknown): string {
+  assertIJson(payload)
+  return createHash('sha256')
+    .update('APS-ACTION-PAYLOAD-V1\0' + canonicalizeJCS(payload), 'utf8')
+    .digest('hex')
+}
+
+export function validateActionReferenceInputV2(candidate: unknown): asserts candidate is ActionReferenceInputV2 {
+  assertPlainRecord(candidate, 'action reference')
+  assertExactKeys(candidate, [
+    'profile', 'agent_id', 'action_type', 'target', 'payload_ref',
+    'scope_required', 'issued_at', 'nonce',
+  ], [], 'action reference')
+  assertIJson(candidate)
+  if (candidate.profile !== 'aps-action-ref-v2') throw new Error('action reference profile')
+  if (typeof candidate.agent_id !== 'string' || candidate.agent_id.length === 0) throw new Error('agent_id')
+  if (typeof candidate.action_type !== 'string' || candidate.action_type.length === 0) throw new Error('action_type')
+  if (typeof candidate.target !== 'string' || candidate.target.length === 0) throw new Error('target')
+  assertHex(String(candidate.payload_ref), 64, 'payload_ref')
+  if (!Array.isArray(candidate.scope_required)) throw new Error('scope_required')
+  assertSortedUnique(candidate.scope_required as string[], 'scope_required')
+  for (const scope of candidate.scope_required as string[]) {
+    if (scope !== scope.normalize('NFC')) throw new Error('scope_required: non-NFC value')
+  }
+  assertUtcMilliseconds(String(candidate.issued_at), 'issued_at')
+  assertHex(String(candidate.nonce), 32, 'nonce')
+}

--- a/src/v2/authority-delegation/budget.ts
+++ b/src/v2/authority-delegation/budget.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { isCanonicalQuantity, validateAuthorityDelegationShape } from './schema.js'
+import { authorityDelegationBody, computeAuthorityDelegationId } from './canonical.js'
+import type {
+  AuthorityDelegationV1,
+  BudgetOperationResult,
+  BudgetReservationState,
+} from './types.js'
+
+interface Counter {
+  reserved: bigint
+  committed: bigint
+}
+
+interface Reservation {
+  actionRef: string
+  unit: string
+  amount: bigint
+  delegationIds: string[]
+  state: BudgetReservationState
+}
+
+const ACTION_REF = /^[0-9a-f]{64}$/
+
+/**
+ * Reference linearizable ledger for one JavaScript process. Each mutation is a
+ * single synchronous critical section. Distributed deployments must replace it
+ * with a store providing the same all-ancestors atomicity and idempotency.
+ */
+export class InMemoryAuthorityBudgetLedger {
+  private readonly counters = new Map<string, Counter>()
+  private readonly reservations = new Map<string, Reservation>()
+
+  reserve(
+    verifiedChain: readonly AuthorityDelegationV1[],
+    actionRef: string,
+    unit: string,
+    amountString: string,
+  ): BudgetOperationResult {
+    if (!ACTION_REF.test(actionRef) || !isCanonicalQuantity(amountString)) {
+      return { ok: false, code: 'CONFLICT' }
+    }
+    if (verifiedChain.length === 0 || verifiedChain.length > 256) {
+      return { ok: false, code: 'CONFLICT' }
+    }
+    const seen = new Set<string>()
+    for (let i = 0; i < verifiedChain.length; i++) {
+      const current = verifiedChain[i]
+      if (validateAuthorityDelegationShape(current).length > 0 ||
+          computeAuthorityDelegationId(authorityDelegationBody(current)) !== current.delegation_id ||
+          seen.has(current.delegation_id)) {
+        return { ok: false, code: 'CONFLICT' }
+      }
+      seen.add(current.delegation_id)
+      if (i === 0) {
+        if (current.parent_delegation_id !== null) return { ok: false, code: 'CONFLICT' }
+      } else {
+        const parent = verifiedChain[i - 1]
+        if (current.parent_delegation_id !== parent.delegation_id || current.issuer !== parent.subject) {
+          return { ok: false, code: 'CONFLICT' }
+        }
+      }
+    }
+    const amount = BigInt(amountString)
+    const bounded = verifiedChain.filter(item => item.authority.spend.mode === 'bounded')
+    const ids = bounded.map(item => item.delegation_id)
+    const prior = this.reservations.get(actionRef)
+    if (prior) {
+      const identical = prior.unit === unit && prior.amount === amount &&
+        prior.delegationIds.length === ids.length &&
+        prior.delegationIds.every((id, index) => id === ids[index])
+      return identical
+        ? { ok: true, code: 'IDEMPOTENT', state: prior.state }
+        : { ok: false, code: 'CONFLICT', state: prior.state }
+    }
+
+    for (const delegation of bounded) {
+      const spend = delegation.authority.spend
+      if (spend.mode !== 'bounded') continue
+      if (spend.unit !== unit) return { ok: false, code: 'UNIT_MISMATCH' }
+      if (amount > BigInt(spend.per_action)) return { ok: false, code: 'PER_ACTION_EXCEEDED' }
+      const counter = this.counters.get(delegation.delegation_id) ?? { reserved: 0n, committed: 0n }
+      if (counter.reserved + counter.committed + amount > BigInt(spend.cumulative)) {
+        return { ok: false, code: 'CUMULATIVE_EXCEEDED' }
+      }
+    }
+
+    // All checks completed before any counter is changed.
+    for (const delegation of bounded) {
+      const counter = this.counters.get(delegation.delegation_id) ?? { reserved: 0n, committed: 0n }
+      counter.reserved += amount
+      this.counters.set(delegation.delegation_id, counter)
+    }
+    this.reservations.set(actionRef, {
+      actionRef,
+      unit,
+      amount,
+      delegationIds: ids,
+      state: 'reserved',
+    })
+    return { ok: true, code: 'RESERVED', state: 'reserved' }
+  }
+
+  markDispatched(actionRef: string): BudgetOperationResult {
+    const reservation = this.reservations.get(actionRef)
+    if (!reservation) return { ok: false, code: 'NOT_FOUND' }
+    if (reservation.state === 'dispatched') return { ok: true, code: 'IDEMPOTENT', state: 'dispatched' }
+    if (reservation.state !== 'reserved') return { ok: false, code: 'INVALID_STATE', state: reservation.state }
+    reservation.state = 'dispatched'
+    return { ok: true, code: 'DISPATCHED', state: 'dispatched' }
+  }
+
+  commit(actionRef: string): BudgetOperationResult {
+    const reservation = this.reservations.get(actionRef)
+    if (!reservation) return { ok: false, code: 'NOT_FOUND' }
+    if (reservation.state === 'committed') return { ok: true, code: 'IDEMPOTENT', state: 'committed' }
+    if (reservation.state !== 'reserved' && reservation.state !== 'dispatched') {
+      return { ok: false, code: 'INVALID_STATE', state: reservation.state }
+    }
+    for (const id of reservation.delegationIds) {
+      const counter = this.counters.get(id)
+      if (!counter || counter.reserved < reservation.amount) {
+        return { ok: false, code: 'INVALID_STATE', state: reservation.state }
+      }
+    }
+    for (const id of reservation.delegationIds) {
+      const counter = this.counters.get(id)!
+      counter.reserved -= reservation.amount
+      counter.committed += reservation.amount
+    }
+    reservation.state = 'committed'
+    return { ok: true, code: 'COMMITTED', state: 'committed' }
+  }
+
+  /** Cancellation is allowed only before dispatch. */
+  cancel(actionRef: string): BudgetOperationResult {
+    const reservation = this.reservations.get(actionRef)
+    if (!reservation) return { ok: false, code: 'NOT_FOUND' }
+    if (reservation.state === 'cancelled') return { ok: true, code: 'IDEMPOTENT', state: 'cancelled' }
+    if (reservation.state !== 'reserved') return { ok: false, code: 'INVALID_STATE', state: reservation.state }
+    for (const id of reservation.delegationIds) {
+      const counter = this.counters.get(id)
+      if (!counter || counter.reserved < reservation.amount) {
+        return { ok: false, code: 'INVALID_STATE', state: reservation.state }
+      }
+    }
+    for (const id of reservation.delegationIds) {
+      this.counters.get(id)!.reserved -= reservation.amount
+    }
+    reservation.state = 'cancelled'
+    return { ok: true, code: 'CANCELLED', state: 'cancelled' }
+  }
+
+  counter(delegationId: string): { reserved: string; committed: string } {
+    const counter = this.counters.get(delegationId) ?? { reserved: 0n, committed: 0n }
+    return { reserved: counter.reserved.toString(), committed: counter.committed.toString() }
+  }
+}

--- a/src/v2/authority-delegation/canonical.ts
+++ b/src/v2/authority-delegation/canonical.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import type { AuthorityDelegationBodyV1, AuthorityDelegationV1 } from './types.js'
+
+export const AUTHORITY_DELEGATION_ID_DOMAIN = 'APS-AUTHORITY-DELEGATION-ID-V1\0'
+export const AUTHORITY_DELEGATION_SIGNATURE_DOMAIN = 'APS-AUTHORITY-DELEGATION-SIGNATURE-V1\0'
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+/** Exact RFC 8785 input used to derive delegation_id. */
+export function authorityDelegationIdInput(body: AuthorityDelegationBodyV1): string {
+  return AUTHORITY_DELEGATION_ID_DOMAIN + canonicalizeJCS(body)
+}
+
+export function computeAuthorityDelegationId(body: AuthorityDelegationBodyV1): string {
+  return `sha256:${sha256Hex(authorityDelegationIdInput(body))}`
+}
+
+/** Exact Ed25519 input: domain plus JCS(record without signature). */
+export function authorityDelegationSignatureInput(
+  delegation: Omit<AuthorityDelegationV1, 'signature'>,
+): string {
+  return AUTHORITY_DELEGATION_SIGNATURE_DOMAIN + canonicalizeJCS(delegation)
+}
+
+export function signAuthorityDelegation(
+  delegation: Omit<AuthorityDelegationV1, 'signature'>,
+  privateKey: string,
+): string {
+  return sign(authorityDelegationSignatureInput(delegation), privateKey)
+}
+
+export function verifyAuthorityDelegationSignature(
+  delegation: AuthorityDelegationV1,
+  publicKey: string,
+): boolean {
+  const { signature, ...unsigned } = delegation
+  return verify(authorityDelegationSignatureInput(unsigned), signature, publicKey)
+}
+
+export function authorityDelegationBody(
+  delegation: AuthorityDelegationV1,
+): AuthorityDelegationBodyV1 {
+  const { delegation_id: _delegationId, signature: _signature, ...body } = delegation
+  return body
+}

--- a/src/v2/authority-delegation/compare.ts
+++ b/src/v2/authority-delegation/compare.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { scopeNarrows } from './scope.js'
+import type { AuthorityFailure, AuthorityVectorV1, ReversibilityClassV1 } from './types.js'
+
+const REVERSIBILITY_RANK: Record<ReversibilityClassV1, number> = {
+  tentative: 0,
+  compensable: 1,
+  irreversible: 2,
+}
+
+function fail(
+  failures: AuthorityFailure[],
+  code: AuthorityFailure['code'],
+  facet: keyof AuthorityVectorV1,
+  message: string,
+): void {
+  failures.push({ code, facet, message })
+}
+
+/** Compare a child against its immediate parent in the seven-facet partial order. */
+export function compareAuthority(
+  parent: AuthorityVectorV1,
+  child: AuthorityVectorV1,
+): AuthorityFailure[] {
+  const failures: AuthorityFailure[] = []
+
+  if (child.scope.profile !== parent.scope.profile) {
+    fail(failures, 'UNSUPPORTED_PROFILE', 'scope', 'scope profile changes are incomparable')
+  } else if (!scopeNarrows(parent.scope.grants, child.scope.grants)) {
+    fail(failures, 'SCOPE_WIDENING', 'scope', 'child scope is not covered by parent scope')
+  }
+
+  if (parent.spend.mode === 'bounded') {
+    if (child.spend.mode === 'unbounded') {
+      fail(failures, 'SPEND_WIDENING', 'spend', 'bounded parent cannot produce unbounded child')
+    } else if (child.spend.unit !== parent.spend.unit) {
+      fail(failures, 'SPEND_UNIT_CHANGE', 'spend', 'bounded spend unit must remain exact')
+    } else if (BigInt(child.spend.per_action) > BigInt(parent.spend.per_action) ||
+               BigInt(child.spend.cumulative) > BigInt(parent.spend.cumulative)) {
+      fail(failures, 'SPEND_WIDENING', 'spend', 'child spend limits exceed parent limits')
+    }
+  }
+
+  if (parent.depth.remaining === 0) {
+    fail(failures, 'DEPTH_EXHAUSTED', 'depth', 'parent has no remaining delegation hop')
+  } else if (child.depth.remaining > parent.depth.remaining - 1) {
+    fail(failures, 'DEPTH_WIDENING', 'depth', 'child remaining depth must consume at least one hop')
+  }
+
+  if (Date.parse(child.time.not_before) < Date.parse(parent.time.not_before) ||
+      Date.parse(child.time.not_after) > Date.parse(parent.time.not_after)) {
+    fail(failures, 'TIME_WIDENING', 'time', 'child validity window is not contained in parent window')
+  }
+
+  if (child.reputation.profile !== parent.reputation.profile) {
+    fail(failures, 'UNSUPPORTED_PROFILE', 'reputation', 'reputation profile changes are incomparable')
+  } else if (child.reputation.ceiling > parent.reputation.ceiling) {
+    fail(failures, 'REPUTATION_WIDENING', 'reputation', 'child reputation ceiling exceeds parent')
+  }
+
+  if (child.values.profile !== parent.values.profile) {
+    fail(failures, 'UNSUPPORTED_PROFILE', 'values', 'values profile changes are incomparable')
+  } else {
+    const childRequired = new Set(child.values.required)
+    if (parent.values.required.some(identifier => !childRequired.has(identifier))) {
+      fail(failures, 'VALUES_WEAKENING', 'values', 'child removed an ancestor-required value identifier')
+    }
+  }
+
+  if (child.reversibility.profile !== parent.reversibility.profile) {
+    fail(failures, 'UNSUPPORTED_PROFILE', 'reversibility', 'reversibility profile changes are incomparable')
+  } else if (REVERSIBILITY_RANK[child.reversibility.ceiling] >
+             REVERSIBILITY_RANK[parent.reversibility.ceiling]) {
+    fail(failures, 'REVERSIBILITY_WIDENING', 'reversibility', 'child reversibility ceiling exceeds parent')
+  }
+
+  return failures
+}

--- a/src/v2/authority-delegation/index.ts
+++ b/src/v2/authority-delegation/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './types.js'
+export * from './schema.js'
+export * from './scope.js'
+export * from './canonical.js'
+export * from './compare.js'
+export * from './issue.js'
+export * from './parse.js'
+export * from './verify.js'
+export * from './budget.js'

--- a/src/v2/authority-delegation/issue.ts
+++ b/src/v2/authority-delegation/issue.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  computeAuthorityDelegationId,
+  signAuthorityDelegation,
+} from './canonical.js'
+import { compareAuthority } from './compare.js'
+import { validateAuthorityDelegationShape } from './schema.js'
+import type { AuthorityDelegationBodyV1, AuthorityDelegationV1 } from './types.js'
+
+function assertBody(body: AuthorityDelegationBodyV1): void {
+  const probe: AuthorityDelegationV1 = {
+    ...body,
+    delegation_id: `sha256:${'0'.repeat(64)}`,
+    signature: '0'.repeat(128),
+  }
+  const failures = validateAuthorityDelegationShape(probe)
+  if (failures.length > 0) {
+    throw new Error(`authority delegation body invalid: ${failures.map(item => `${item.code}: ${item.message}`).join('; ')}`)
+  }
+}
+
+/** Create a deterministic v1 record from explicit body fields and an Ed25519 key. */
+export function issueAuthorityDelegation(
+  body: AuthorityDelegationBodyV1,
+  privateKey: string,
+): AuthorityDelegationV1 {
+  assertBody(body)
+  const delegation_id = computeAuthorityDelegationId(body)
+  const unsigned: Omit<AuthorityDelegationV1, 'signature'> = { ...body, delegation_id }
+  return { ...unsigned, signature: signAuthorityDelegation(unsigned, privateKey) }
+}
+
+/**
+ * Issue a child after immediate-parent attenuation checks. The caller must first
+ * validate the complete parent chain and revocation state; this pure primitive
+ * cannot establish live ancestor status by itself.
+ */
+export function issueSubAuthorityDelegation(
+  parent: AuthorityDelegationV1,
+  body: AuthorityDelegationBodyV1,
+  privateKey: string,
+): AuthorityDelegationV1 {
+  const parentFailures = validateAuthorityDelegationShape(parent)
+  if (parentFailures.length > 0) {
+    throw new Error(`authority delegation parent invalid: ${parentFailures.map(item => item.code).join(', ')}`)
+  }
+  assertBody(body)
+  if (body.parent_delegation_id !== parent.delegation_id) {
+    throw new Error('authority delegation parent mismatch')
+  }
+  if (body.issuer !== parent.subject) {
+    throw new Error('authority delegation chain continuity failure')
+  }
+  const issued = Date.parse(body.issued_at)
+  if (issued < Date.parse(parent.authority.time.not_before) ||
+      issued >= Date.parse(parent.authority.time.not_after)) {
+    throw new Error('authority delegation issued_at is outside parent validity')
+  }
+  const failures = compareAuthority(parent.authority, body.authority)
+  if (failures.length > 0) {
+    throw new Error(`authority delegation does not narrow: ${failures.map(item => item.code).join(', ')}`)
+  }
+  return issueAuthorityDelegation(body, privateKey)
+}

--- a/src/v2/authority-delegation/parse.ts
+++ b/src/v2/authority-delegation/parse.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { validateAuthorityDelegationShape } from './schema.js'
+import type { AuthorityDelegationV1 } from './types.js'
+
+const MAX_WIRE_BYTES = 1_048_576
+
+/**
+ * JSON.parse silently keeps the last occurrence of a duplicate member. RFC
+ * 8785 operates on I-JSON, so scan the already-syntax-checked source and reject
+ * repeated names at every object depth before accepting a signed record.
+ */
+function rejectDuplicateMembers(source: string): void {
+  let cursor = 0
+
+  const skipWhitespace = (): void => {
+    while (cursor < source.length && /[\u0009\u000a\u000d\u0020]/.test(source[cursor])) cursor++
+  }
+  const readString = (): string => {
+    const start = cursor
+    cursor++ // opening quote; whole-document JSON.parse already proved syntax
+    while (cursor < source.length) {
+      if (source[cursor] === '\\') {
+        cursor += 2
+      } else if (source[cursor++] === '"') {
+        return JSON.parse(source.slice(start, cursor)) as string
+      }
+    }
+    throw new SyntaxError('unterminated JSON string')
+  }
+  const value = (): void => {
+    skipWhitespace()
+    const first = source[cursor]
+    if (first === '{') {
+      cursor++
+      skipWhitespace()
+      const names = new Set<string>()
+      if (source[cursor] === '}') { cursor++; return }
+      while (cursor < source.length) {
+        const name = readString()
+        if (names.has(name)) throw new SyntaxError('duplicate JSON object member')
+        names.add(name)
+        skipWhitespace()
+        cursor++ // colon
+        value()
+        skipWhitespace()
+        if (source[cursor++] === '}') return
+        skipWhitespace() // comma was consumed
+      }
+    } else if (first === '[') {
+      cursor++
+      skipWhitespace()
+      if (source[cursor] === ']') { cursor++; return }
+      while (cursor < source.length) {
+        value()
+        skipWhitespace()
+        if (source[cursor++] === ']') return
+      }
+    } else if (first === '"') {
+      readString()
+    } else {
+      const start = cursor
+      while (cursor < source.length && !/[\u0009\u000a\u000d\u0020,}\]]/.test(source[cursor])) cursor++
+      const token = source.slice(start, cursor)
+      if (/^[-0-9]/.test(token) && !/^-?(0|[1-9][0-9]*)$/.test(token)) {
+        throw new SyntaxError('non-integer JSON numbers are not permitted')
+      }
+    }
+  }
+
+  value()
+}
+
+/** Strict untrusted-wire entry point: valid JSON, I-JSON names, and closed v1 schema. */
+export function parseAuthorityDelegationJson(source: string): AuthorityDelegationV1 {
+  if (typeof source !== 'string' || Buffer.byteLength(source, 'utf8') > MAX_WIRE_BYTES) {
+    throw new TypeError('authority delegation JSON must be a string no larger than 1 MiB')
+  }
+  const decoded: unknown = JSON.parse(source)
+  rejectDuplicateMembers(source)
+  const failures = validateAuthorityDelegationShape(decoded)
+  if (failures.length > 0) {
+    throw new TypeError(`authority delegation wire invalid: ${failures.map(item => item.code).join(', ')}`)
+  }
+  return decoded as AuthorityDelegationV1
+}

--- a/src/v2/authority-delegation/schema.ts
+++ b/src/v2/authority-delegation/schema.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { grantsAreCanonical } from './scope.js'
+import {
+  AUTHORITY_DELEGATION_RECORD_TYPE,
+  AUTHORITY_DELEGATION_VERSION,
+  REPUTATION_PROFILE_V1,
+  REVERSIBILITY_PROFILE_V1,
+  SCOPE_PROFILE_V1,
+  VALUES_PROFILE_V1,
+} from './types.js'
+import type { AuthorityDelegationV1, AuthorityFailure } from './types.js'
+
+const ID = /^sha256:[0-9a-f]{64}$/
+const HEX_32 = /^[0-9a-f]{32}$/
+const HEX_128 = /^[0-9a-f]{128}$/
+const DECIMAL = /^(0|[1-9][0-9]*)$/
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/
+const MAX_QUANTITY = 9223372036854775807n
+const MILLIS_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  return actual.length === wanted.length && actual.every((key, i) => key === wanted[i])
+}
+
+function wellFormedUnicode(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const unit = value.charCodeAt(i)
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(++i)
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return false
+    }
+  }
+  return true
+}
+
+export function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string' || !MILLIS_UTC.test(value) || value.startsWith('0000-')) return false
+  const parsed = new Date(value)
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value
+}
+
+export function isCanonicalQuantity(value: unknown): value is string {
+  if (typeof value !== 'string' || !DECIMAL.test(value)) return false
+  try { return BigInt(value) <= MAX_QUANTITY } catch { return false }
+}
+
+function failure(code: AuthorityFailure['code'], message: string): AuthorityFailure {
+  return { code, message }
+}
+
+/** Closed-schema and canonical-value validation for an in-memory decoded record. */
+export function validateAuthorityDelegationShape(value: unknown): AuthorityFailure[] {
+  const failures: AuthorityFailure[] = []
+  const top = record(value)
+  if (!top || !exactKeys(top, [
+    'record_type', 'version', 'delegation_id', 'parent_delegation_id', 'issuer',
+    'subject', 'verification_method', 'issued_at', 'nonce', 'authority', 'signature',
+  ])) return [failure('SCHEMA_INVALID', 'delegation must be an exact closed v1 object')]
+
+  if (top.record_type !== AUTHORITY_DELEGATION_RECORD_TYPE || top.version !== AUTHORITY_DELEGATION_VERSION) {
+    failures.push(failure('UNSUPPORTED_VERSION', 'unsupported authority-delegation record_type or version'))
+  }
+  if (typeof top.delegation_id !== 'string' || !ID.test(top.delegation_id)) {
+    failures.push(failure('SCHEMA_INVALID', 'delegation_id must be sha256:<64 lowercase hex>'))
+  }
+  if (top.parent_delegation_id !== null &&
+      (typeof top.parent_delegation_id !== 'string' || !ID.test(top.parent_delegation_id))) {
+    failures.push(failure('SCHEMA_INVALID', 'parent_delegation_id must be null or a delegation digest'))
+  }
+  for (const key of ['issuer', 'subject', 'verification_method'] as const) {
+    const item = top[key]
+    if (typeof item !== 'string' || item.length === 0 || Buffer.byteLength(item, 'utf8') > 1024 || !wellFormedUnicode(item)) {
+      failures.push(failure('SCHEMA_INVALID', `${key} must be a non-empty well-formed Unicode string`))
+    }
+  }
+  if (!isCanonicalTimestamp(top.issued_at)) failures.push(failure('NONCANONICAL_VALUE', 'issued_at must be canonical UTC milliseconds'))
+  if (typeof top.nonce !== 'string' || !HEX_32.test(top.nonce)) failures.push(failure('NONCANONICAL_VALUE', 'nonce must be 32 lowercase hex characters'))
+  if (typeof top.signature !== 'string' || !HEX_128.test(top.signature)) failures.push(failure('SCHEMA_INVALID', 'signature must be 128 lowercase hex characters'))
+
+  const authority = record(top.authority)
+  if (!authority || !exactKeys(authority, ['scope', 'spend', 'depth', 'time', 'reputation', 'values', 'reversibility'])) {
+    failures.push(failure('SCHEMA_INVALID', 'authority must carry exactly all seven facets'))
+    return failures
+  }
+
+  const scope = record(authority.scope)
+  if (!scope || !exactKeys(scope, ['profile', 'grants']) || typeof scope.profile !== 'string' ||
+      !IDENTIFIER.test(scope.profile) || !Array.isArray(scope.grants) ||
+      !scope.grants.every(item => typeof item === 'string')) {
+    failures.push(failure('SCHEMA_INVALID', 'scope must contain profile and grants'))
+  } else {
+    if (scope.profile !== SCOPE_PROFILE_V1) failures.push(failure('UNSUPPORTED_PROFILE', 'unsupported scope profile'))
+    if (!grantsAreCanonical(scope.grants as string[])) failures.push(failure('NONCANONICAL_VALUE', 'scope grants must be valid, sorted, unique, and irredundant'))
+  }
+
+  const spend = record(authority.spend)
+  if (!spend || typeof spend.mode !== 'string') {
+    failures.push(failure('SCHEMA_INVALID', 'spend must be a tagged object'))
+  } else if (spend.mode === 'unbounded') {
+    if (!exactKeys(spend, ['mode'])) failures.push(failure('SCHEMA_INVALID', 'unbounded spend has no other fields'))
+  } else if (spend.mode === 'bounded') {
+    if (!exactKeys(spend, ['mode', 'unit', 'per_action', 'cumulative']) ||
+        typeof spend.unit !== 'string' || !IDENTIFIER.test(spend.unit) ||
+        !isCanonicalQuantity(spend.per_action) || !isCanonicalQuantity(spend.cumulative)) {
+      failures.push(failure('NONCANONICAL_VALUE', 'bounded spend fields are malformed'))
+    } else if (BigInt(spend.per_action) > BigInt(spend.cumulative)) {
+      failures.push(failure('SCHEMA_INVALID', 'spend per_action cannot exceed cumulative'))
+    }
+  } else failures.push(failure('SCHEMA_INVALID', 'unknown spend mode'))
+
+  const depth = record(authority.depth)
+  if (!depth || !exactKeys(depth, ['remaining']) || !Number.isInteger(depth.remaining) ||
+      (depth.remaining as number) < 0 || (depth.remaining as number) > 255) {
+    failures.push(failure('SCHEMA_INVALID', 'depth.remaining must be an integer from 0 through 255'))
+  }
+
+  const time = record(authority.time)
+  if (!time || !exactKeys(time, ['not_before', 'not_after']) ||
+      !isCanonicalTimestamp(time.not_before) || !isCanonicalTimestamp(time.not_after)) {
+    failures.push(failure('NONCANONICAL_VALUE', 'time bounds must be canonical UTC milliseconds'))
+  } else if (Date.parse(time.not_before) >= Date.parse(time.not_after)) {
+    failures.push(failure('SCHEMA_INVALID', 'time window must be non-empty'))
+  } else if (isCanonicalTimestamp(top.issued_at) && Date.parse(time.not_before) < Date.parse(top.issued_at)) {
+    failures.push(failure('SCHEMA_INVALID', 'time.not_before cannot predate issued_at'))
+  }
+
+  const reputation = record(authority.reputation)
+  if (!reputation || !exactKeys(reputation, ['profile', 'ceiling']) ||
+      typeof reputation.profile !== 'string' || !IDENTIFIER.test(reputation.profile) ||
+      !Number.isInteger(reputation.ceiling) || (reputation.ceiling as number) < 0 ||
+      (reputation.ceiling as number) > 100) {
+    failures.push(failure('SCHEMA_INVALID', 'reputation ceiling must be an integer from 0 through 100'))
+  } else if (reputation.profile !== REPUTATION_PROFILE_V1) {
+    failures.push(failure('UNSUPPORTED_PROFILE', 'unsupported reputation profile'))
+  }
+
+  const values = record(authority.values)
+  if (!values || !exactKeys(values, ['profile', 'required']) || typeof values.profile !== 'string' ||
+      !IDENTIFIER.test(values.profile) || !Array.isArray(values.required) ||
+      !values.required.every(item => typeof item === 'string' && IDENTIFIER.test(item))) {
+    failures.push(failure('SCHEMA_INVALID', 'values.required must contain valid identifiers'))
+  } else {
+    if (values.profile !== VALUES_PROFILE_V1) failures.push(failure('UNSUPPORTED_PROFILE', 'unsupported values profile'))
+    const required = values.required as string[]
+    if (required.some((item, i) => i > 0 && required[i - 1] >= item)) {
+      failures.push(failure('NONCANONICAL_VALUE', 'values.required must be sorted and unique'))
+    }
+  }
+
+  const reversibility = record(authority.reversibility)
+  if (!reversibility || !exactKeys(reversibility, ['profile', 'ceiling']) ||
+      typeof reversibility.profile !== 'string' || !IDENTIFIER.test(reversibility.profile) ||
+      !['tentative', 'compensable', 'irreversible'].includes(String(reversibility.ceiling))) {
+    failures.push(failure('SCHEMA_INVALID', 'reversibility facet is malformed'))
+  } else if (reversibility.profile !== REVERSIBILITY_PROFILE_V1) {
+    failures.push(failure('UNSUPPORTED_PROFILE', 'unsupported reversibility profile'))
+  }
+
+  return failures
+}
+
+export function isAuthorityDelegationV1(value: unknown): value is AuthorityDelegationV1 {
+  return validateAuthorityDelegationShape(value).length === 0
+}

--- a/src/v2/authority-delegation/scope.ts
+++ b/src/v2/authority-delegation/scope.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+const SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
+
+export function isValidScopeGrant(grant: string): boolean {
+  if (grant === '*') return true
+  if (typeof grant !== 'string' || grant.length === 0 || grant.length > 255) return false
+  const parts = grant.split(':')
+  if (parts.length > 16) return false
+  const wildcard = parts.at(-1) === '*'
+  if (wildcard) parts.pop()
+  if (parts.length === 0 || parts.some(part => !SEGMENT.test(part))) return false
+  return !parts.includes('*')
+}
+
+/** Exact grants cover only themselves. A terminal :* grant covers its prefix and descendants. */
+export function scopeGrantCovers(parent: string, child: string): boolean {
+  if (parent === '*') return true
+  if (parent.endsWith(':*')) {
+    const prefix = parent.slice(0, -2)
+    const childPrefix = child.endsWith(':*') ? child.slice(0, -2) : child
+    return childPrefix === prefix || childPrefix.startsWith(prefix + ':')
+  }
+  return parent === child
+}
+
+export function grantsAreCanonical(grants: readonly string[]): boolean {
+  if (!Array.isArray(grants)) return false
+  for (let i = 0; i < grants.length; i++) {
+    const grant = grants[i]
+    if (!isValidScopeGrant(grant)) return false
+    if (i > 0 && grants[i - 1] >= grant) return false
+    // A canonical set is an antichain: no entry is redundant under another entry.
+    for (let j = 0; j < grants.length; j++) {
+      if (i !== j && scopeGrantCovers(grants[j], grant)) return false
+    }
+  }
+  return true
+}
+
+export function scopeNarrows(parent: readonly string[], child: readonly string[]): boolean {
+  return child.every(grant => parent.some(parentGrant => scopeGrantCovers(parentGrant, grant)))
+}

--- a/src/v2/authority-delegation/types.ts
+++ b/src/v2/authority-delegation/types.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+/** First complete APS authority-delegation wire profile. */
+export const AUTHORITY_DELEGATION_RECORD_TYPE = 'aps:authority-delegation:v1' as const
+export const AUTHORITY_DELEGATION_VERSION = '1.0' as const
+
+export const SCOPE_PROFILE_V1 = 'aps-hierarchical-v1' as const
+export const REPUTATION_PROFILE_V1 = 'aps-score-0-100-v1' as const
+export const VALUES_PROFILE_V1 = 'aps-values-identifiers-v1' as const
+export const REVERSIBILITY_PROFILE_V1 = 'aps-tci-v1' as const
+
+export interface ScopeFacetV1 {
+  profile: typeof SCOPE_PROFILE_V1
+  grants: string[]
+}
+
+export type SpendFacetV1 =
+  | { mode: 'unbounded' }
+  | {
+      mode: 'bounded'
+      /** Opaque, exact-match accounting unit, for example iso4217:USD:minor. */
+      unit: string
+      /** Canonical unsigned decimal integer. */
+      per_action: string
+      /** Canonical unsigned decimal integer applying to the whole delegation subtree. */
+      cumulative: string
+    }
+
+export interface DepthFacetV1 {
+  /** Number of further delegation hops the subject may create. */
+  remaining: number
+}
+
+export interface TimeFacetV1 {
+  not_before: string
+  not_after: string
+}
+
+export interface ReputationFacetV1 {
+  profile: typeof REPUTATION_PROFILE_V1
+  ceiling: number
+}
+
+export interface ValuesFacetV1 {
+  profile: typeof VALUES_PROFILE_V1
+  required: string[]
+}
+
+export type ReversibilityClassV1 = 'tentative' | 'compensable' | 'irreversible'
+
+export interface ReversibilityFacetV1 {
+  profile: typeof REVERSIBILITY_PROFILE_V1
+  ceiling: ReversibilityClassV1
+}
+
+export interface AuthorityVectorV1 {
+  scope: ScopeFacetV1
+  spend: SpendFacetV1
+  depth: DepthFacetV1
+  time: TimeFacetV1
+  reputation: ReputationFacetV1
+  values: ValuesFacetV1
+  reversibility: ReversibilityFacetV1
+}
+
+export interface AuthorityDelegationBodyV1 {
+  record_type: typeof AUTHORITY_DELEGATION_RECORD_TYPE
+  version: typeof AUTHORITY_DELEGATION_VERSION
+  /** Null only for a trust-policy-selected root. */
+  parent_delegation_id: string | null
+  issuer: string
+  subject: string
+  verification_method: string
+  issued_at: string
+  /** 16 random bytes encoded as 32 lowercase hexadecimal characters. */
+  nonce: string
+  authority: AuthorityVectorV1
+}
+
+export interface AuthorityDelegationV1 extends AuthorityDelegationBodyV1 {
+  delegation_id: string
+  /** Raw 64-byte Ed25519 signature encoded as 128 lowercase hexadecimal characters. */
+  signature: string
+}
+
+export type AuthorityFailureCode =
+  | 'SCHEMA_INVALID'
+  | 'UNSUPPORTED_VERSION'
+  | 'UNSUPPORTED_PROFILE'
+  | 'NONCANONICAL_VALUE'
+  | 'ID_MISMATCH'
+  | 'KEY_RESOLUTION_FAILED'
+  | 'SIGNATURE_INVALID'
+  | 'ROOT_UNTRUSTED'
+  | 'CHAIN_DUPLICATE_ID'
+  | 'PARENT_MISMATCH'
+  | 'CHAIN_CONTINUITY'
+  | 'ISSUED_AT_OUTSIDE_PARENT'
+  | 'SCOPE_WIDENING'
+  | 'SPEND_WIDENING'
+  | 'SPEND_UNIT_CHANGE'
+  | 'DEPTH_EXHAUSTED'
+  | 'DEPTH_WIDENING'
+  | 'TIME_WIDENING'
+  | 'REPUTATION_WIDENING'
+  | 'VALUES_WEAKENING'
+  | 'REVERSIBILITY_WIDENING'
+  | 'NOT_YET_VALID'
+  | 'EXPIRED'
+  | 'REVOKED'
+  | 'REVOCATION_UNKNOWN'
+
+export interface AuthorityFailure {
+  code: AuthorityFailureCode
+  message: string
+  index?: number
+  facet?: keyof AuthorityVectorV1
+}
+
+export type AuthorityValidationState = 'valid' | 'invalid' | 'indeterminate' | 'unsupported'
+
+export interface AuthorityValidationResult {
+  state: AuthorityValidationState
+  valid: boolean
+  failures: AuthorityFailure[]
+}
+
+export type VerificationKeyResolver = (
+  issuer: string,
+  verificationMethod: string,
+  issuedAt: string,
+) => string | null
+
+export type RevocationResolution = 'active' | 'revoked' | 'unknown'
+
+export interface AuthorityChainVerificationOptions {
+  now: string
+  resolveVerificationKey: VerificationKeyResolver
+  trustRoot: (root: AuthorityDelegationV1) => boolean
+  resolveRevocation: (delegation: AuthorityDelegationV1) => RevocationResolution
+}
+
+export type BudgetReservationState = 'reserved' | 'dispatched' | 'committed' | 'cancelled'
+
+export interface BudgetOperationResult {
+  ok: boolean
+  code: 'RESERVED' | 'DISPATCHED' | 'COMMITTED' | 'CANCELLED' | 'IDEMPOTENT' |
+    'CONFLICT' | 'UNIT_MISMATCH' | 'PER_ACTION_EXCEEDED' |
+    'CUMULATIVE_EXCEEDED' | 'NOT_FOUND' | 'INVALID_STATE'
+  state?: BudgetReservationState
+}

--- a/src/v2/authority-delegation/verify.ts
+++ b/src/v2/authority-delegation/verify.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  authorityDelegationBody,
+  computeAuthorityDelegationId,
+  verifyAuthorityDelegationSignature,
+} from './canonical.js'
+import { compareAuthority } from './compare.js'
+import { isCanonicalTimestamp, validateAuthorityDelegationShape } from './schema.js'
+import type {
+  AuthorityChainVerificationOptions,
+  AuthorityDelegationV1,
+  AuthorityFailure,
+  AuthorityValidationResult,
+  AuthorityValidationState,
+} from './types.js'
+
+function result(state: AuthorityValidationState, failures: AuthorityFailure[]): AuthorityValidationResult {
+  return { state, valid: state === 'valid', failures }
+}
+
+function indexed(failure: AuthorityFailure, index: number): AuthorityFailure {
+  return { ...failure, index }
+}
+
+/** Full root-to-leaf structural, cryptographic, temporal, and revocation validation. */
+export function verifyAuthorityDelegationChain(
+  rawChain: readonly unknown[],
+  options: AuthorityChainVerificationOptions,
+): AuthorityValidationResult {
+  if (!Array.isArray(rawChain) || rawChain.length === 0 || rawChain.length > 256) {
+    return result('invalid', [{ code: 'SCHEMA_INVALID', message: 'chain must contain 1 through 256 records' }])
+  }
+  if (!options || !isCanonicalTimestamp(options.now)) {
+    return result('invalid', [{ code: 'NONCANONICAL_VALUE', message: 'verification clock must be canonical UTC milliseconds' }])
+  }
+  const now = Date.parse(options.now)
+
+  const chain: AuthorityDelegationV1[] = []
+  for (let i = 0; i < rawChain.length; i++) {
+    const failures = validateAuthorityDelegationShape(rawChain[i]).map(item => indexed(item, i))
+    if (failures.length > 0) {
+      const unsupported = failures.every(item => item.code === 'UNSUPPORTED_VERSION' || item.code === 'UNSUPPORTED_PROFILE')
+      return result(unsupported ? 'unsupported' : 'invalid', failures)
+    }
+    chain.push(rawChain[i] as AuthorityDelegationV1)
+  }
+
+  const seen = new Set<string>()
+  for (let i = 0; i < chain.length; i++) {
+    const delegation = chain[i]
+    if (seen.has(delegation.delegation_id)) {
+      return result('invalid', [{ code: 'CHAIN_DUPLICATE_ID', index: i, message: 'delegation ID repeats in chain' }])
+    }
+    seen.add(delegation.delegation_id)
+    const expectedId = computeAuthorityDelegationId(authorityDelegationBody(delegation))
+    if (expectedId !== delegation.delegation_id) {
+      return result('invalid', [{ code: 'ID_MISMATCH', index: i, message: 'delegation content address does not match body' }])
+    }
+    let publicKey: string | null = null
+    try {
+      publicKey = options.resolveVerificationKey(
+        delegation.issuer,
+        delegation.verification_method,
+        delegation.issued_at,
+      )
+    } catch {
+      publicKey = null
+    }
+    if (publicKey === null) {
+      return result('indeterminate', [{ code: 'KEY_RESOLUTION_FAILED', index: i, message: 'issuer verification key could not be resolved' }])
+    }
+    if (!verifyAuthorityDelegationSignature(delegation, publicKey)) {
+      return result('invalid', [{ code: 'SIGNATURE_INVALID', index: i, message: 'Ed25519 signature is invalid' }])
+    }
+  }
+
+  const root = chain[0]
+  if (root.parent_delegation_id !== null) {
+    return result('invalid', [{ code: 'PARENT_MISMATCH', index: 0, message: 'full chain root must carry null parent_delegation_id' }])
+  }
+  if (typeof options.trustRoot !== 'function') {
+    return result('indeterminate', [{ code: 'ROOT_UNTRUSTED', index: 0, message: 'root trust policy is unavailable' }])
+  }
+  let trustDecision: unknown
+  try { trustDecision = options.trustRoot(root) } catch {
+    return result('indeterminate', [{ code: 'ROOT_UNTRUSTED', index: 0, message: 'root trust policy could not decide' }])
+  }
+  if (typeof trustDecision !== 'boolean') {
+    return result('indeterminate', [{ code: 'ROOT_UNTRUSTED', index: 0, message: 'root trust policy returned no boolean decision' }])
+  }
+  if (!trustDecision) {
+    return result('invalid', [{ code: 'ROOT_UNTRUSTED', index: 0, message: 'root is not accepted by verifier trust policy' }])
+  }
+
+  for (let i = 1; i < chain.length; i++) {
+    const parent = chain[i - 1]
+    const child = chain[i]
+    if (child.parent_delegation_id !== parent.delegation_id) {
+      return result('invalid', [{ code: 'PARENT_MISMATCH', index: i, message: 'child does not name immediate parent content address' }])
+    }
+    if (child.issuer !== parent.subject) {
+      return result('invalid', [{ code: 'CHAIN_CONTINUITY', index: i, message: 'child issuer is not parent subject' }])
+    }
+    const issued = Date.parse(child.issued_at)
+    if (issued < Date.parse(parent.authority.time.not_before) ||
+        issued >= Date.parse(parent.authority.time.not_after)) {
+      return result('invalid', [{ code: 'ISSUED_AT_OUTSIDE_PARENT', index: i, message: 'child was issued outside parent validity window' }])
+    }
+    const attenuationFailures = compareAuthority(parent.authority, child.authority)
+    if (attenuationFailures.length > 0) {
+      const indexedFailures = attenuationFailures.map(item => indexed(item, i))
+      const unsupported = indexedFailures.every(item => item.code === 'UNSUPPORTED_PROFILE')
+      return result(unsupported ? 'unsupported' : 'invalid', indexedFailures)
+    }
+  }
+
+  for (let i = 0; i < chain.length; i++) {
+    const delegation = chain[i]
+    if (now < Date.parse(delegation.authority.time.not_before)) {
+      return result('invalid', [{ code: 'NOT_YET_VALID', index: i, message: 'delegation is not yet valid' }])
+    }
+    if (now >= Date.parse(delegation.authority.time.not_after)) {
+      return result('invalid', [{ code: 'EXPIRED', index: i, message: 'delegation has expired' }])
+    }
+    let revocation: 'active' | 'revoked' | 'unknown' = 'unknown'
+    try {
+      const resolved = options.resolveRevocation(delegation)
+      revocation = resolved === 'active' || resolved === 'revoked' ? resolved : 'unknown'
+    } catch { revocation = 'unknown' }
+    if (revocation === 'revoked') {
+      return result('invalid', [{ code: 'REVOKED', index: i, message: 'delegation is revoked' }])
+    }
+    if (revocation === 'unknown') {
+      return result('indeterminate', [{ code: 'REVOCATION_UNKNOWN', index: i, message: 'revocation status is unknown' }])
+    }
+  }
+
+  return result('valid', [])
+}
+
+export function verifyAuthorityDelegation(
+  delegation: unknown,
+  options: AuthorityChainVerificationOptions,
+): AuthorityValidationResult {
+  return verifyAuthorityDelegationChain([delegation], options)
+}

--- a/src/v2/identity-binding/did-aps.ts
+++ b/src/v2/identity-binding/did-aps.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { hexToMultibase, multibaseToHex } from '../../core/did.js'
+
+/**
+ * Legacy APS self-certifying identifier support. New PassportV2 issuance uses
+ * did:key by default; this parser exists so previously emitted did:aps values
+ * remain verifiable without implying that their identifier survives rotation.
+ */
+export function legacyDidApsFromPublicKey(publicKeyHex: string): string {
+  assertEd25519PublicKey(publicKeyHex)
+  return `did:aps:${hexToMultibase(publicKeyHex)}`
+}
+
+export function publicKeyFromLegacyDidAps(did: string): string {
+  if (!/^did:aps:z[1-9A-HJ-NP-Za-km-z]+$/.test(did)) {
+    throw new Error('Invalid did:aps identifier')
+  }
+  const publicKey = multibaseToHex(did.slice('did:aps:'.length))
+  assertEd25519PublicKey(publicKey)
+  if (legacyDidApsFromPublicKey(publicKey) !== did) {
+    throw new Error('Non-canonical did:aps identifier')
+  }
+  return publicKey
+}
+
+export function publicKeyFromDidKey(did: string): string {
+  if (!/^did:key:z[1-9A-HJ-NP-Za-km-z]+$/.test(did)) throw new Error('Invalid did:key identifier')
+  const publicKey = multibaseToHex(did.slice('did:key:'.length))
+  assertEd25519PublicKey(publicKey)
+  if (didKeyFromPublicKey(publicKey) !== did) throw new Error('Non-canonical did:key identifier')
+  return publicKey
+}
+
+export function didKeyFromPublicKey(publicKeyHex: string): string {
+  assertEd25519PublicKey(publicKeyHex)
+  return `did:key:${hexToMultibase(publicKeyHex)}`
+}
+
+export function selfCertifyingPublicKey(did: string): string | null {
+  if (did.startsWith('did:key:')) return publicKeyFromDidKey(did)
+  if (did.startsWith('did:aps:')) return publicKeyFromLegacyDidAps(did)
+  return null
+}
+
+export function defaultVerificationMethod(agentId: string): string {
+  if (agentId.startsWith('did:key:')) return `${agentId}#${agentId.slice('did:key:'.length)}`
+  return `${agentId}#key-1`
+}
+
+function assertEd25519PublicKey(value: string): void {
+  if (!/^[0-9a-f]{64}$/.test(value)) throw new Error('Invalid Ed25519 public key')
+}

--- a/src/v2/identity-binding/index.ts
+++ b/src/v2/identity-binding/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js'
+export * from './did-aps.js'
+export * from './passport.js'
+export * from './principal-binding.js'
+export * from './revocation.js'

--- a/src/v2/identity-binding/passport.ts
+++ b/src/v2/identity-binding/passport.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import { hexToMultibase, multibaseToHex } from '../../core/did.js'
+import {
+  defaultVerificationMethod,
+  didKeyFromPublicKey,
+  selfCertifyingPublicKey,
+} from './did-aps.js'
+import type {
+  HistoricalKeyResolver,
+  IdentityVerificationResult,
+  PassportV2,
+} from './types.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertSortedUnique,
+  assertUtcMilliseconds,
+  sortedUnique,
+} from './validation.js'
+
+const ID_DOMAIN = 'APS-PASSPORT-ID-V2\0'
+const SIGNATURE_DOMAIN = 'APS-PASSPORT-SIG-V2\0'
+
+export interface IssuePassportV2Input {
+  public_key_hex: string
+  private_key_hex: string
+  agent_id?: string
+  verification_method?: string
+  issued_at: string
+  expires_at: string
+  nonce: string
+  display_name?: string
+  capabilities?: readonly string[]
+}
+
+export function issuePassportV2(input: IssuePassportV2Input): PassportV2 {
+  assertHex(input.public_key_hex, 64, 'public_key_hex')
+  const agentId = input.agent_id ?? didKeyFromPublicKey(input.public_key_hex)
+  const draft: Omit<PassportV2, 'passport_id' | 'signature'> = {
+    record_type: 'aps.agent-passport',
+    version: '2.0',
+    agent_id: agentId,
+    verification_method: input.verification_method ?? defaultVerificationMethod(agentId),
+    public_key_multibase: hexToMultibase(input.public_key_hex),
+    issued_at: input.issued_at,
+    expires_at: input.expires_at,
+    nonce: input.nonce,
+    self_asserted: {
+      ...(input.display_name === undefined ? {} : { display_name: input.display_name }),
+      capabilities: sortedUnique(input.capabilities ?? [], 'self_asserted.capabilities'),
+    },
+  }
+  validatePassportDraft(draft)
+  const passportId = digest(ID_DOMAIN + canonicalizeJCS(draft))
+  const withId: Omit<PassportV2, 'signature'> = { ...draft, passport_id: passportId }
+  const signature = sign(SIGNATURE_DOMAIN + canonicalizeJCS(withId), input.private_key_hex)
+  return { ...withId, signature }
+}
+
+export async function verifyPassportV2(
+  candidate: unknown,
+  options: { now?: string; resolve_key?: HistoricalKeyResolver } = {},
+): Promise<IdentityVerificationResult> {
+  let passport: PassportV2
+  try {
+    passport = validatePassport(candidate)
+  } catch {
+    return invalid('PASSPORT_MALFORMED')
+  }
+
+  const idForm = omit(passport, ['passport_id', 'signature'])
+  if (digest(ID_DOMAIN + canonicalizeJCS(idForm)) !== passport.passport_id) {
+    return invalid('PASSPORT_ID_MISMATCH')
+  }
+  const publicKey = multibaseToHex(passport.public_key_multibase)
+  const signatureForm = omit(passport, ['signature'])
+  if (!verify(SIGNATURE_DOMAIN + canonicalizeJCS(signatureForm), passport.signature, publicKey)) {
+    return invalid('PASSPORT_SIGNATURE_INVALID')
+  }
+
+  const now = options.now ?? new Date().toISOString()
+  if (now < passport.issued_at || now >= passport.expires_at) {
+    return { ...invalid('PASSPORT_NOT_CURRENT'), proof_of_possession: true }
+  }
+
+  const derived = selfCertifyingPublicKey(passport.agent_id)
+  if (derived !== null) {
+    if (derived !== publicKey) {
+      return {
+        ...invalid('PASSPORT_KEY_AUTHORITY_REJECTED'),
+        proof_of_possession: true,
+        key_authority: 'rejected',
+      }
+    }
+    return { state: 'valid', code: 'OK', proof_of_possession: true, key_authority: 'verified' }
+  }
+
+  if (!options.resolve_key) {
+    return {
+      state: 'indeterminate',
+      code: 'PASSPORT_KEY_AUTHORITY_UNRESOLVED',
+      proof_of_possession: true,
+      key_authority: 'unresolved',
+    }
+  }
+  const resolution = await options.resolve_key({
+    controller: passport.agent_id,
+    verification_method: passport.verification_method,
+    at: passport.issued_at,
+  })
+  if (resolution.state !== 'resolved' || !resolution.public_key_hex) {
+    return {
+      state: resolution.state === 'unreachable' ? 'indeterminate' : 'invalid',
+      code: `PASSPORT_KEY_${resolution.state.toUpperCase()}`,
+      proof_of_possession: true,
+      key_authority: resolution.state === 'unreachable' ? 'unresolved' : 'rejected',
+    }
+  }
+  if (resolution.public_key_hex !== publicKey) {
+    return {
+      ...invalid('PASSPORT_KEY_AUTHORITY_REJECTED'),
+      proof_of_possession: true,
+      key_authority: 'rejected',
+    }
+  }
+  return { state: 'valid', code: 'OK', proof_of_possession: true, key_authority: 'verified' }
+}
+
+function validatePassport(value: unknown): PassportV2 {
+  assertPlainRecord(value, 'passport')
+  assertExactKeys(value, [
+    'record_type', 'version', 'passport_id', 'agent_id', 'verification_method',
+    'public_key_multibase', 'issued_at', 'expires_at', 'nonce', 'self_asserted', 'signature',
+  ], [], 'passport')
+  validatePassportDraft(value as unknown as Omit<PassportV2, 'passport_id' | 'signature'>)
+  assertHex(String(value.passport_id), 64, 'passport_id')
+  assertHex(String(value.signature), 128, 'signature')
+  return value as unknown as PassportV2
+}
+
+function validatePassportDraft(value: Omit<PassportV2, 'passport_id' | 'signature'>): void {
+  assertIJson(value)
+  if (value.record_type !== 'aps.agent-passport' || value.version !== '2.0') throw new Error('passport profile')
+  if (!/^did:[a-z0-9]+:.+$/.test(value.agent_id)) throw new Error('agent_id')
+  if (!value.verification_method.startsWith(`${value.agent_id}#`)) throw new Error('verification_method')
+  const key = multibaseToHex(value.public_key_multibase)
+  assertHex(key, 64, 'public_key_multibase')
+  assertUtcMilliseconds(value.issued_at, 'issued_at')
+  assertUtcMilliseconds(value.expires_at, 'expires_at')
+  if (value.issued_at >= value.expires_at) throw new Error('passport time window')
+  assertHex(value.nonce, 32, 'nonce')
+  assertPlainRecord(value.self_asserted, 'self_asserted')
+  assertExactKeys(value.self_asserted, ['capabilities'], ['display_name'], 'self_asserted')
+  if (!Array.isArray(value.self_asserted.capabilities)) throw new Error('capabilities')
+  assertSortedUnique(value.self_asserted.capabilities, 'capabilities')
+  if (value.self_asserted.display_name !== undefined && typeof value.self_asserted.display_name !== 'string') {
+    throw new Error('display_name')
+  }
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+function omit(value: object, keys: readonly string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) if (!keys.includes(key)) result[key] = entry
+  return result
+}
+
+function invalid(code: string): IdentityVerificationResult {
+  return { state: 'invalid', code, proof_of_possession: false, key_authority: 'rejected' }
+}

--- a/src/v2/identity-binding/principal-binding.ts
+++ b/src/v2/identity-binding/principal-binding.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import type {
+  HistoricalKeyResolver,
+  IdentityVerificationResult,
+  PrincipalBindingV1,
+  PrincipalClaimLevel,
+} from './types.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertSortedUnique,
+  assertUtcMilliseconds,
+  sortedUnique,
+} from './validation.js'
+
+const ID_DOMAIN = 'APS-PRINCIPAL-BINDING-ID-V1\0'
+const SIGNATURE_DOMAIN = 'APS-PRINCIPAL-BINDING-SIG-V1\0'
+
+export interface IssuePrincipalBindingV1Input {
+  agent_id: string
+  principal_id: string
+  verification_method: string
+  audiences: readonly string[]
+  authority_profiles: readonly string[]
+  status_uri: string
+  issued_at: string
+  expires_at: string
+  nonce: string
+  principal_private_key_hex: string
+}
+
+export function issuePrincipalBindingV1(input: IssuePrincipalBindingV1Input): PrincipalBindingV1 {
+  const draft: Omit<PrincipalBindingV1, 'binding_id' | 'signature'> = {
+    record_type: 'aps.principal-binding',
+    version: '1.0',
+    agent_id: input.agent_id,
+    principal_id: input.principal_id,
+    verification_method: input.verification_method,
+    audiences: sortedUnique(input.audiences, 'audiences'),
+    authority_profiles: sortedUnique(input.authority_profiles, 'authority_profiles'),
+    status_uri: input.status_uri,
+    issued_at: input.issued_at,
+    expires_at: input.expires_at,
+    nonce: input.nonce,
+  }
+  validateBindingDraft(draft)
+  const bindingId = digest(ID_DOMAIN + canonicalizeJCS(draft))
+  const withId: Omit<PrincipalBindingV1, 'signature'> = { ...draft, binding_id: bindingId }
+  return {
+    ...withId,
+    signature: sign(SIGNATURE_DOMAIN + canonicalizeJCS(withId), input.principal_private_key_hex),
+  }
+}
+
+export async function verifyPrincipalBindingV1(
+  candidate: unknown,
+  options: {
+    now?: string
+    resolve_key: HistoricalKeyResolver
+    principal_is_externally_verified?: (principalId: string, at: string) => boolean | Promise<boolean>
+  },
+): Promise<IdentityVerificationResult> {
+  let binding: PrincipalBindingV1
+  try {
+    binding = validateBinding(candidate)
+  } catch {
+    return invalid('PRINCIPAL_BINDING_MALFORMED')
+  }
+  const idForm = omit(binding, ['binding_id', 'signature'])
+  if (digest(ID_DOMAIN + canonicalizeJCS(idForm)) !== binding.binding_id) {
+    return invalid('PRINCIPAL_BINDING_ID_MISMATCH')
+  }
+  const now = options.now ?? new Date().toISOString()
+  if (now < binding.issued_at || now >= binding.expires_at) {
+    return invalid('PRINCIPAL_BINDING_NOT_CURRENT')
+  }
+  const resolution = await options.resolve_key({
+    controller: binding.principal_id,
+    verification_method: binding.verification_method,
+    at: binding.issued_at,
+  })
+  if (resolution.state !== 'resolved' || !resolution.public_key_hex) {
+    const indeterminate = resolution.state === 'unreachable'
+    return {
+      state: indeterminate ? 'indeterminate' : 'invalid',
+      code: `PRINCIPAL_BINDING_KEY_${resolution.state.toUpperCase()}`,
+      proof_of_possession: false,
+      key_authority: indeterminate ? 'unresolved' : 'rejected',
+    }
+  }
+  const signatureForm = omit(binding, ['signature'])
+  if (!verify(
+    SIGNATURE_DOMAIN + canonicalizeJCS(signatureForm),
+    binding.signature,
+    resolution.public_key_hex,
+  )) {
+    return invalid('PRINCIPAL_BINDING_SIGNATURE_INVALID')
+  }
+  let claimLevel: PrincipalClaimLevel = 'principal_attested'
+  if (options.principal_is_externally_verified &&
+      await options.principal_is_externally_verified(binding.principal_id, binding.issued_at)) {
+    claimLevel = 'externally_verified_principal'
+  }
+  return {
+    state: 'valid',
+    code: 'OK',
+    proof_of_possession: true,
+    key_authority: 'verified',
+    principal_claim_level: claimLevel,
+  }
+}
+
+function validateBinding(value: unknown): PrincipalBindingV1 {
+  assertPlainRecord(value, 'principal binding')
+  assertExactKeys(value, [
+    'record_type', 'version', 'binding_id', 'agent_id', 'principal_id',
+    'verification_method', 'audiences', 'authority_profiles', 'status_uri',
+    'issued_at', 'expires_at', 'nonce', 'signature',
+  ], [], 'principal binding')
+  validateBindingDraft(value as unknown as Omit<PrincipalBindingV1, 'binding_id' | 'signature'>)
+  assertHex(String(value.binding_id), 64, 'binding_id')
+  assertHex(String(value.signature), 128, 'signature')
+  return value as unknown as PrincipalBindingV1
+}
+
+function validateBindingDraft(value: Omit<PrincipalBindingV1, 'binding_id' | 'signature'>): void {
+  assertIJson(value)
+  if (value.record_type !== 'aps.principal-binding' || value.version !== '1.0') throw new Error('profile')
+  if (!/^did:[a-z0-9]+:.+$/.test(value.agent_id)) throw new Error('agent_id')
+  if (!/^did:[a-z0-9]+:.+$/.test(value.principal_id) && !/^https:\/\//.test(value.principal_id)) {
+    throw new Error('principal_id')
+  }
+  if (!value.verification_method.startsWith(`${value.principal_id}#`)) throw new Error('verification_method')
+  if (!Array.isArray(value.audiences) || value.audiences.length === 0) throw new Error('audiences')
+  if (!Array.isArray(value.authority_profiles) || value.authority_profiles.length === 0) throw new Error('authority_profiles')
+  assertSortedUnique(value.audiences, 'audiences')
+  assertSortedUnique(value.authority_profiles, 'authority_profiles')
+  if (!/^https:\/\//.test(value.status_uri)) throw new Error('status_uri')
+  assertUtcMilliseconds(value.issued_at, 'issued_at')
+  assertUtcMilliseconds(value.expires_at, 'expires_at')
+  if (value.issued_at >= value.expires_at) throw new Error('binding time window')
+  assertHex(value.nonce, 32, 'nonce')
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+function omit(value: object, keys: readonly string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) if (!keys.includes(key)) result[key] = entry
+  return result
+}
+
+function invalid(code: string): IdentityVerificationResult {
+  return { state: 'invalid', code, proof_of_possession: false, key_authority: 'rejected' }
+}

--- a/src/v2/identity-binding/revocation.ts
+++ b/src/v2/identity-binding/revocation.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { sign, verify } from '../../crypto/keys.js'
+import type {
+  HistoricalKeyResolver,
+  IdentityVerificationResult,
+  PrincipalBindingRevocationV1,
+} from './types.js'
+import {
+  assertExactKeys,
+  assertHex,
+  assertIJson,
+  assertPlainRecord,
+  assertUtcMilliseconds,
+} from './validation.js'
+
+const ID_DOMAIN = 'APS-PRINCIPAL-BINDING-REVOCATION-ID-V1\0'
+const SIGNATURE_DOMAIN = 'APS-PRINCIPAL-BINDING-REVOCATION-SIG-V1\0'
+
+export function issuePrincipalBindingRevocationV1(input: {
+  binding_id: string
+  principal_id: string
+  verification_method: string
+  revoked_at: string
+  reason_code: string
+  nonce: string
+  principal_private_key_hex: string
+}): PrincipalBindingRevocationV1 {
+  const draft: Omit<PrincipalBindingRevocationV1, 'revocation_id' | 'signature'> = {
+    record_type: 'aps.principal-binding-revocation',
+    version: '1.0',
+    binding_id: input.binding_id,
+    principal_id: input.principal_id,
+    verification_method: input.verification_method,
+    revoked_at: input.revoked_at,
+    reason_code: input.reason_code,
+    nonce: input.nonce,
+  }
+  validateRevocationDraft(draft)
+  const revocationId = digest(ID_DOMAIN + canonicalizeJCS(draft))
+  const withId: Omit<PrincipalBindingRevocationV1, 'signature'> = {
+    ...draft,
+    revocation_id: revocationId,
+  }
+  return {
+    ...withId,
+    signature: sign(SIGNATURE_DOMAIN + canonicalizeJCS(withId), input.principal_private_key_hex),
+  }
+}
+
+export async function verifyPrincipalBindingRevocationV1(
+  candidate: unknown,
+  resolveKey: HistoricalKeyResolver,
+): Promise<IdentityVerificationResult> {
+  let revocation: PrincipalBindingRevocationV1
+  try {
+    revocation = validateRevocation(candidate)
+  } catch {
+    return invalid('PRINCIPAL_BINDING_REVOCATION_MALFORMED')
+  }
+  const idForm = omit(revocation, ['revocation_id', 'signature'])
+  if (digest(ID_DOMAIN + canonicalizeJCS(idForm)) !== revocation.revocation_id) {
+    return invalid('PRINCIPAL_BINDING_REVOCATION_ID_MISMATCH')
+  }
+  const resolution = await resolveKey({
+    controller: revocation.principal_id,
+    verification_method: revocation.verification_method,
+    at: revocation.revoked_at,
+  })
+  if (resolution.state !== 'resolved' || !resolution.public_key_hex) {
+    return {
+      state: resolution.state === 'unreachable' ? 'indeterminate' : 'invalid',
+      code: `PRINCIPAL_BINDING_REVOCATION_KEY_${resolution.state.toUpperCase()}`,
+      proof_of_possession: false,
+      key_authority: resolution.state === 'unreachable' ? 'unresolved' : 'rejected',
+    }
+  }
+  const signatureForm = omit(revocation, ['signature'])
+  if (!verify(
+    SIGNATURE_DOMAIN + canonicalizeJCS(signatureForm),
+    revocation.signature,
+    resolution.public_key_hex,
+  )) return invalid('PRINCIPAL_BINDING_REVOCATION_SIGNATURE_INVALID')
+
+  return { state: 'valid', code: 'OK', proof_of_possession: true, key_authority: 'verified' }
+}
+
+function validateRevocation(value: unknown): PrincipalBindingRevocationV1 {
+  assertPlainRecord(value, 'binding revocation')
+  assertExactKeys(value, [
+    'record_type', 'version', 'revocation_id', 'binding_id', 'principal_id',
+    'verification_method', 'revoked_at', 'reason_code', 'nonce', 'signature',
+  ], [], 'binding revocation')
+  validateRevocationDraft(value as unknown as Omit<PrincipalBindingRevocationV1, 'revocation_id' | 'signature'>)
+  assertHex(String(value.revocation_id), 64, 'revocation_id')
+  assertHex(String(value.signature), 128, 'signature')
+  return value as unknown as PrincipalBindingRevocationV1
+}
+
+function validateRevocationDraft(value: Omit<PrincipalBindingRevocationV1, 'revocation_id' | 'signature'>): void {
+  assertIJson(value)
+  if (value.record_type !== 'aps.principal-binding-revocation' || value.version !== '1.0') throw new Error('profile')
+  assertHex(value.binding_id, 64, 'binding_id')
+  if (!value.verification_method.startsWith(`${value.principal_id}#`)) throw new Error('verification_method')
+  assertUtcMilliseconds(value.revoked_at, 'revoked_at')
+  if (!/^[a-z][a-z0-9_.-]{0,63}$/.test(value.reason_code)) throw new Error('reason_code')
+  assertHex(value.nonce, 32, 'nonce')
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex')
+}
+
+function omit(value: object, keys: readonly string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) if (!keys.includes(key)) result[key] = entry
+  return result
+}
+
+function invalid(code: string): IdentityVerificationResult {
+  return { state: 'invalid', code, proof_of_possession: false, key_authority: 'rejected' }
+}

--- a/src/v2/identity-binding/types.ts
+++ b/src/v2/identity-binding/types.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+export type Hex32 = string
+export type Hex64 = string
+export type Hex128 = string
+
+export interface PassportSelfAssertionsV2 {
+  display_name?: string
+  capabilities: string[]
+}
+
+/**
+ * A cryptographic agent identity record. Principal authority is deliberately
+ * absent; it is carried by PrincipalBindingV1 instead of being self-asserted
+ * inside the passport.
+ */
+export interface PassportV2 {
+  record_type: 'aps.agent-passport'
+  version: '2.0'
+  passport_id: Hex64
+  agent_id: string
+  verification_method: string
+  public_key_multibase: string
+  issued_at: string
+  expires_at: string
+  nonce: Hex32
+  self_asserted: PassportSelfAssertionsV2
+  signature: Hex128
+}
+
+export interface PrincipalBindingV1 {
+  record_type: 'aps.principal-binding'
+  version: '1.0'
+  binding_id: Hex64
+  agent_id: string
+  principal_id: string
+  verification_method: string
+  audiences: string[]
+  authority_profiles: string[]
+  status_uri: string
+  issued_at: string
+  expires_at: string
+  nonce: Hex32
+  signature: Hex128
+}
+
+export interface PrincipalBindingRevocationV1 {
+  record_type: 'aps.principal-binding-revocation'
+  version: '1.0'
+  revocation_id: Hex64
+  binding_id: Hex64
+  principal_id: string
+  verification_method: string
+  revoked_at: string
+  reason_code: string
+  nonce: Hex32
+  signature: Hex128
+}
+
+export type PrincipalClaimLevel =
+  | 'self_asserted'
+  | 'principal_attested'
+  | 'externally_verified_principal'
+
+export type IdentityVerificationState =
+  | 'valid'
+  | 'invalid'
+  | 'indeterminate'
+  | 'unsupported'
+
+export interface IdentityVerificationResult {
+  state: IdentityVerificationState
+  code: string
+  proof_of_possession: boolean
+  key_authority: 'verified' | 'unresolved' | 'rejected'
+  principal_claim_level?: PrincipalClaimLevel
+}
+
+export interface HistoricalKeyResolutionRequest {
+  controller: string
+  verification_method: string
+  at: string
+}
+
+export interface HistoricalKeyResolutionResult {
+  state: 'resolved' | 'not_found' | 'ambiguous' | 'malformed' | 'unreachable' | 'unsupported'
+  public_key_hex?: string
+}
+
+export type HistoricalKeyResolver = (
+  request: HistoricalKeyResolutionRequest,
+) => HistoricalKeyResolutionResult | Promise<HistoricalKeyResolutionResult>

--- a/src/v2/identity-binding/validation.ts
+++ b/src/v2/identity-binding/validation.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+const UTC_MILLISECONDS = /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}Z$/
+
+export function assertPlainRecord(value: unknown, name: string): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name}: expected object`)
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${name}: non-JSON object`)
+  }
+}
+
+export function assertExactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+  name = 'object',
+): void {
+  const allowed = new Set([...required, ...optional])
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) throw new Error(`${name}: missing ${key}`)
+  }
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${name}: unknown field ${key}`)
+  }
+}
+
+export function assertIJson(value: unknown, path = '$', ancestors = new WeakSet<object>()): void {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    if (typeof value === 'string') assertUnicodeScalarString(value, path)
+    return
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || (Number.isInteger(value) && !Number.isSafeInteger(value))) {
+      throw new Error(`${path}: non-I-JSON number`)
+    }
+    return
+  }
+  if (typeof value !== 'object' || value === undefined || value instanceof Date) {
+    throw new Error(`${path}: unsupported I-JSON value`)
+  }
+  if (ancestors.has(value)) throw new Error(`${path}: cyclic value`)
+  ancestors.add(value)
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertIJson(entry, `${path}[${index}]`, ancestors))
+  } else {
+    assertPlainRecord(value, path)
+    for (const [key, entry] of Object.entries(value)) {
+      assertUnicodeScalarString(key, `${path} key`)
+      if (entry === undefined) throw new Error(`${path}.${key}: undefined is not I-JSON`)
+      assertIJson(entry, `${path}.${key}`, ancestors)
+    }
+  }
+  ancestors.delete(value)
+}
+
+export function assertUnicodeScalarString(value: string, path: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index)
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (next < 0xdc00 || next > 0xdfff) throw new Error(`${path}: lone surrogate`)
+      index++
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new Error(`${path}: lone surrogate`)
+    }
+  }
+}
+
+export function assertUtcMilliseconds(value: string, name: string): void {
+  if (!UTC_MILLISECONDS.test(value)) throw new Error(`${name}: expected canonical UTC milliseconds`)
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(`${name}: invalid calendar timestamp`)
+  }
+}
+
+export function assertHex(value: string, length: number, name: string): void {
+  if (!new RegExp(`^[0-9a-f]{${length}}$`).test(value)) {
+    throw new Error(`${name}: expected ${length} lowercase hexadecimal characters`)
+  }
+}
+
+export function assertSortedUnique(values: string[], name: string): void {
+  for (const value of values) {
+    if (typeof value !== 'string' || value.length === 0) throw new Error(`${name}: empty or non-string value`)
+    assertUnicodeScalarString(value, name)
+  }
+  for (let index = 1; index < values.length; index++) {
+    if (compareUtf8(values[index - 1], values[index]) >= 0) {
+      throw new Error(`${name}: values must be sorted and unique by UTF-8 bytes`)
+    }
+  }
+}
+
+export function sortedUnique(values: readonly string[], name: string): string[] {
+  const result = [...values]
+  result.sort(compareUtf8)
+  assertSortedUnique(result, name)
+  return result
+}
+
+function compareUtf8(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'))
+}

--- a/src/v2/receipt-core/decision-ref.ts
+++ b/src/v2/receipt-core/decision-ref.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { strictJCS, assertExactKeys } from './jcs.js'
+import type { CoreDecisionOutputV1, DecisionRefInputV1, JsonValue } from './types.js'
+
+export const DECISION_REF_TAG = 'APS-DECISION-REF-V1' as const
+export const DECISION_COMPONENT_TAGS = {
+  authority: 'APS-DECISION-AUTHORITY-V1',
+  policy: 'APS-DECISION-POLICY-V1',
+  context: 'APS-DECISION-CONTEXT-V1',
+  output: 'APS-DECISION-OUTPUT-V1',
+} as const
+
+const HEX64 = /^[0-9a-f]{64}$/
+const tagged = (tag: string, canonical: string): string => `${tag}\0${canonical}`
+const sha256Hex = (value: string): string => createHash('sha256').update(value, 'utf8').digest('hex')
+
+export function computeDecisionComponentRefV1(tag: keyof typeof DECISION_COMPONENT_TAGS, value: JsonValue): string {
+  return sha256Hex(tagged(DECISION_COMPONENT_TAGS[tag], strictJCS(value)))
+}
+
+export function validateDecisionRefInputV1(input: DecisionRefInputV1): void {
+  assertExactKeys(input as unknown as Record<string, unknown>,
+    ['profile', 'action_ref', 'authority_state_ref', 'policy_ref', 'context_ref', 'decision_output_ref'],
+    ['profile', 'action_ref', 'authority_state_ref', 'policy_ref', 'context_ref', 'decision_output_ref'],
+    'DecisionRefInputV1')
+  if (input.profile !== 'aps-decision-ref-v1') throw new TypeError('DecisionRefInputV1: profile')
+  for (const [key, value] of Object.entries(input)) {
+    if (key !== 'profile' && (typeof value !== 'string' || !HEX64.test(value))) {
+      throw new TypeError(`DecisionRefInputV1: ${key} must be lowercase sha256 hex`)
+    }
+  }
+}
+
+export function computeDecisionRefV1(input: DecisionRefInputV1): string {
+  validateDecisionRefInputV1(input)
+  return sha256Hex(tagged(DECISION_REF_TAG, strictJCS(input)))
+}
+
+export function normalizeCoreDecisionOutputV1(input: CoreDecisionOutputV1): CoreDecisionOutputV1 {
+  assertExactKeys(input as unknown as Record<string, unknown>,
+    ['profile', 'verdict', 'effective_authority_ref', 'constraints'],
+    ['profile', 'verdict', 'effective_authority_ref', 'constraints'], 'CoreDecisionOutputV1')
+  strictJCS(input)
+  if (input.profile !== 'aps-core-decision-output-v1') throw new TypeError('CoreDecisionOutputV1: profile')
+  if (!['permit', 'deny', 'narrow'].includes(input.verdict)) throw new TypeError('CoreDecisionOutputV1: verdict')
+  if (input.effective_authority_ref !== null && !HEX64.test(input.effective_authority_ref)) {
+    throw new TypeError('CoreDecisionOutputV1: effective_authority_ref')
+  }
+  if (input.verdict === 'deny' && input.effective_authority_ref !== null) {
+    throw new TypeError('CoreDecisionOutputV1: deny requires null effective_authority_ref')
+  }
+  if (input.verdict !== 'deny' && input.effective_authority_ref === null) {
+    throw new TypeError('CoreDecisionOutputV1: permit/narrow require effective_authority_ref')
+  }
+  if (!Array.isArray(input.constraints) || !input.constraints.every(v => typeof v === 'string')) {
+    throw new TypeError('CoreDecisionOutputV1: constraints')
+  }
+  const constraints = [...new Set(input.constraints.map(v => v.normalize('NFC')))]
+    .sort((a, b) => {
+      const aa = Array.from(a, c => c.codePointAt(0) as number)
+      const bb = Array.from(b, c => c.codePointAt(0) as number)
+      for (let i = 0; i < Math.min(aa.length, bb.length); i++) if (aa[i] !== bb[i]) return aa[i] - bb[i]
+      return aa.length - bb.length
+    })
+  return { ...input, constraints }
+}
+
+export function buildDecisionRefV1(input: {
+  action_ref: string
+  authority_state: JsonValue
+  policy_input: JsonValue
+  decision_context: JsonValue
+  decision_output: JsonValue
+}): { input: DecisionRefInputV1; decision_ref: string } {
+  if (!HEX64.test(input.action_ref)) throw new TypeError('action_ref must be lowercase sha256 hex')
+  const refInput: DecisionRefInputV1 = {
+    profile: 'aps-decision-ref-v1',
+    action_ref: input.action_ref,
+    authority_state_ref: computeDecisionComponentRefV1('authority', input.authority_state),
+    policy_ref: computeDecisionComponentRefV1('policy', input.policy_input),
+    context_ref: computeDecisionComponentRefV1('context', input.decision_context),
+    decision_output_ref: computeDecisionComponentRefV1('output', input.decision_output),
+  }
+  return { input: refInput, decision_ref: computeDecisionRefV1(refInput) }
+}

--- a/src/v2/receipt-core/jcs.ts
+++ b/src/v2/receipt-core/jcs.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import type { JsonValue } from './types.js'
+
+export class IJsonValidationError extends TypeError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IJsonValidationError'
+  }
+}
+
+function assertUnicodeScalarString(value: string, path: string): void {
+  for (let i = 0; i < value.length; i++) {
+    const unit = value.charCodeAt(i)
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : -1
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        i++
+        continue
+      }
+      throw new IJsonValidationError(`${path}: unpaired high surrogate`)
+    }
+    if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new IJsonValidationError(`${path}: unpaired low surrogate`)
+    }
+  }
+}
+
+/** Validate the in-memory new-write input before RFC 8785 processing.
+ *  No coercion is performed. In particular, undefined is not converted to null
+ *  and Date is not converted to a string. */
+export function assertIJson(value: unknown, path = '$', ancestors = new WeakSet<object>()): asserts value is JsonValue {
+  if (value === null || typeof value === 'boolean') return
+  if (typeof value === 'string') {
+    assertUnicodeScalarString(value, path)
+    return
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new IJsonValidationError(`${path}: non-finite number`)
+    if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+      throw new IJsonValidationError(`${path}: integer exceeds the interoperable IEEE 754 range`)
+    }
+    return
+  }
+  if (typeof value !== 'object') {
+    throw new IJsonValidationError(`${path}: unsupported ${typeof value}`)
+  }
+  if (value instanceof Date) throw new IJsonValidationError(`${path}: Date must be converted explicitly`)
+  if (ancestors.has(value)) throw new IJsonValidationError(`${path}: cyclic value`)
+  ancestors.add(value)
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => assertIJson(item, `${path}[${i}]`, ancestors))
+  } else {
+    const proto = Object.getPrototypeOf(value)
+    if (proto !== Object.prototype && proto !== null) {
+      throw new IJsonValidationError(`${path}: non-plain object`)
+    }
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      assertUnicodeScalarString(key, `${path} key`)
+      assertIJson(item, `${path}.${key}`, ancestors)
+    }
+  }
+  ancestors.delete(value)
+}
+
+export function strictJCS(value: unknown): string {
+  assertIJson(value)
+  return canonicalizeJCS(value)
+}
+
+/** Parse bounded raw JSON without losing duplicate object names.
+ *  Duplicate comparison is performed after JSON string decoding, so aliases
+ *  such as "a" and "\u0061" are the same member name and are rejected. */
+export function parseStrictIJson(raw: string, maxUtf8Bytes = 1_048_576, maxDepth = 128): JsonValue {
+  if (typeof raw !== 'string') throw new IJsonValidationError('$: raw JSON string required')
+  if (!Number.isSafeInteger(maxUtf8Bytes) || maxUtf8Bytes < 1 || Buffer.byteLength(raw, 'utf8') > maxUtf8Bytes) {
+    throw new IJsonValidationError('$: raw JSON size limit exceeded')
+  }
+  if (!Number.isSafeInteger(maxDepth) || maxDepth < 1) throw new IJsonValidationError('$: invalid depth limit')
+  let offset = 0
+  const skipWhitespace = (): void => { while (offset < raw.length && /[\x20\t\r\n]/.test(raw[offset])) offset++ }
+  const parseString = (): string => {
+    const start = offset++
+    let escaped = false
+    while (offset < raw.length) {
+      const code = raw.charCodeAt(offset)
+      if (!escaped && code === 0x22) {
+        offset++
+        let decoded: unknown
+        try { decoded = JSON.parse(raw.slice(start, offset)) } catch { throw new IJsonValidationError('$: invalid JSON string') }
+        assertIJson(decoded)
+        return decoded as string
+      }
+      if (!escaped && code < 0x20) throw new IJsonValidationError('$: unescaped control character')
+      if (!escaped && code === 0x5c) escaped = true
+      else escaped = false
+      offset++
+    }
+    throw new IJsonValidationError('$: unterminated JSON string')
+  }
+  const parseValue = (depth: number): JsonValue => {
+    if (depth > maxDepth) throw new IJsonValidationError('$: JSON nesting limit exceeded')
+    skipWhitespace()
+    const token = raw[offset]
+    if (token === '"') return parseString()
+    if (token === '{') {
+      offset++
+      const value: { [key: string]: JsonValue } = Object.create(null)
+      const names = new Set<string>()
+      skipWhitespace()
+      if (raw[offset] === '}') { offset++; return value }
+      while (true) {
+        skipWhitespace()
+        if (raw[offset] !== '"') throw new IJsonValidationError('$: object member name required')
+        const name = parseString()
+        if (names.has(name)) throw new IJsonValidationError('$: duplicate object member')
+        names.add(name)
+        skipWhitespace()
+        if (raw[offset++] !== ':') throw new IJsonValidationError('$: colon required')
+        value[name] = parseValue(depth + 1)
+        skipWhitespace()
+        const separator = raw[offset++]
+        if (separator === '}') return value
+        if (separator !== ',') throw new IJsonValidationError('$: comma or object end required')
+      }
+    }
+    if (token === '[') {
+      offset++
+      const value: JsonValue[] = []
+      skipWhitespace()
+      if (raw[offset] === ']') { offset++; return value }
+      while (true) {
+        value.push(parseValue(depth + 1))
+        skipWhitespace()
+        const separator = raw[offset++]
+        if (separator === ']') return value
+        if (separator !== ',') throw new IJsonValidationError('$: comma or array end required')
+      }
+    }
+    for (const [literal, value] of [['true', true], ['false', false], ['null', null]] as const) {
+      if (raw.startsWith(literal, offset)) { offset += literal.length; return value }
+    }
+    const number = raw.slice(offset).match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/)
+    if (!number) throw new IJsonValidationError('$: JSON value required')
+    offset += number[0].length
+    const value: unknown = JSON.parse(number[0])
+    assertIJson(value)
+    return value as number
+  }
+  const value = parseValue(1)
+  skipWhitespace()
+  if (offset !== raw.length) throw new IJsonValidationError('$: trailing JSON data')
+  assertIJson(value)
+  return value
+}
+
+export function assertExactKeys(value: Record<string, unknown>, allowed: readonly string[], required: readonly string[], name: string): void {
+  const allow = new Set(allowed)
+  for (const key of Object.keys(value)) {
+    if (!allow.has(key)) throw new IJsonValidationError(`${name}: unknown field ${key}`)
+  }
+  for (const key of required) {
+    if (!(key in value)) throw new IJsonValidationError(`${name}: missing field ${key}`)
+  }
+}

--- a/src/v2/receipt-core/receipt.ts
+++ b/src/v2/receipt-core/receipt.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { sign, verify } from '../../crypto/keys.js'
+import { assertExactKeys, strictJCS } from './jcs.js'
+import type { EvidenceRefV1, ReceiptSignatureV1, ReceiptSignerV1, ReceiptV1 } from './types.js'
+
+export const RECEIPT_ID_TAG = 'APS-RECEIPT-ID-V1' as const
+export const RECEIPT_SIG_TAG = 'APS-RECEIPT-SIG-V1' as const
+const HEX64 = /^[0-9a-f]{64}$/
+const HEX128 = /^[0-9a-f]{128}$/
+const UTC_MS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf8').digest('hex')
+const compareUtf8 = (a: string, b: string): number => Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))
+
+function compareEvidence(a: EvidenceRefV1, b: EvidenceRefV1): number {
+  return compareUtf8(a.artifact_type, b.artifact_type) || compareUtf8(a.sha256, b.sha256)
+}
+
+function compareSignatures(a: Pick<ReceiptSignatureV1, 'signer' | 'key_id'>, b: Pick<ReceiptSignatureV1, 'signer' | 'key_id'>): number {
+  return compareUtf8(a.signer, b.signer) || compareUtf8(a.key_id, b.key_id)
+}
+
+function isExactUtcMilliseconds(value: string): boolean {
+  if (!UTC_MS.test(value)) return false
+  const parsed = new Date(value)
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString() === value
+}
+
+function receiptWithout<T extends 'receipt_id' | 'signatures'>(receipt: ReceiptV1, ...keys: T[]): Omit<ReceiptV1, T> {
+  const copy = { ...receipt } as Record<string, unknown>
+  keys.forEach(k => delete copy[k])
+  return copy as Omit<ReceiptV1, T>
+}
+
+export function receiptIdPayloadV1(receipt: ReceiptV1): string {
+  return `${RECEIPT_ID_TAG}\0${strictJCS(receiptWithout(receipt, 'receipt_id', 'signatures'))}`
+}
+
+export function computeReceiptIdV1(receipt: ReceiptV1): string {
+  return sha256Hex(receiptIdPayloadV1(receipt))
+}
+
+export function receiptSignaturePayloadV1(receipt: ReceiptV1, descriptor: Omit<ReceiptSignatureV1, 'value'>): string {
+  const form = { receipt: receiptWithout(receipt, 'signatures'), signer: descriptor }
+  return `${RECEIPT_SIG_TAG}\0${strictJCS(form)}`
+}
+
+export function validateReceiptV1(receipt: ReceiptV1, requireValues = true): void {
+  assertExactKeys(receipt as unknown as Record<string, unknown>,
+    ['profile', 'receipt_id', 'receipt_type', 'issuer', 'subject_agent', 'action_ref', 'delegation_ref', 'decision_ref', 'issued_at', 'evidence_refs', 'result', 'prev', 'signatures'],
+    ['profile', 'receipt_id', 'receipt_type', 'issuer', 'subject_agent', 'action_ref', 'delegation_ref', 'issued_at', 'evidence_refs', 'result', 'signatures'], 'ReceiptV1')
+  strictJCS(receipt)
+  if (receipt.profile !== 'aps-receipt-v1') throw new TypeError('ReceiptV1: profile')
+  if (!receipt.receipt_type || !receipt.issuer || !receipt.subject_agent || !receipt.delegation_ref) throw new TypeError('ReceiptV1: empty identifier')
+  if (requireValues && !HEX64.test(receipt.receipt_id)) throw new TypeError('ReceiptV1: receipt_id')
+  if (!HEX64.test(receipt.action_ref)) throw new TypeError('ReceiptV1: action_ref')
+  if (receipt.decision_ref !== undefined && !HEX64.test(receipt.decision_ref)) throw new TypeError('ReceiptV1: decision_ref')
+  if (receipt.prev !== undefined && !HEX64.test(receipt.prev)) throw new TypeError('ReceiptV1: prev')
+  if (!isExactUtcMilliseconds(receipt.issued_at)) throw new TypeError('ReceiptV1: issued_at')
+  if (typeof receipt.result !== 'object' || receipt.result === null || Array.isArray(receipt.result)) throw new TypeError('ReceiptV1: result')
+  if (!Array.isArray(receipt.evidence_refs) || !Array.isArray(receipt.signatures)) throw new TypeError('ReceiptV1: arrays')
+  const seenEvidence = new Set<string>()
+  receipt.evidence_refs.forEach((ref, i) => {
+    assertExactKeys(ref as unknown as Record<string, unknown>, ['artifact_type', 'sha256'], ['artifact_type', 'sha256'], 'EvidenceRefV1')
+    if (!ref.artifact_type || !HEX64.test(ref.sha256)) throw new TypeError('EvidenceRefV1: value')
+    const key = `${ref.artifact_type}\0${ref.sha256}`
+    if (seenEvidence.has(key)) throw new TypeError('ReceiptV1: duplicate evidence_ref')
+    seenEvidence.add(key)
+    if (i > 0 && compareEvidence(receipt.evidence_refs[i - 1], ref) >= 0) throw new TypeError('ReceiptV1: evidence_refs not sorted')
+  })
+  const seenSigs = new Set<string>()
+  receipt.signatures.forEach((proof, i) => {
+    assertExactKeys(proof as unknown as Record<string, unknown>, ['signer', 'key_id', 'alg', 'value'], ['signer', 'key_id', 'alg', 'value'], 'ReceiptSignatureV1')
+    if (!proof.signer || !proof.key_id || proof.alg !== 'Ed25519' || (requireValues && !HEX128.test(proof.value))) throw new TypeError('ReceiptSignatureV1: value')
+    const key = `${proof.signer}\0${proof.key_id}`
+    if (seenSigs.has(key)) throw new TypeError('ReceiptV1: duplicate signature')
+    seenSigs.add(key)
+    if (i > 0 && compareSignatures(receipt.signatures[i - 1], proof) >= 0) throw new TypeError('ReceiptV1: signatures not sorted')
+  })
+  if (requireValues && !receipt.signatures.some(s => s.signer === receipt.issuer)) throw new TypeError('ReceiptV1: issuer signature missing')
+}
+
+export function createReceiptV1(
+  fields: Omit<ReceiptV1, 'receipt_id' | 'signatures'>,
+  signers: ReceiptSignerV1[],
+): ReceiptV1 {
+  if (signers.length === 0) throw new TypeError('ReceiptV1: at least one signer')
+  const copiedFields = structuredClone(fields)
+  const evidence_refs = [...copiedFields.evidence_refs].sort(compareEvidence)
+  const descriptors = signers.map(s => ({ signer: s.signer, key_id: s.key_id, alg: 'Ed25519' as const, private_key: s.private_key }))
+    .sort(compareSignatures)
+  const draft = { ...copiedFields, evidence_refs, receipt_id: '0'.repeat(64), signatures: [] } as ReceiptV1
+  validateReceiptV1(draft, false)
+  draft.receipt_id = computeReceiptIdV1(draft)
+  draft.signatures = descriptors.map(({ private_key, ...descriptor }) => ({
+    ...descriptor,
+    value: sign(receiptSignaturePayloadV1(draft, descriptor), private_key),
+  }))
+  validateReceiptV1(draft)
+  return draft
+}
+
+export interface ReceiptVerificationV1 {
+  valid: boolean
+  receipt_id_valid: boolean
+  signature_results: { signer: string; key_id: string; valid: boolean; reason?: string }[]
+  errors: string[]
+}
+
+export function verifyReceiptV1(receipt: ReceiptV1, resolveKey: (signer: string, keyId: string, issuedAt: string) => string | undefined): ReceiptVerificationV1 {
+  const errors: string[] = []
+  try { validateReceiptV1(receipt) } catch (err) {
+    return { valid: false, receipt_id_valid: false, signature_results: [], errors: [err instanceof Error ? err.message : String(err)] }
+  }
+  const receipt_id_valid = computeReceiptIdV1(receipt) === receipt.receipt_id
+  if (!receipt_id_valid) errors.push('receipt_id_mismatch')
+  const signature_results = receipt.signatures.map(proof => {
+    try {
+      const key = resolveKey(proof.signer, proof.key_id, receipt.issued_at)
+      if (!key) return { signer: proof.signer, key_id: proof.key_id, valid: false, reason: 'key_unresolved' }
+      const { value, ...descriptor } = proof
+      return { signer: proof.signer, key_id: proof.key_id, valid: verify(receiptSignaturePayloadV1(receipt, descriptor), value, key) }
+    } catch {
+      return { signer: proof.signer, key_id: proof.key_id, valid: false, reason: 'key_resolution_error' }
+    }
+  })
+  if (signature_results.some(r => !r.valid)) errors.push('signature_invalid')
+  return { valid: errors.length === 0, receipt_id_valid, signature_results, errors }
+}

--- a/src/v2/receipt-core/supporting-record.ts
+++ b/src/v2/receipt-core/supporting-record.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { sign, verify } from '../../crypto/keys.js'
+import { canonicalize } from '../../core/canonical.js'
+import { assertExactKeys, strictJCS } from './jcs.js'
+import type { EvidenceBundleBodyV2, EvidenceBundleMemberInputV2, EvidenceBundleMemberV2, EvidenceBundleProofStepV2, EvidenceBundleProofV2, JsonValue, SupportingRecordV1 } from './types.js'
+
+export const SUPPORTING_RECORD_ID_TAG = 'APS-SUPPORTING-RECORD-ID-V1' as const
+export const SUPPORTING_RECORD_SIG_TAG = 'APS-SUPPORTING-RECORD-SIG-V1' as const
+const HEX64 = /^[0-9a-f]{64}$/
+const HEX128 = /^[0-9a-f]{128}$/
+const UTC_MS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+const sha256 = (value: string | Buffer): Buffer => createHash('sha256').update(value).digest()
+const sha256Hex = (value: string | Buffer): string => sha256(value).toString('hex')
+const isExactUtcMilliseconds = (value: string): boolean => {
+  if (!UTC_MS.test(value)) return false
+  const parsed = new Date(value)
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString() === value
+}
+
+function without(record: SupportingRecordV1, ...keys: ('record_id' | 'sig')[]): Record<string, JsonValue> {
+  const copy = { ...record } as unknown as Record<string, JsonValue>
+  keys.forEach(key => delete copy[key])
+  return copy
+}
+
+export function supportingRecordIdPayloadV1(record: SupportingRecordV1): string {
+  return `${SUPPORTING_RECORD_ID_TAG}\0${record.record_type}\0${strictJCS(without(record, 'record_id', 'sig'))}`
+}
+
+export function computeSupportingRecordIdV1(record: SupportingRecordV1): string {
+  return sha256Hex(supportingRecordIdPayloadV1(record))
+}
+
+export function supportingRecordSignaturePayloadV1(record: SupportingRecordV1): string {
+  return `${SUPPORTING_RECORD_SIG_TAG}\0${record.record_type}\0${strictJCS(without(record, 'sig'))}`
+}
+
+export function validateSupportingRecordV1(record: SupportingRecordV1, requireCrypto = true): void {
+  assertExactKeys(record as unknown as Record<string, unknown>,
+    ['profile', 'record_id', 'record_type', 'issuer', 'issuer_key_id', 'issued_at', 'action_ref', 'body', 'sig_alg', 'sig'],
+    ['profile', 'record_id', 'record_type', 'issuer', 'issuer_key_id', 'issued_at', 'body', 'sig_alg', 'sig'], 'SupportingRecordV1')
+  strictJCS(record)
+  if (record.profile !== 'aps-supporting-record-v1') throw new TypeError('SupportingRecordV1: profile')
+  if (!record.record_type || !record.issuer || !record.issuer_key_id) throw new TypeError('SupportingRecordV1: identifier')
+  if (!isExactUtcMilliseconds(record.issued_at)) throw new TypeError('SupportingRecordV1: issued_at')
+  if (record.action_ref !== undefined && !HEX64.test(record.action_ref)) throw new TypeError('SupportingRecordV1: action_ref')
+  if (typeof record.body !== 'object' || record.body === null || Array.isArray(record.body)) throw new TypeError('SupportingRecordV1: body')
+  if (record.sig_alg !== 'Ed25519') throw new TypeError('SupportingRecordV1: sig_alg')
+  if (requireCrypto && (!HEX64.test(record.record_id) || !HEX128.test(record.sig))) throw new TypeError('SupportingRecordV1: crypto encoding')
+}
+
+export function createSupportingRecordV1(
+  fields: Omit<SupportingRecordV1, 'record_id' | 'sig'>,
+  privateKey: string,
+): SupportingRecordV1 {
+  const record = { ...structuredClone(fields), record_id: '0'.repeat(64), sig: '' } as SupportingRecordV1
+  validateSupportingRecordV1(record, false)
+  record.record_id = computeSupportingRecordIdV1(record)
+  record.sig = sign(supportingRecordSignaturePayloadV1(record), privateKey)
+  validateSupportingRecordV1(record)
+  return record
+}
+
+export function verifySupportingRecordV1(record: SupportingRecordV1, publicKey: string): { valid: boolean; id_valid: boolean; signature_valid: boolean } {
+  try { validateSupportingRecordV1(record) } catch { return { valid: false, id_valid: false, signature_valid: false } }
+  const id_valid = computeSupportingRecordIdV1(record) === record.record_id
+  const signature_valid = verify(supportingRecordSignaturePayloadV1(record), record.sig, publicKey)
+  return { valid: id_valid && signature_valid, id_valid, signature_valid }
+}
+
+function validateEvidenceBundleMemberV2(entry: EvidenceBundleMemberV2): void {
+  assertExactKeys(entry as unknown as Record<string, unknown>, ['member_id', 'member_type', 'sha256'], ['member_id', 'member_type', 'sha256'], 'EvidenceBundleMemberV2')
+  if (!entry.member_id || !entry.member_type || !HEX64.test(entry.sha256)) throw new TypeError('EvidenceBundleMemberV2: value')
+}
+
+function entryCanonical(entry: EvidenceBundleMemberV2): string {
+  validateEvidenceBundleMemberV2(entry)
+  return strictJCS(entry)
+}
+
+export function evidenceBundleMerkleRootV2(entries: EvidenceBundleMemberV2[]): string {
+  if (entries.length === 0) throw new TypeError('EvidenceBundleV2: at least one member')
+  const seen = new Set<string>()
+  const canonicalEntries = entries.map((entry, i) => {
+    const canonical = entryCanonical(entry)
+    if (seen.has(entry.member_id)) throw new TypeError('EvidenceBundleV2: duplicate member_id')
+    seen.add(entry.member_id)
+    if (i > 0 && Buffer.compare(Buffer.from(entryCanonical(entries[i - 1]), 'utf8'), Buffer.from(canonical, 'utf8')) >= 0) {
+      throw new TypeError('EvidenceBundleV2: members not sorted')
+    }
+    return canonical
+  })
+  let level = canonicalEntries.map(canonical => sha256(Buffer.concat([Buffer.from([0]), Buffer.from(canonical, 'utf8')])))
+  while (level.length > 1) {
+    const next: Buffer[] = []
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 === level.length) next.push(level[i])
+      else next.push(sha256(Buffer.concat([Buffer.from([1]), level[i], level[i + 1]])))
+    }
+    level = next
+  }
+  return level[0].toString('hex')
+}
+
+export function buildEvidenceBundleBodyV2(members: EvidenceBundleMemberInputV2[]): EvidenceBundleBodyV2 {
+  if (members.length === 0) throw new TypeError('EvidenceBundleV2: at least one member')
+  const seen = new Set<string>()
+  const entries = members.map(member => {
+    assertExactKeys(member as unknown as Record<string, unknown>, ['member_id', 'member_type', 'payload'], ['member_id', 'member_type', 'payload'], 'EvidenceBundleMemberInputV2')
+    if (!member.member_id || !member.member_type) throw new TypeError('EvidenceBundleV2: member identifier')
+    if (seen.has(member.member_id)) throw new TypeError('EvidenceBundleV2: duplicate member_id')
+    seen.add(member.member_id)
+    return { member_id: member.member_id, member_type: member.member_type, sha256: sha256Hex(strictJCS(member.payload)) }
+  }).sort((a, b) => Buffer.compare(Buffer.from(entryCanonical(a)), Buffer.from(entryCanonical(b))))
+  return { members: entries, merkle_root: evidenceBundleMerkleRootV2(entries) }
+}
+
+export function verifyEvidenceBundleBodyV2(body: EvidenceBundleBodyV2, payloads?: Record<string, JsonValue>): boolean {
+  try {
+    assertExactKeys(body as unknown as Record<string, unknown>, ['members', 'merkle_root'], ['members', 'merkle_root'], 'EvidenceBundleBodyV2')
+    if (!Array.isArray(body.members) || body.members.length === 0 || !HEX64.test(body.merkle_root)) return false
+    const seen = new Set<string>()
+    for (let i = 0; i < body.members.length; i++) {
+      const entry = body.members[i]
+      validateEvidenceBundleMemberV2(entry)
+      if (seen.has(entry.member_id)) return false
+      seen.add(entry.member_id)
+      if (i > 0 && Buffer.compare(Buffer.from(entryCanonical(body.members[i - 1])), Buffer.from(entryCanonical(entry))) >= 0) return false
+      if (payloads && (!Object.prototype.hasOwnProperty.call(payloads, entry.member_id) || sha256Hex(strictJCS(payloads[entry.member_id])) !== entry.sha256)) return false
+    }
+    return evidenceBundleMerkleRootV2(body.members) === body.merkle_root
+  } catch { return false }
+}
+
+function evidenceLeaf(entry: EvidenceBundleMemberV2): Buffer {
+  return sha256(Buffer.concat([Buffer.from([0]), Buffer.from(entryCanonical(entry), 'utf8')]))
+}
+
+/** Build an inclusion proof over the already-sorted manifest members.
+ *  Odd nodes are promoted, never duplicated, and the promotion is explicit in
+ *  the proof so a verifier can validate the tree shape from leaf_count. */
+export function buildEvidenceBundleProofV2(entries: EvidenceBundleMemberV2[], memberId: string): EvidenceBundleProofV2 {
+  evidenceBundleMerkleRootV2(entries)
+  const leaf_index = entries.findIndex(entry => entry.member_id === memberId)
+  if (leaf_index < 0) throw new TypeError('EvidenceBundleV2: member not found')
+  let index = leaf_index
+  let level = entries.map(evidenceLeaf)
+  const path: EvidenceBundleProofStepV2[] = []
+  while (level.length > 1) {
+    if (index % 2 === 1) path.push({ position: 'left', sha256: level[index - 1].toString('hex') })
+    else if (index + 1 < level.length) path.push({ position: 'right', sha256: level[index + 1].toString('hex') })
+    else path.push({ position: 'promote' })
+    const next: Buffer[] = []
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 === level.length) next.push(level[i])
+      else next.push(sha256(Buffer.concat([Buffer.from([1]), level[i], level[i + 1]])))
+    }
+    index = Math.floor(index / 2)
+    level = next
+  }
+  return { profile: 'aps-evidence-proof-v2', member: { ...entries[leaf_index] }, leaf_index, leaf_count: entries.length, path }
+}
+
+export function verifyEvidenceBundleProofV2(proof: EvidenceBundleProofV2, trustedRoot: string, payload?: JsonValue): boolean {
+  try {
+    assertExactKeys(proof as unknown as Record<string, unknown>, ['profile', 'member', 'leaf_index', 'leaf_count', 'path'], ['profile', 'member', 'leaf_index', 'leaf_count', 'path'], 'EvidenceBundleProofV2')
+    if (proof.profile !== 'aps-evidence-proof-v2' || !HEX64.test(trustedRoot)) return false
+    validateEvidenceBundleMemberV2(proof.member)
+    if (!Number.isSafeInteger(proof.leaf_index) || !Number.isSafeInteger(proof.leaf_count) || proof.leaf_count < 1 || proof.leaf_index < 0 || proof.leaf_index >= proof.leaf_count || !Array.isArray(proof.path)) return false
+    if (payload !== undefined && sha256Hex(strictJCS(payload)) !== proof.member.sha256) return false
+    let index = proof.leaf_index
+    let width = proof.leaf_count
+    let hash = evidenceLeaf(proof.member)
+    let pathIndex = 0
+    while (width > 1) {
+      const step = proof.path[pathIndex++]
+      if (!step) return false
+      const expected = index % 2 === 1 ? 'left' : index + 1 < width ? 'right' : 'promote'
+      if (step.position !== expected) return false
+      if (step.position === 'promote') {
+        assertExactKeys(step as unknown as Record<string, unknown>, ['position'], ['position'], 'EvidenceBundleProofStepV2')
+      } else {
+        assertExactKeys(step as unknown as Record<string, unknown>, ['position', 'sha256'], ['position', 'sha256'], 'EvidenceBundleProofStepV2')
+        if (!HEX64.test(step.sha256)) return false
+        const sibling = Buffer.from(step.sha256, 'hex')
+        hash = step.position === 'left'
+          ? sha256(Buffer.concat([Buffer.from([1]), sibling, hash]))
+          : sha256(Buffer.concat([Buffer.from([1]), hash, sibling]))
+      }
+      index = Math.floor(index / 2)
+      width = Math.ceil(width / 2)
+    }
+    return pathIndex === proof.path.length && hash.toString('hex') === trustedRoot
+  } catch { return false }
+}
+
+export type SupportingRecordFormat =
+  | { format: 'supporting-record-v1'; canonicalization: 'rfc8785'; legacy: false }
+  | { format: 'evidence-bundle-v1'; canonicalization: 'aps-legacy-null-dropping'; legacy: true }
+  | { format: 'composition-check-v0'; canonicalization: 'rfc8785-tagged-v0'; legacy: true }
+  | { format: 'accountability-record-0.1.0'; canonicalization: 'rfc8785-untagged'; legacy: true }
+  | { format: 'read-fidelity-unwrapped'; canonicalization: 'rfc8785-untagged'; legacy: true }
+  | { format: 'revocation-observation-unversioned'; canonicalization: 'aps-legacy-null-dropping'; legacy: true }
+  | { format: 'unknown'; canonicalization: 'unknown'; legacy: false }
+
+/** Explicit discriminator dispatch. Verification code must never try both canonicalizers. */
+export function classifySupportingRecordFormat(value: unknown): SupportingRecordFormat {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return { format: 'unknown', canonicalization: 'unknown', legacy: false }
+  const v = value as Record<string, unknown>
+  if (v.profile === 'aps-supporting-record-v1') return { format: 'supporting-record-v1', canonicalization: 'rfc8785', legacy: false }
+  if (v.profile === 'aps-composition-check-v0') return { format: 'composition-check-v0', canonicalization: 'rfc8785-tagged-v0', legacy: true }
+  if (v.spec_version === '0.1.0' && v.record_type === 'accountability_record') return { format: 'accountability-record-0.1.0', canonicalization: 'rfc8785-untagged', legacy: true }
+  if (v.type === 'read_fidelity_receipt') return { format: 'read-fidelity-unwrapped', canonicalization: 'rfc8785-untagged', legacy: true }
+  if (typeof v.manifest === 'object' && v.manifest !== null && (v.manifest as Record<string, unknown>).profile === 'aps:evidence-bundle:v1') return { format: 'evidence-bundle-v1', canonicalization: 'aps-legacy-null-dropping', legacy: true }
+  if ('authority_ref' in v && 'observer_key' in v && !('profile' in v)) return { format: 'revocation-observation-unversioned', canonicalization: 'aps-legacy-null-dropping', legacy: true }
+  return { format: 'unknown', canonicalization: 'unknown', legacy: false }
+}
+
+/** Legacy canonical bytes are exposed only after explicit legacy classification. */
+export function legacyNullDroppingPayload(value: JsonValue): string {
+  return canonicalize(value)
+}

--- a/src/v2/receipt-core/types.ts
+++ b/src/v2/receipt-core/types.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+export type JsonPrimitive = null | boolean | number | string
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue }
+
+export type Hex64 = string
+export type Hex128 = string
+
+export interface EvidenceRefV1 {
+  artifact_type: string
+  sha256: Hex64
+}
+
+export interface ReceiptSignatureV1 {
+  signer: string
+  key_id: string
+  alg: 'Ed25519'
+  value: Hex128
+}
+
+export interface ReceiptV1 {
+  profile: 'aps-receipt-v1'
+  receipt_id: Hex64
+  receipt_type: string
+  issuer: string
+  subject_agent: string
+  action_ref: Hex64
+  delegation_ref: string
+  decision_ref?: Hex64
+  issued_at: string
+  evidence_refs: EvidenceRefV1[]
+  result: { [key: string]: JsonValue }
+  prev?: Hex64
+  signatures: ReceiptSignatureV1[]
+}
+
+export interface ReceiptSignerV1 {
+  signer: string
+  key_id: string
+  private_key: string
+}
+
+export interface DecisionRefInputV1 {
+  profile: 'aps-decision-ref-v1'
+  action_ref: Hex64
+  authority_state_ref: Hex64
+  policy_ref: Hex64
+  context_ref: Hex64
+  decision_output_ref: Hex64
+}
+
+export interface CoreDecisionOutputV1 {
+  profile: 'aps-core-decision-output-v1'
+  verdict: 'permit' | 'deny' | 'narrow'
+  effective_authority_ref: Hex64 | null
+  constraints: string[]
+}
+
+export interface SupportingRecordV1 {
+  profile: 'aps-supporting-record-v1'
+  record_id: Hex64
+  record_type: string
+  issuer: string
+  issuer_key_id: string
+  issued_at: string
+  action_ref?: Hex64
+  body: { [key: string]: JsonValue }
+  sig_alg: 'Ed25519'
+  sig: Hex128
+}
+
+export interface EvidenceBundleMemberInputV2 {
+  member_id: string
+  member_type: string
+  payload: JsonValue
+}
+
+export interface EvidenceBundleMemberV2 {
+  member_id: string
+  member_type: string
+  sha256: Hex64
+}
+
+export interface EvidenceBundleBodyV2 {
+  members: EvidenceBundleMemberV2[]
+  merkle_root: Hex64
+}
+
+export type EvidenceBundleProofStepV2 =
+  | { position: 'left' | 'right'; sha256: Hex64 }
+  | { position: 'promote' }
+
+export interface EvidenceBundleProofV2 {
+  profile: 'aps-evidence-proof-v2'
+  member: EvidenceBundleMemberV2
+  leaf_index: number
+  leaf_count: number
+  path: EvidenceBundleProofStepV2[]
+}

--- a/tests/action-reference-v2.test.ts
+++ b/tests/action-reference-v2.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  computeActionRefV2,
+  computePayloadRefV1,
+  createActionReferenceInputV2,
+} from '../src/v2/action-reference/v2.js'
+
+describe('action_ref v2', () => {
+  const base = () => createActionReferenceInputV2({
+    agent_id: 'did:example:agent',
+    action_type: 'mcp:tools/call',
+    target: 'https://mcp.example#tool=checkout',
+    payload_ref: computePayloadRefV1({ cart: ['sku-1'] }),
+    scope_required: ['commerce:write'],
+    issued_at: '2026-07-17T00:00:00.000Z',
+    nonce: '11'.repeat(16),
+  })
+
+  it('is deterministic and domain-shaped', () => {
+    assert.match(computeActionRefV2(base()), /^[0-9a-f]{64}$/)
+    assert.equal(computeActionRefV2(base()), computeActionRefV2(base()))
+  })
+
+  it('binds target, payload, and nonce so same-second calls do not collide', () => {
+    const original = base()
+    assert.notEqual(computeActionRefV2(original), computeActionRefV2({ ...original, target: 'https://mcp.example#tool=refund' }))
+    assert.notEqual(computeActionRefV2(original), computeActionRefV2({ ...original, payload_ref: computePayloadRefV1({ cart: ['sku-2'] }) }))
+    assert.notEqual(computeActionRefV2(original), computeActionRefV2({ ...original, nonce: '12'.repeat(16) }))
+  })
+
+  it('normalizes and sorts scopes before hashing', () => {
+    const first = createActionReferenceInputV2({
+      ...base(),
+      scope_required: ['repo:write', 'cafe\u0301:read'],
+    })
+    const second = createActionReferenceInputV2({
+      ...base(),
+      scope_required: ['caf\u00e9:read', 'repo:write'],
+    })
+    assert.equal(computeActionRefV2(first), computeActionRefV2(second))
+  })
+})

--- a/tests/identity-binding-v2.test.ts
+++ b/tests/identity-binding-v2.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPair } from '../src/crypto/keys.js'
+import {
+  issuePassportV2,
+  verifyPassportV2,
+} from '../src/v2/identity-binding/passport.js'
+import {
+  issuePrincipalBindingV1,
+  verifyPrincipalBindingV1,
+} from '../src/v2/identity-binding/principal-binding.js'
+import {
+  issuePrincipalBindingRevocationV1,
+  verifyPrincipalBindingRevocationV1,
+} from '../src/v2/identity-binding/revocation.js'
+import { didKeyFromPublicKey, publicKeyFromDidKey } from '../src/v2/identity-binding/did-aps.js'
+
+const issuedAt = '2026-07-16T18:00:00.000Z'
+const expiresAt = '2026-07-19T18:00:00.000Z'
+
+describe('PassportV2 identity and principal separation', () => {
+  it('issues an immutable self-certifying did:key passport', async () => {
+    const key = generateKeyPair()
+    const passport = issuePassportV2({
+      public_key_hex: key.publicKey,
+      private_key_hex: key.privateKey,
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+      nonce: '01'.repeat(16),
+      display_name: 'Procurement agent',
+      capabilities: ['tools:read', 'commerce:checkout'],
+    })
+    assert.match(passport.agent_id, /^did:key:z6Mk/)
+    assert.equal(publicKeyFromDidKey(passport.agent_id), key.publicKey)
+    assert.equal('principal_id' in passport, false)
+    const verified = await verifyPassportV2(passport, { now: '2026-07-17T00:00:00.000Z' })
+    assert.deepEqual(verified, {
+      state: 'valid', code: 'OK', proof_of_possession: true, key_authority: 'verified',
+    })
+  })
+
+  it('changes the self-certifying identifier on rotation', () => {
+    const first = generateKeyPair()
+    const second = generateKeyPair()
+    assert.notEqual(didKeyFromPublicKey(first.publicKey), didKeyFromPublicKey(second.publicKey))
+  })
+
+  it('does not upgrade proof of possession into authority for an unresolved stable DID', async () => {
+    const key = generateKeyPair()
+    const passport = issuePassportV2({
+      public_key_hex: key.publicKey,
+      private_key_hex: key.privateKey,
+      agent_id: 'did:web:agent.example',
+      verification_method: 'did:web:agent.example#key-2026-07',
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+      nonce: '02'.repeat(16),
+    })
+    const verified = await verifyPassportV2(passport, { now: '2026-07-17T00:00:00.000Z' })
+    assert.equal(verified.state, 'indeterminate')
+    assert.equal(verified.proof_of_possession, true)
+    assert.equal(verified.key_authority, 'unresolved')
+  })
+
+  it('principal binding is a separate principal-signed, scoped record', async () => {
+    const agent = generateKeyPair()
+    const principal = generateKeyPair()
+    const agentId = didKeyFromPublicKey(agent.publicKey)
+    const principalId = didKeyFromPublicKey(principal.publicKey)
+    const binding = issuePrincipalBindingV1({
+      agent_id: agentId,
+      principal_id: principalId,
+      verification_method: `${principalId}#${principalId.slice('did:key:'.length)}`,
+      audiences: ['https://mcp.example'],
+      authority_profiles: ['aps-authority-delegation-v1'],
+      status_uri: 'https://principal.example/aps/status/binding-1',
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+      nonce: '03'.repeat(16),
+      principal_private_key_hex: principal.privateKey,
+    })
+    const verified = await verifyPrincipalBindingV1(binding, {
+      now: '2026-07-17T00:00:00.000Z',
+      resolve_key: () => ({ state: 'resolved', public_key_hex: principal.publicKey }),
+    })
+    assert.equal(verified.state, 'valid')
+    assert.equal(verified.principal_claim_level, 'principal_attested')
+    const tampered = { ...binding, agent_id: didKeyFromPublicKey(generateKeyPair().publicKey) }
+    assert.equal((await verifyPrincipalBindingV1(tampered, {
+      now: '2026-07-17T00:00:00.000Z',
+      resolve_key: () => ({ state: 'resolved', public_key_hex: principal.publicKey }),
+    })).state, 'invalid')
+  })
+
+  it('binding revocation is separately content-addressed and signed', async () => {
+    const principal = generateKeyPair()
+    const principalId = didKeyFromPublicKey(principal.publicKey)
+    const revocation = issuePrincipalBindingRevocationV1({
+      binding_id: 'ab'.repeat(32),
+      principal_id: principalId,
+      verification_method: `${principalId}#${principalId.slice('did:key:'.length)}`,
+      revoked_at: '2026-07-17T01:00:00.000Z',
+      reason_code: 'principal_request',
+      nonce: '04'.repeat(16),
+      principal_private_key_hex: principal.privateKey,
+    })
+    const verified = await verifyPrincipalBindingRevocationV1(
+      revocation,
+      () => ({ state: 'resolved', public_key_hex: principal.publicKey }),
+    )
+    assert.equal(verified.state, 'valid')
+  })
+})

--- a/tests/oauth-id-jag-import-v1.test.ts
+++ b/tests/oauth-id-jag-import-v1.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPair } from '../src/crypto/keys.js'
+import { didKeyFromPublicKey } from '../src/v2/identity-binding/did-aps.js'
+import {
+  computeIdJagGrantRefV1,
+  createIdJagActorBindingSignatureV1,
+  createIdJagImportV1,
+  verifyIdJagImportV1,
+} from '../src/adapters/oauth-id-jag/import-v1.js'
+
+function compact(header: Record<string, unknown>, claims: Record<string, unknown>): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value), 'utf8').toString('base64url')
+  return `${encode(header)}.${encode(claims)}.${Buffer.from('external-signature').toString('base64url')}`
+}
+
+describe('OAuth ID-JAG exact-grant import profile', () => {
+  it('keeps grant, verification decision, and delegation root as separate commitments', async () => {
+    const agent = generateKeyPair()
+    const importer = generateKeyPair()
+    const agentId = didKeyFromPublicKey(agent.publicKey)
+    const importerId = didKeyFromPublicKey(importer.publicKey)
+    const claims = {
+      iss: 'https://issuer.example',
+      sub: 'principal-123',
+      aud: 'https://resource.example',
+      client_id: 'oauth-client-7',
+      jti: 'grant-1',
+      exp: 1780000000,
+      iat: 1779990000,
+      scope: 'read write',
+    }
+    const compactJws = compact({ alg: 'EdDSA', kid: 'issuer-key-1' }, claims)
+    const grantRef = computeIdJagGrantRefV1(compactJws)
+    const agentMethod = `${agentId}#${agentId.slice('did:key:'.length)}`
+    const binding = {
+      method: 'dual_signature' as const,
+      agent_id: agentId,
+      verification_method: agentMethod,
+      signature: createIdJagActorBindingSignatureV1(grantRef, agentId, agentMethod, agent.privateKey),
+    }
+    const grant = {
+      compact_jws: compactJws,
+      claims,
+      verification: {
+        status: 'verified' as const,
+        verified_by: importerId,
+        verification_method: `${importerId}#${importerId.slice('did:key:'.length)}`,
+        grant_key_id: 'issuer-key-1',
+        verified_at: '2026-07-17T01:00:00.000Z',
+      },
+    }
+    const record = await createIdJagImportV1({
+      grant,
+      delegation_chain_root: 'ab'.repeat(32),
+      agent_binding: binding,
+      importer_private_key_hex: importer.privateKey,
+      issued_at: '2026-07-17T01:00:01.000Z',
+      resolve_agent_key: () => ({ state: 'resolved', public_key_hex: agent.publicKey }),
+    })
+    assert.equal(record.grant_ref, grantRef)
+    assert.notEqual(record.grant_ref, record.grant_decision_ref)
+    assert.notEqual(record.grant_ref, record.delegation_chain_root)
+    assert.equal(record.subject, 'principal-123')
+    assert.equal(record.client_id, 'oauth-client-7')
+    assert.equal(record.agent_id, agentId)
+
+    const verified = await verifyIdJagImportV1(record, { compact_jws: compactJws, claims }, {
+      resolve_importer_key: () => ({ state: 'resolved', public_key_hex: importer.publicKey }),
+      resolve_agent_key: () => ({ state: 'resolved', public_key_hex: agent.publicKey }),
+    })
+    assert.deepEqual(verified, {
+      state: 'valid', code: 'OK', grant_bytes: 'matched',
+      importer_signature: 'verified', actor_binding: 'verified',
+    })
+  })
+
+  it('grant_ref commits to exact compact JWS bytes', () => {
+    const claims = { iss: 'i', sub: 's', aud: 'a', client_id: 'c', jti: 'j', exp: 2, iat: 1 }
+    const first = compact({ alg: 'EdDSA', kid: 'k1' }, claims)
+    const second = compact({ kid: 'k1', alg: 'EdDSA' }, claims)
+    assert.notEqual(first, second)
+    assert.notEqual(computeIdJagGrantRefV1(first), computeIdJagGrantRefV1(second))
+  })
+})

--- a/tests/protocol-bindings-v1.test.ts
+++ b/tests/protocol-bindings-v1.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPair } from '../src/crypto/keys.js'
+import { didKeyFromPublicKey } from '../src/v2/identity-binding/did-aps.js'
+import {
+  APS_A2A_IDENTITY_EXTENSION,
+  attachApsIdentityExtensionV1,
+  signA2AAgentCardV1,
+  verifyApsA2AAgentCardV1,
+} from '../src/profiles/a2a/identity-v1.js'
+import {
+  APS_MCP_AUTHORIZATION_META,
+  APS_MCP_RECEIPT_META,
+  ApsMcpAuthorizationError,
+  createApsMcpToolCallMiddleware,
+  issueApsMcpAuthorizationV1,
+} from '../src/profiles/mcp/authorization-v1.js'
+
+describe('A2A APS identity extension', () => {
+  it('uses native Agent Card extensions and JWS signatures', async () => {
+    const agent = generateKeyPair()
+    const agentId = didKeyFromPublicKey(agent.publicKey)
+    const kid = `${agentId}#${agentId.slice('did:key:'.length)}`
+    const passportBytes = Buffer.from('{"passport":"v2"}', 'utf8')
+    const base = {
+      name: 'Checkout Agent',
+      description: 'Runs governed checkout actions',
+      supportedInterfaces: [{ url: 'https://agent.example/a2a', protocolBinding: 'JSONRPC', protocolVersion: '1.0' }],
+      version: '1.0.0',
+      capabilities: { streaming: false },
+      defaultInputModes: ['application/json'],
+      defaultOutputModes: ['application/json'],
+      skills: [],
+    }
+    const extended = attachApsIdentityExtensionV1(base, {
+      agent_id: agentId,
+      passport_uri: 'https://agent.example/.well-known/aps-passport.json',
+      passport_sha256: createHash('sha256').update(passportBytes).digest('hex'),
+      issued_at: '2026-07-16T00:00:00.000Z',
+      expires_at: '2026-07-19T00:00:00.000Z',
+    })
+    assert.equal((extended.capabilities.extensions![0] as Record<string, unknown>).uri, APS_A2A_IDENTITY_EXTENSION)
+    const signed = signA2AAgentCardV1(extended, agent.privateKey, kid)
+    const verified = await verifyApsA2AAgentCardV1(signed, {
+      now: '2026-07-17T00:00:00.000Z',
+      resolve_key: () => ({ state: 'resolved', public_key_hex: agent.publicKey }),
+      resolve_artifact: async () => passportBytes,
+    })
+    assert.equal(verified.state, 'valid')
+    assert.equal(verified.card_signature, 'verified')
+    assert.equal(verified.passport, 'resolved')
+
+    const tampered = { ...signed, name: 'Refund Agent' }
+    assert.equal((await verifyApsA2AAgentCardV1(tampered, {
+      now: '2026-07-17T00:00:00.000Z',
+      resolve_key: () => ({ state: 'resolved', public_key_hex: agent.publicKey }),
+      resolve_artifact: async () => passportBytes,
+    })).state, 'invalid')
+  })
+})
+
+describe('MCP aps-mcp-1 pre-dispatch middleware', () => {
+  function setup() {
+    const agent = generateKeyPair()
+    const agentId = didKeyFromPublicKey(agent.publicKey)
+    const authorization = issueApsMcpAuthorizationV1({
+      agent_id: agentId,
+      verification_method: `${agentId}#${agentId.slice('did:key:'.length)}`,
+      delegation_ref: 'sha256:' + 'aa'.repeat(32),
+      mcp_server: 'https://mcp.example',
+      tool_name: 'checkout',
+      arguments: { cart_id: 'cart-1' },
+      scope_required: ['commerce:checkout'],
+      spend: { unit: 'iso4217:USD:minor', amount: '5000' },
+      nonce: '22'.repeat(16),
+      issued_at: '2026-01-01T00:00:00.000Z',
+      expires_at: '2027-01-01T00:00:00.000Z',
+      private_key_hex: agent.privateKey,
+    })
+    const request = {
+      method: 'tools/call' as const,
+      params: {
+        name: 'checkout',
+        arguments: { cart_id: 'cart-1' },
+        _meta: { [APS_MCP_AUTHORIZATION_META]: authorization },
+      },
+    }
+    return { agent, authorization, request }
+  }
+
+  it('denies before dispatch when transport authentication is absent', async () => {
+    const { agent, request } = setup()
+    let dispatched = false
+    const middleware = createApsMcpToolCallMiddleware({
+      mcp_server: 'https://mcp.example',
+      resolve_key: () => ({ state: 'resolved', public_key_hex: agent.publicKey }),
+      consume_action_ref: () => true,
+      evaluate_authority: () => ({ state: 'permit', code: 'OK' }),
+      emit_receipt: () => ({ receipt_id: 'r1' }),
+    })
+    await assert.rejects(
+      () => middleware(request, { transport_authenticated: false }, async () => {
+        dispatched = true
+        return { content: [] }
+      }),
+      (error: unknown) => error instanceof ApsMcpAuthorizationError && error.code === 'MCP_TRANSPORT_UNAUTHENTICATED',
+    )
+    assert.equal(dispatched, false)
+  })
+
+  it('authorizes, dispatches once, returns a receipt, and rejects replay', async () => {
+    const { agent, request } = setup()
+    const seen = new Set<string>()
+    let dispatches = 0
+    const middleware = createApsMcpToolCallMiddleware({
+      mcp_server: 'https://mcp.example',
+      resolve_key: () => ({ state: 'resolved', public_key_hex: agent.publicKey }),
+      consume_action_ref: (ref) => seen.has(ref) ? false : (seen.add(ref), true),
+      evaluate_authority: () => ({ state: 'permit', code: 'OK', decision_ref: 'bb'.repeat(32) }),
+      emit_receipt: (authorization) => ({ action_ref: authorization.action_ref }),
+    })
+    const response = await middleware(request, { transport_authenticated: true }, async () => {
+      dispatches++
+      return { content: [{ type: 'text', text: 'ok' }] }
+    })
+    assert.equal(dispatches, 1)
+    assert.ok(response._meta?.[APS_MCP_RECEIPT_META])
+    await assert.rejects(
+      () => middleware(request, { transport_authenticated: true }, async () => {
+        dispatches++
+        return { content: [] }
+      }),
+      (error: unknown) => error instanceof ApsMcpAuthorizationError && error.code === 'MCP_ACTION_REPLAY',
+    )
+    assert.equal(dispatches, 1)
+  })
+})

--- a/tests/receipt-core-v1.test.ts
+++ b/tests/receipt-core-v1.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { publicKeyFromPrivate } from '../src/crypto/keys.js'
+import { buildDecisionRefV1, normalizeCoreDecisionOutputV1 } from '../src/v2/receipt-core/decision-ref.js'
+import { createReceiptV1, computeReceiptIdV1, verifyReceiptV1 } from '../src/v2/receipt-core/receipt.js'
+import { parseStrictIJson, strictJCS } from '../src/v2/receipt-core/jcs.js'
+import { buildEvidenceBundleBodyV2, buildEvidenceBundleProofV2, classifySupportingRecordFormat, createSupportingRecordV1, verifyEvidenceBundleBodyV2, verifyEvidenceBundleProofV2, verifySupportingRecordV1 } from '../src/v2/receipt-core/supporting-record.js'
+
+const privateKey = '00'.repeat(32)
+const publicKey = publicKeyFromPrivate(privateKey)
+const hex = (c: string) => c.repeat(64)
+const KAT = {
+  decision_ref: '2157809a9a722314ae19dce7a242ea3b54a8948230fab2fab5d5dc15bd663dc2',
+  receipt_id: '89b0b77807e99845aab403f01bcdaa2f02949f6c9db84e1aca6c0a8449e4d023',
+  receipt_sig: '83deb713568bbdf0c85e1a6d46345530e84dbe86cdefe1cb608b0f14372c176a9e69e0033db11c4c44ff84be3de3bee5e212707eb84206f6c34455206d37f90b',
+  merkle_root: '03700eeba1b453086063612d3df73f711827735c3fe30cf8a8a2a6379a6f6d5f',
+  record_id: '7d73684a65444088e841f2b30f0ecf139fbadbeab277d57d20d1a2ef5fe2a7b2',
+  record_sig: '56a2116eb4e259a336c36a646e69322cf2e7850b7202f2093c5957e4e6a100cf4cae8048cb4647bbc557447bea531dd7e69c117e9298515cc767110cf0f7d809',
+  proof_root: 'dab9f2f5f3571345327f0144f2eafbb6e835ac5cbb48e9d789224e135ce16247',
+  proof_left: 'f3bdfcf031dea9da3129ae67bdf7f69caefc41660541d0acb015e1b49ae95470',
+}
+
+test('decision_ref is content-derived and event fields cannot enter it', () => {
+  const a = buildDecisionRefV1({
+    action_ref: hex('a'),
+    authority_state: { scope: ['read'], revoked: false },
+    policy_input: { id: 'p1', version: '1' },
+    decision_context: { tenant: 't1' },
+    decision_output: { verdict: 'permit', constraints: [] },
+  })
+  assert.equal(a.decision_ref, KAT.decision_ref)
+  const b = buildDecisionRefV1({
+    action_ref: hex('a'), authority_state: { revoked: false, scope: ['read'] },
+    policy_input: { version: '1', id: 'p1' }, decision_context: { tenant: 't1' },
+    decision_output: { constraints: [], verdict: 'permit' },
+  })
+  assert.equal(a.decision_ref, b.decision_ref)
+  assert.notEqual(a.decision_ref, buildDecisionRefV1({
+    action_ref: hex('a'), authority_state: { scope: ['write'], revoked: false },
+    policy_input: { id: 'p1', version: '1' }, decision_context: { tenant: 't1' },
+    decision_output: { verdict: 'permit', constraints: [] },
+  }).decision_ref)
+})
+
+test('core decision output normalizes a set of constraints', () => {
+  const out = normalizeCoreDecisionOutputV1({ profile: 'aps-core-decision-output-v1', verdict: 'narrow', effective_authority_ref: hex('b'), constraints: ['é', 'read', 'e\u0301', 'read'] })
+  assert.deepEqual(out.constraints, ['read', 'é'])
+})
+
+test('receipt binds id, signer descriptor, and signed content', () => {
+  const receipt = createReceiptV1({
+    profile: 'aps-receipt-v1', receipt_type: 'aps:action:v1', issuer: 'did:example:issuer',
+    subject_agent: 'did:example:agent', action_ref: hex('a'), delegation_ref: hex('b'),
+    decision_ref: hex('c'), issued_at: '2026-07-18T12:00:00.000Z',
+    evidence_refs: [{ artifact_type: 'z', sha256: hex('e') }, { artifact_type: 'a', sha256: hex('d') }],
+    result: { status: 'success', detail: null },
+  }, [{ signer: 'did:example:issuer', key_id: 'key-1', private_key: privateKey }])
+  assert.equal(receipt.receipt_id, computeReceiptIdV1(receipt))
+  assert.equal(receipt.receipt_id, KAT.receipt_id)
+  assert.equal(receipt.signatures[0].value, KAT.receipt_sig)
+  assert.equal(verifyReceiptV1(receipt, () => publicKey).valid, true)
+  assert.deepEqual(receipt.evidence_refs.map(e => e.artifact_type), ['a', 'z'])
+  const relabeled = structuredClone(receipt)
+  relabeled.signatures[0].key_id = 'key-2'
+  assert.equal(verifyReceiptV1(relabeled, () => publicKey).valid, false)
+  const tampered = structuredClone(receipt)
+  tampered.result.status = 'failure'
+  assert.equal(verifyReceiptV1(tampered, () => publicKey).valid, false)
+})
+
+test('supporting record and evidence bundle v2 bind type, member id, type, and payload', () => {
+  const payloads = { m1: { value: null }, m2: { value: 2 } }
+  const bundle = buildEvidenceBundleBodyV2([
+    { member_id: 'm2', member_type: 'two', payload: payloads.m2 },
+    { member_id: 'm1', member_type: 'one', payload: payloads.m1 },
+  ])
+  assert.equal(bundle.merkle_root, KAT.merkle_root)
+  assert.equal(verifyEvidenceBundleBodyV2(bundle, payloads), true)
+  const record = createSupportingRecordV1({
+    profile: 'aps-supporting-record-v1', record_type: 'aps:evidence-bundle:v2',
+    issuer: 'did:example:issuer', issuer_key_id: 'key-1', issued_at: '2026-07-18T12:00:00.000Z',
+    body: bundle, sig_alg: 'Ed25519',
+  }, privateKey)
+  assert.equal(record.record_id, KAT.record_id)
+  assert.equal(record.sig, KAT.record_sig)
+  assert.equal(verifySupportingRecordV1(record, publicKey).valid, true)
+  const relabeled = { ...record, record_type: 'aps:accountability:v1' }
+  assert.equal(verifySupportingRecordV1(relabeled, publicKey).valid, false)
+  const changed = structuredClone(bundle)
+  changed.members[0].member_type = 'changed'
+  assert.equal(verifyEvidenceBundleBodyV2(changed, payloads), false)
+
+  const three = buildEvidenceBundleBodyV2([
+    { member_id: 'm3', member_type: 'three', payload: { value: 3 } },
+    { member_id: 'm1', member_type: 'one', payload: { value: 1 } },
+    { member_id: 'm2', member_type: 'two', payload: { value: 2 } },
+  ])
+  const proof = buildEvidenceBundleProofV2(three.members, 'm3')
+  assert.equal(three.merkle_root, KAT.proof_root)
+  assert.deepEqual(proof.path, [{ position: 'promote' }, { position: 'left', sha256: KAT.proof_left }])
+  assert.equal(proof.path.some(step => step.position === 'promote'), true)
+  assert.equal(verifyEvidenceBundleProofV2(proof, three.merkle_root, { value: 3 }), true)
+  assert.equal(verifyEvidenceBundleProofV2({ ...proof, leaf_count: 4 }, three.merkle_root, { value: 3 }), false)
+})
+
+test('legacy dispatch is explicit and never guesses from canonical bytes', () => {
+  assert.deepEqual(classifySupportingRecordFormat({ manifest: { profile: 'aps:evidence-bundle:v1' } }).format, 'evidence-bundle-v1')
+  assert.deepEqual(classifySupportingRecordFormat({ profile: 'aps-supporting-record-v1' }).legacy, false)
+  assert.deepEqual(classifySupportingRecordFormat({ profile: 'future' }).format, 'unknown')
+  assert.throws(() => strictJCS({ integer: 9007199254740992 }), /IEEE 754/)
+  assert.throws(() => parseStrictIJson('{"a":1,"\\u0061":2}'), /duplicate object member/)
+  assert.equal(strictJCS(parseStrictIJson('{"a":null}')), '{"a":null}')
+})

--- a/tests/v2/authority-budget.test.ts
+++ b/tests/v2/authority-budget.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPair } from '../../src/crypto/keys.js'
+import {
+  AUTHORITY_DELEGATION_RECORD_TYPE,
+  AUTHORITY_DELEGATION_VERSION,
+  InMemoryAuthorityBudgetLedger,
+  REPUTATION_PROFILE_V1,
+  REVERSIBILITY_PROFILE_V1,
+  SCOPE_PROFILE_V1,
+  VALUES_PROFILE_V1,
+  issueAuthorityDelegation,
+  issueSubAuthorityDelegation,
+} from '../../src/v2/authority-delegation/index.js'
+import type { AuthorityDelegationBodyV1, AuthorityDelegationV1 } from '../../src/v2/authority-delegation/index.js'
+
+function root(): { delegation: AuthorityDelegationV1; subjectKey: ReturnType<typeof generateKeyPair> } {
+  const rootKey = generateKeyPair()
+  const subjectKey = generateKeyPair()
+  const body: AuthorityDelegationBodyV1 = {
+    record_type: AUTHORITY_DELEGATION_RECORD_TYPE,
+    version: AUTHORITY_DELEGATION_VERSION,
+    parent_delegation_id: null,
+    issuer: 'did:example:root', subject: 'did:example:a',
+    verification_method: 'did:example:root#key',
+    issued_at: '2026-07-18T22:00:00.000Z', nonce: '11111111111111111111111111111111',
+    authority: {
+      scope: { profile: SCOPE_PROFILE_V1, grants: ['commerce:*'] },
+      spend: { mode: 'bounded', unit: 'iso4217:USD:minor', per_action: '100', cumulative: '100' },
+      depth: { remaining: 2 },
+      time: { not_before: '2026-07-18T22:00:00.000Z', not_after: '2026-07-18T23:00:00.000Z' },
+      reputation: { profile: REPUTATION_PROFILE_V1, ceiling: 100 },
+      values: { profile: VALUES_PROFILE_V1, required: [] },
+      reversibility: { profile: REVERSIBILITY_PROFILE_V1, ceiling: 'irreversible' },
+    },
+  }
+  return { delegation: issueAuthorityDelegation(body, rootKey.privateKey), subjectKey }
+}
+
+function child(parent: AuthorityDelegationV1, subjectKey: ReturnType<typeof generateKeyPair>, subject: string, nonce: string): AuthorityDelegationV1 {
+  const body: AuthorityDelegationBodyV1 = {
+    record_type: AUTHORITY_DELEGATION_RECORD_TYPE,
+    version: AUTHORITY_DELEGATION_VERSION,
+    parent_delegation_id: parent.delegation_id,
+    issuer: parent.subject, subject,
+    verification_method: `${parent.subject}#key`,
+    issued_at: '2026-07-18T22:00:01.000Z', nonce,
+    authority: {
+      ...structuredClone(parent.authority),
+      depth: { remaining: 1 },
+      time: { not_before: '2026-07-18T22:00:01.000Z', not_after: '2026-07-18T22:59:00.000Z' },
+    },
+  }
+  return issueSubAuthorityDelegation(parent, body, subjectKey.privateKey)
+}
+
+test('sibling actions debit their shared ancestor atomically', () => {
+  const { delegation: parent, subjectKey } = root()
+  const left = child(parent, subjectKey, 'did:example:left', '22222222222222222222222222222222')
+  const right = child(parent, subjectKey, 'did:example:right', '33333333333333333333333333333333')
+  const ledger = new InMemoryAuthorityBudgetLedger()
+
+  const first = ledger.reserve([parent, left], 'a'.repeat(64), 'iso4217:USD:minor', '60')
+  const second = ledger.reserve([parent, right], 'b'.repeat(64), 'iso4217:USD:minor', '60')
+  assert.equal(first.ok, true)
+  assert.deepEqual(second, { ok: false, code: 'CUMULATIVE_EXCEEDED' })
+  assert.deepEqual(ledger.counter(parent.delegation_id), { reserved: '60', committed: '0' })
+
+  assert.equal(ledger.commit('a'.repeat(64)).ok, true)
+  assert.deepEqual(ledger.counter(parent.delegation_id), { reserved: '0', committed: '60' })
+  assert.equal(ledger.commit('a'.repeat(64)).code, 'IDEMPOTENT')
+})
+
+test('action_ref retries are idempotent, conflicts fail, and dispatched reservations cannot cancel', () => {
+  const { delegation: parent, subjectKey } = root()
+  const leaf = child(parent, subjectKey, 'did:example:leaf', '44444444444444444444444444444444')
+  const ledger = new InMemoryAuthorityBudgetLedger()
+  const actionRef = 'c'.repeat(64)
+
+  assert.equal(ledger.reserve([parent, leaf], actionRef, 'iso4217:USD:minor', '25').code, 'RESERVED')
+  assert.equal(ledger.reserve([parent, leaf], actionRef, 'iso4217:USD:minor', '25').code, 'IDEMPOTENT')
+  assert.equal(ledger.reserve([parent, leaf], actionRef, 'iso4217:USD:minor', '26').code, 'CONFLICT')
+  assert.equal(ledger.markDispatched(actionRef).ok, true)
+  assert.deepEqual(ledger.cancel(actionRef), { ok: false, code: 'INVALID_STATE', state: 'dispatched' })
+  assert.equal(ledger.commit(actionRef).ok, true)
+})
+
+test('budget ledger rejects truncated, malformed, and duplicate chains', () => {
+  const { delegation: parent, subjectKey } = root()
+  const leaf = child(parent, subjectKey, 'did:example:leaf', '55555555555555555555555555555555')
+  const ledger = new InMemoryAuthorityBudgetLedger()
+  assert.equal(ledger.reserve([], 'd'.repeat(64), 'iso4217:USD:minor', '1').code, 'CONFLICT')
+  assert.equal(ledger.reserve([leaf], 'e'.repeat(64), 'iso4217:USD:minor', '1').code, 'CONFLICT')
+  assert.equal(ledger.reserve([parent, parent], 'f'.repeat(64), 'iso4217:USD:minor', '1').code, 'CONFLICT')
+})

--- a/tests/v2/authority-delegation.test.ts
+++ b/tests/v2/authority-delegation.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Tymofii Pidlisnyi
+// SPDX-License-Identifier: Apache-2.0
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPair, publicKeyFromPrivate } from '../../src/crypto/keys.js'
+import {
+  AUTHORITY_DELEGATION_RECORD_TYPE,
+  AUTHORITY_DELEGATION_VERSION,
+  REPUTATION_PROFILE_V1,
+  REVERSIBILITY_PROFILE_V1,
+  SCOPE_PROFILE_V1,
+  VALUES_PROFILE_V1,
+  compareAuthority,
+  computeAuthorityDelegationId,
+  authorityDelegationBody,
+  issueAuthorityDelegation,
+  issueSubAuthorityDelegation,
+  parseAuthorityDelegationJson,
+  verifyAuthorityDelegationChain,
+} from '../../src/v2/authority-delegation/index.js'
+import type {
+  AuthorityDelegationBodyV1,
+  AuthorityDelegationV1,
+  AuthorityVectorV1,
+} from '../../src/v2/authority-delegation/index.js'
+
+function rootAuthority(): AuthorityVectorV1 {
+  return {
+    scope: { profile: SCOPE_PROFILE_V1, grants: ['commerce:*'] },
+    spend: { mode: 'bounded', unit: 'iso4217:USD:minor', per_action: '100', cumulative: '100' },
+    depth: { remaining: 3 },
+    time: { not_before: '2026-07-18T22:00:00.000Z', not_after: '2026-07-18T23:00:00.000Z' },
+    reputation: { profile: REPUTATION_PROFILE_V1, ceiling: 80 },
+    values: { profile: VALUES_PROFILE_V1, required: ['F-001', 'F-003'] },
+    reversibility: { profile: REVERSIBILITY_PROFILE_V1, ceiling: 'compensable' },
+  }
+}
+
+function rootBody(): AuthorityDelegationBodyV1 {
+  return {
+    record_type: AUTHORITY_DELEGATION_RECORD_TYPE,
+    version: AUTHORITY_DELEGATION_VERSION,
+    parent_delegation_id: null,
+    issuer: 'did:example:root',
+    subject: 'did:example:agent-a',
+    verification_method: 'did:example:root#key-1',
+    issued_at: '2026-07-18T22:00:00.000Z',
+    nonce: '00112233445566778899aabbccddeeff',
+    authority: rootAuthority(),
+  }
+}
+
+function childBody(parent: AuthorityDelegationV1, subject = 'did:example:agent-b', nonce = '102132435465768798a9bacbdcedfe0f'): AuthorityDelegationBodyV1 {
+  return {
+    record_type: AUTHORITY_DELEGATION_RECORD_TYPE,
+    version: AUTHORITY_DELEGATION_VERSION,
+    parent_delegation_id: parent.delegation_id,
+    issuer: parent.subject,
+    subject,
+    verification_method: `${parent.subject}#key-1`,
+    issued_at: '2026-07-18T22:00:01.000Z',
+    nonce,
+    authority: {
+      scope: { profile: SCOPE_PROFILE_V1, grants: ['commerce:checkout'] },
+      spend: { mode: 'bounded', unit: 'iso4217:USD:minor', per_action: '80', cumulative: '80' },
+      depth: { remaining: 2 },
+      time: { not_before: '2026-07-18T22:00:01.000Z', not_after: '2026-07-18T22:50:00.000Z' },
+      reputation: { profile: REPUTATION_PROFILE_V1, ceiling: 70 },
+      values: { profile: VALUES_PROFILE_V1, required: ['F-001', 'F-003', 'F-004'] },
+      reversibility: { profile: REVERSIBILITY_PROFILE_V1, ceiling: 'tentative' },
+    },
+  }
+}
+
+test('authority delegation v1 cross-language known-answer vector is stable', () => {
+  const seed = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+  const delegation = issueAuthorityDelegation(rootBody(), seed)
+  assert.equal(publicKeyFromPrivate(seed), '03a107bff3ce10be1d70dd18e74bc09967e4d6309ba50d5f1ddc8664125531b8')
+  assert.equal(delegation.delegation_id, 'sha256:44ab6d778b1a1b9acf4fadb07772892ae33e7b5dba84152a0a1af501e9bbb40a')
+  assert.equal(delegation.signature, 'b070ad54a75b44b4340333e0b381f83d4e474b3149188e3f5846a38ad29863eab9e65e245d1c457e0e539e19d3ca813987ea6848f20a4f212754ebd10cf24200')
+  assert.deepEqual(parseAuthorityDelegationJson(JSON.stringify(delegation)), delegation)
+})
+
+test('strict wire parser rejects unknown and duplicate members', () => {
+  const seed = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+  const wire = JSON.stringify(issueAuthorityDelegation(rootBody(), seed))
+  assert.throws(
+    () => parseAuthorityDelegationJson(wire.replace('"version":"1.0"', '"version":"1.0","future":true')),
+    /SCHEMA_INVALID/,
+  )
+  assert.throws(
+    () => parseAuthorityDelegationJson(wire.replace('"version":"1.0"', '"version":"1.0","version":"1.0"')),
+    /duplicate JSON object member/,
+  )
+  assert.throws(
+    () => parseAuthorityDelegationJson(wire.replace('did:example:root', 'did:example:\\ud800')),
+    /SCHEMA_INVALID/,
+  )
+  assert.throws(
+    () => parseAuthorityDelegationJson(wire.replace('"remaining":3', '"remaining":3.0')),
+    /non-integer JSON numbers/,
+  )
+})
+
+test('v1 ID and Ed25519 signature inputs are deterministic and full chain validates', () => {
+  const rootKeys = generateKeyPair()
+  const childKeys = generateKeyPair()
+  const root = issueAuthorityDelegation(rootBody(), rootKeys.privateKey)
+  const again = issueAuthorityDelegation(rootBody(), rootKeys.privateKey)
+  assert.deepEqual(again, root)
+  assert.equal(root.delegation_id, computeAuthorityDelegationId(authorityDelegationBody(root)))
+
+  const child = issueSubAuthorityDelegation(root, childBody(root), childKeys.privateKey)
+  const keys = new Map([
+    [root.verification_method, rootKeys.publicKey],
+    [child.verification_method, childKeys.publicKey],
+  ])
+  const checked = verifyAuthorityDelegationChain([root, child], {
+    now: '2026-07-18T22:10:00.000Z',
+    resolveVerificationKey: (_issuer, method) => keys.get(method) ?? null,
+    trustRoot: candidate => candidate.issuer === 'did:example:root',
+    resolveRevocation: () => 'active',
+  })
+  assert.equal(checked.state, 'valid')
+  assert.equal(checked.valid, true)
+
+  const tampered = structuredClone(child)
+  tampered.authority.reputation.ceiling = 69
+  const rejected = verifyAuthorityDelegationChain([root, tampered], {
+    now: '2026-07-18T22:10:00.000Z',
+    resolveVerificationKey: (_issuer, method) => keys.get(method) ?? null,
+    trustRoot: () => true,
+    resolveRevocation: () => 'active',
+  })
+  assert.equal(rejected.failures[0]?.code, 'ID_MISMATCH')
+})
+
+test('each of the seven authority facets rejects outward movement', () => {
+  const parent = rootAuthority()
+  const base = childBody({ delegation_id: `sha256:${'0'.repeat(64)}` } as AuthorityDelegationV1).authority
+  assert.deepEqual(compareAuthority(parent, base), [])
+
+  const cases: Array<[string, (value: AuthorityVectorV1, parentValue: AuthorityVectorV1) => void, string]> = [
+    ['scope', value => { value.scope.grants = ['admin:root'] }, 'SCOPE_WIDENING'],
+    ['spend', value => { value.spend = { mode: 'bounded', unit: 'iso4217:USD:minor', per_action: '101', cumulative: '101' } }, 'SPEND_WIDENING'],
+    ['depth', value => { value.depth.remaining = 3 }, 'DEPTH_WIDENING'],
+    ['time', value => { value.time.not_after = '2026-07-19T00:00:00.000Z' }, 'TIME_WIDENING'],
+    ['reputation', value => { value.reputation.ceiling = 81 }, 'REPUTATION_WIDENING'],
+    ['values', value => { value.values.required = ['F-001'] }, 'VALUES_WEAKENING'],
+    ['reversibility', (value, parentValue) => {
+      parentValue.reversibility.ceiling = 'tentative'
+      value.reversibility.ceiling = 'irreversible'
+    }, 'REVERSIBILITY_WIDENING'],
+  ]
+  for (const [name, mutate, expected] of cases) {
+    const child = structuredClone(base)
+    const localParent = structuredClone(parent)
+    mutate(child, localParent)
+    assert.ok(compareAuthority(localParent, child).some(item => item.code === expected), `${name} must reject`)
+  }
+})
+
+test('unknown revocation state is indeterminate rather than valid', () => {
+  const keys = generateKeyPair()
+  const root = issueAuthorityDelegation(rootBody(), keys.privateKey)
+  const checked = verifyAuthorityDelegationChain([root], {
+    now: '2026-07-18T22:10:00.000Z',
+    resolveVerificationKey: () => keys.publicKey,
+    trustRoot: () => true,
+    resolveRevocation: () => 'unknown',
+  })
+  assert.equal(checked.state, 'indeterminate')
+  assert.equal(checked.failures[0]?.code, 'REVOCATION_UNKNOWN')
+})


### PR DESCRIPTION
## What this is

The v2 protocol surface behind `draft-pidlisnyi-aps-03`, plus a runnable interop harness mapping the draft-liu OAuth agent-authorization family onto signed, independently verifiable APS records.

Opened as a PR so the vectors have a browsable, linkable home while the v2 core gets its own review. Not requesting a fast merge.

## v2 core (`src/v2/`, `src/adapters/`, `src/profiles/`)

- `receipt-core`: the common receipt envelope (`aps-receipt-v1`, strict RFC 8785 JCS), decision-ref and supporting-record computation.
- `authority-delegation`: seven-facet authority with narrowing and cumulative-budget checks.
- `identity-binding`: passport, principal binding, revocation, `did:key` with `did:aps` read compatibility.
- `action-reference/v2`: native content-addressed action identifier.
- `adapters/oauth-id-jag/import-v1`: OAuth identity-assertion grant import kept separate from the APS chain root.
- `profiles/a2a`, `profiles/mcp`: the two binding surfaces.

Each module carries its own tests. The full suite passes (4326 tests, 0 failures).

## OAuth composition vectors (`interop/oauth-liu-composition/`)

Three vectors connect the `delegation_chain`, `authorization_evidence`, and Rego-policy inputs of the draft-liu family to signed permit, denial, and observation records that another party can verify later:

- **permit**: a two-hop chain (child scope a strict subset of the parent) plus an evidence object plus the Section 9.7 audit tuple, emitted as a signed decision record whose `evidence_refs` bind digests of both inputs.
- **denial**: a requested action outside the final hop's narrowed subset, recorded with the subset it fell outside.
- **observation**: the Section 10.8 fallback, a signed revocation-observation recording the source consulted, the observation time, the accepted staleness, the affected scope, and the decision that followed.

Verified two ways: through the SDK verifier and through `independent-verify.mjs`, which recomputes the RFC 8785 canonical form and the Ed25519 signature with no SDK on the path. Vectors are byte-stable under fixed, clearly-labelled test keys, so re-running the emitter reproduces identical bytes.

`MAPPING-TABLE.md` records the field-by-field mapping and marks where a JSON spelling (Section 9.7 prescribes tuple content, not field names) or the RFC 8417 Security Event Token binding (Section 10.8 names back-channel notification without citing 8417) is APS vocabulary rather than the draft's own text.

## Not included

The AISec paper PDF is deliberately excluded. `interop/` sits outside the package `files` allowlist and is absent from `npm pack`.
