### PR TITLE
receipt-core: CoreDecisionOutputV1 semantic core (valid_until binding, normalize-before-hash)

### DIFF
--- a/src/v2/receipt-core/decision-ref.ts
+++ b/src/v2/receipt-core/decision-ref.ts
@@ -3,6 +3,7 @@
 
 import { createHash } from 'node:crypto'
 import { strictJCS, assertExactKeys } from './jcs.js'
+import { isExactUtcMilliseconds } from './receipt.js'
 import type { CoreDecisionOutputV1, DecisionRefInputV1, JsonValue } from './types.js'
 
 export const DECISION_REF_TAG = 'APS-DECISION-REF-V1' as const
@@ -41,8 +42,8 @@ export function computeDecisionRefV1(input: DecisionRefInputV1): string {
 
 export function normalizeCoreDecisionOutputV1(input: CoreDecisionOutputV1): CoreDecisionOutputV1 {
   assertExactKeys(input as unknown as Record<string, unknown>,
-    ['profile', 'verdict', 'effective_authority_ref', 'constraints'],
-    ['profile', 'verdict', 'effective_authority_ref', 'constraints'], 'CoreDecisionOutputV1')
+    ['profile', 'verdict', 'effective_authority_ref', 'constraints', 'valid_until'],
+    ['profile', 'verdict', 'effective_authority_ref', 'constraints', 'valid_until'], 'CoreDecisionOutputV1')
   strictJCS(input)
   if (input.profile !== 'aps-core-decision-output-v1') throw new TypeError('CoreDecisionOutputV1: profile')
   if (!['permit', 'deny', 'narrow'].includes(input.verdict)) throw new TypeError('CoreDecisionOutputV1: verdict')
@@ -57,6 +58,11 @@ export function normalizeCoreDecisionOutputV1(input: CoreDecisionOutputV1): Core
   }
   if (!Array.isArray(input.constraints) || !input.constraints.every(v => typeof v === 'string')) {
     throw new TypeError('CoreDecisionOutputV1: constraints')
+  }
+  if (input.verdict === 'deny') {
+    if (input.valid_until !== null) throw new TypeError('CoreDecisionOutputV1: deny requires null valid_until')
+  } else if (typeof input.valid_until !== 'string' || !isExactUtcMilliseconds(input.valid_until)) {
+    throw new TypeError('CoreDecisionOutputV1: permit/narrow require valid_until as exact UTC milliseconds')
   }
   const constraints = [...new Set(input.constraints.map(v => v.normalize('NFC')))]
     .sort((a, b) => {

--- a/src/v2/receipt-core/decision-ref.ts
+++ b/src/v2/receipt-core/decision-ref.ts
@@ -18,6 +18,7 @@ const HEX64 = /^[0-9a-f]{64}$/
 const tagged = (tag: string, canonical: string): string => `${tag}\0${canonical}`
 const sha256Hex = (value: string): string => createHash('sha256').update(value, 'utf8').digest('hex')
 
+// Internal hash primitive: input must already be normalized. Protocol-facing callers use buildDecisionRefV1.
 export function computeDecisionComponentRefV1(tag: keyof typeof DECISION_COMPONENT_TAGS, value: JsonValue): string {
   return sha256Hex(tagged(DECISION_COMPONENT_TAGS[tag], strictJCS(value)))
 }
@@ -79,16 +80,19 @@ export function buildDecisionRefV1(input: {
   authority_state: JsonValue
   policy_input: JsonValue
   decision_context: JsonValue
-  decision_output: JsonValue
+  decision_output: CoreDecisionOutputV1
 }): { input: DecisionRefInputV1; decision_ref: string } {
   if (!HEX64.test(input.action_ref)) throw new TypeError('action_ref must be lowercase sha256 hex')
+  // Normalize before hashing: the normalizer validates the closed five-member shape, so an
+  // unnormalized or malformed decision output cannot reach the digest through this path.
+  const normalizedOutput = normalizeCoreDecisionOutputV1(input.decision_output)
   const refInput: DecisionRefInputV1 = {
     profile: 'aps-decision-ref-v1',
     action_ref: input.action_ref,
     authority_state_ref: computeDecisionComponentRefV1('authority', input.authority_state),
     policy_ref: computeDecisionComponentRefV1('policy', input.policy_input),
     context_ref: computeDecisionComponentRefV1('context', input.decision_context),
-    decision_output_ref: computeDecisionComponentRefV1('output', input.decision_output),
+    decision_output_ref: computeDecisionComponentRefV1('output', normalizedOutput as unknown as JsonValue),
   }
   return { input: refInput, decision_ref: computeDecisionRefV1(refInput) }
 }

--- a/src/v2/receipt-core/receipt.ts
+++ b/src/v2/receipt-core/receipt.ts
@@ -22,7 +22,7 @@ function compareSignatures(a: Pick<ReceiptSignatureV1, 'signer' | 'key_id'>, b: 
   return compareUtf8(a.signer, b.signer) || compareUtf8(a.key_id, b.key_id)
 }
 
-function isExactUtcMilliseconds(value: string): boolean {
+export function isExactUtcMilliseconds(value: string): boolean {
   if (!UTC_MS.test(value)) return false
   const parsed = new Date(value)
   return !Number.isNaN(parsed.valueOf()) && parsed.toISOString() === value

--- a/src/v2/receipt-core/types.ts
+++ b/src/v2/receipt-core/types.ts
@@ -55,6 +55,7 @@ export interface CoreDecisionOutputV1 {
   verdict: 'permit' | 'deny' | 'narrow'
   effective_authority_ref: Hex64 | null
   constraints: string[]
+  valid_until: string | null
 }
 
 export interface SupportingRecordV1 {

--- a/tests/receipt-core-v1.test.ts
+++ b/tests/receipt-core-v1.test.ts
@@ -13,7 +13,9 @@ const privateKey = '00'.repeat(32)
 const publicKey = publicKeyFromPrivate(privateKey)
 const hex = (c: string) => c.repeat(64)
 const KAT = {
-  decision_ref: '2157809a9a722314ae19dce7a242ea3b54a8948230fab2fab5d5dc15bd663dc2',
+  // Repinned: buildDecisionRefV1 now normalizes before hashing, so the decision output
+  // must be a valid five-member CoreDecisionOutputV1. Was 2157809a9a722314ae19dce7a242ea3b54a8948230fab2fab5d5dc15bd663dc2.
+  decision_ref: 'e474f27bc7e228cd515d4192936cd5525ac8f362fa95173c82eaff02059389e7',
   receipt_id: '89b0b77807e99845aab403f01bcdaa2f02949f6c9db84e1aca6c0a8449e4d023',
   receipt_sig: '83deb713568bbdf0c85e1a6d46345530e84dbe86cdefe1cb608b0f14372c176a9e69e0033db11c4c44ff84be3de3bee5e212707eb84206f6c34455206d37f90b',
   merkle_root: '03700eeba1b453086063612d3df73f711827735c3fe30cf8a8a2a6379a6f6d5f',
@@ -23,25 +25,27 @@ const KAT = {
   proof_left: 'f3bdfcf031dea9da3129ae67bdf7f69caefc41660541d0acb015e1b49ae95470',
 }
 
+const KAT_OUTPUT = { profile: 'aps-core-decision-output-v1' as const, verdict: 'permit' as const, effective_authority_ref: hex('b'), constraints: [] as string[], valid_until: '2026-04-08T12:00:05.000Z' }
+
 test('decision_ref is content-derived and event fields cannot enter it', () => {
   const a = buildDecisionRefV1({
     action_ref: hex('a'),
     authority_state: { scope: ['read'], revoked: false },
     policy_input: { id: 'p1', version: '1' },
     decision_context: { tenant: 't1' },
-    decision_output: { verdict: 'permit', constraints: [] },
+    decision_output: KAT_OUTPUT,
   })
   assert.equal(a.decision_ref, KAT.decision_ref)
   const b = buildDecisionRefV1({
     action_ref: hex('a'), authority_state: { revoked: false, scope: ['read'] },
     policy_input: { version: '1', id: 'p1' }, decision_context: { tenant: 't1' },
-    decision_output: { constraints: [], verdict: 'permit' },
+    decision_output: { valid_until: '2026-04-08T12:00:05.000Z', constraints: [], effective_authority_ref: hex('b'), verdict: 'permit', profile: 'aps-core-decision-output-v1' },
   })
   assert.equal(a.decision_ref, b.decision_ref)
   assert.notEqual(a.decision_ref, buildDecisionRefV1({
     action_ref: hex('a'), authority_state: { scope: ['write'], revoked: false },
     policy_input: { id: 'p1', version: '1' }, decision_context: { tenant: 't1' },
-    decision_output: { verdict: 'permit', constraints: [] },
+    decision_output: KAT_OUTPUT,
   }).decision_ref)
 })
 
@@ -130,4 +134,42 @@ test('core decision output binds valid_until into the hashed preimage', () => {
   const { valid_until: _omitted, ...missing } = permit
   assert.throws(() => normalizeCoreDecisionOutputV1(missing as never), /valid_until/)
   assert.throws(() => normalizeCoreDecisionOutputV1({ ...permit, valid_until: '2026-04-08T12:00:05Z' } as never), /valid_until/)
+})
+
+const BUILDER_PLACEHOLDERS = {
+  action_ref: hex('a'),
+  authority_state: { scope: ['read'], revoked: false } as never,
+  policy_input: { id: 'p1', version: '1' } as never,
+  decision_context: { tenant: 't1' } as never,
+}
+const CASE1_OUTPUT = { profile: 'aps-core-decision-output-v1' as const, verdict: 'permit' as const, effective_authority_ref: '3f2a1c9d8e7b6a5f4e3d2c1b0a9f8e7d6c5b4a39281706f5e4d3c2b1a0987654', constraints: ['commerce:read'], valid_until: '2026-04-08T12:00:05.000Z' }
+
+test('buildDecisionRefV1 end-to-end binds the normalized five-member output', () => {
+  const built = buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: CASE1_OUTPUT })
+  assert.equal(built.input.decision_output_ref, '4226e417c01f4d395db503bfcc00a2e022f5f864568b5fb2b88eefe4fbd0c551')
+  assert.equal(built.decision_ref, '8a9595fd9d7caf15654fca34816e22d02562f9db16dcc7d5958b906541dce8de')
+})
+
+test('buildDecisionRefV1 rejects every malformed decision output', () => {
+  const { valid_until: _dropped, ...missingValidUntil } = CASE1_OUTPUT
+  assert.throws(() => buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: missingValidUntil as never }), /valid_until/)
+  assert.throws(() => buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: { ...CASE1_OUTPUT, valid_until: '2026-04-08T12:00:05Z' } }), /valid_until/)
+  assert.throws(() => buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: { profile: 'aps-core-decision-output-v1', verdict: 'deny', effective_authority_ref: null, constraints: [], valid_until: '2026-04-08T12:00:05.000Z' } }), /valid_until/)
+  assert.throws(() => buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: { ...CASE1_OUTPUT, valid_until: null } as never }), /valid_until/)
+  assert.throws(() => buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: { ...CASE1_OUTPUT, extra: 'nope' } as never }), /unknown field extra/)
+})
+
+test('decision_ref changes when only valid_until changes', () => {
+  const a = buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: CASE1_OUTPUT })
+  const b = buildDecisionRefV1({ ...BUILDER_PLACEHOLDERS, decision_output: { ...CASE1_OUTPUT, valid_until: '2026-04-08T12:00:06.000Z' } })
+  assert.notEqual(a.decision_ref, b.decision_ref)
+  assert.equal(b.decision_ref, '7c45ce5ecfa8f8aa1bd249513c73c81b31eb193b236dfe50530d58b598c388eb')
+})
+
+// Hash primitive test, not a conformance path test. computeDecisionComponentRefV1 is the
+// low-level primitive and takes an already-normalized I-JSON value.
+test('computeDecisionComponentRefV1 hashes an arbitrary I-JSON value', () => {
+  const digest = computeDecisionComponentRefV1('context', { tenant: 't1', nested: [1, 2, 3] } as never)
+  assert.ok(/^[0-9a-f]{64}$/.test(digest))
+  assert.equal(digest, computeDecisionComponentRefV1('context', { nested: [1, 2, 3], tenant: 't1' } as never))
 })

--- a/tests/receipt-core-v1.test.ts
+++ b/tests/receipt-core-v1.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { publicKeyFromPrivate } from '../src/crypto/keys.js'
-import { buildDecisionRefV1, normalizeCoreDecisionOutputV1 } from '../src/v2/receipt-core/decision-ref.js'
+import { buildDecisionRefV1, computeDecisionComponentRefV1, normalizeCoreDecisionOutputV1 } from '../src/v2/receipt-core/decision-ref.js'
 import { createReceiptV1, computeReceiptIdV1, verifyReceiptV1 } from '../src/v2/receipt-core/receipt.js'
 import { parseStrictIJson, strictJCS } from '../src/v2/receipt-core/jcs.js'
 import { buildEvidenceBundleBodyV2, buildEvidenceBundleProofV2, classifySupportingRecordFormat, createSupportingRecordV1, verifyEvidenceBundleBodyV2, verifyEvidenceBundleProofV2, verifySupportingRecordV1 } from '../src/v2/receipt-core/supporting-record.js'
@@ -46,7 +46,7 @@ test('decision_ref is content-derived and event fields cannot enter it', () => {
 })
 
 test('core decision output normalizes a set of constraints', () => {
-  const out = normalizeCoreDecisionOutputV1({ profile: 'aps-core-decision-output-v1', verdict: 'narrow', effective_authority_ref: hex('b'), constraints: ['é', 'read', 'e\u0301', 'read'] })
+  const out = normalizeCoreDecisionOutputV1({ profile: 'aps-core-decision-output-v1', verdict: 'narrow', effective_authority_ref: hex('b'), constraints: ['é', 'read', 'e\u0301', 'read'], valid_until: '2026-04-08T12:00:05.000Z' })
   assert.deepEqual(out.constraints, ['read', 'é'])
 })
 
@@ -113,4 +113,21 @@ test('legacy dispatch is explicit and never guesses from canonical bytes', () =>
   assert.throws(() => strictJCS({ integer: 9007199254740992 }), /IEEE 754/)
   assert.throws(() => parseStrictIJson('{"a":1,"\\u0061":2}'), /duplicate object member/)
   assert.equal(strictJCS(parseStrictIJson('{"a":null}')), '{"a":null}')
+})
+
+test('core decision output binds valid_until into the hashed preimage', () => {
+  const permit = { profile: 'aps-core-decision-output-v1' as const, verdict: 'permit' as const, effective_authority_ref: hex('b'), constraints: ['commerce:read'], valid_until: '2026-04-08T12:00:05.000Z' }
+  const first = computeDecisionComponentRefV1('output', normalizeCoreDecisionOutputV1(permit) as never)
+  const later = computeDecisionComponentRefV1('output', normalizeCoreDecisionOutputV1({ ...permit, valid_until: '2026-04-08T12:00:06.000Z' }) as never)
+  assert.notEqual(first, later)
+
+  const deny = normalizeCoreDecisionOutputV1({ profile: 'aps-core-decision-output-v1', verdict: 'deny', effective_authority_ref: null, constraints: [], valid_until: null })
+  assert.equal(deny.valid_until, null)
+  assert.ok(/^[0-9a-f]{64}$/.test(computeDecisionComponentRefV1('output', deny as never)))
+
+  assert.throws(() => normalizeCoreDecisionOutputV1({ ...permit, valid_until: null } as never), /valid_until/)
+  assert.throws(() => normalizeCoreDecisionOutputV1({ profile: 'aps-core-decision-output-v1', verdict: 'deny', effective_authority_ref: null, constraints: [], valid_until: '2026-04-08T12:00:05.000Z' } as never), /valid_until/)
+  const { valid_until: _omitted, ...missing } = permit
+  assert.throws(() => normalizeCoreDecisionOutputV1(missing as never), /valid_until/)
+  assert.throws(() => normalizeCoreDecisionOutputV1({ ...permit, valid_until: '2026-04-08T12:00:05Z' } as never), /valid_until/)
 })


### PR DESCRIPTION
## What this changes

The core decision output becomes a closed five-member object and its digest path is enforced.

1. `fix(receipt-core): bind valid_until in CoreDecisionOutputV1`. The output object is exactly `profile`, `verdict`, `effective_authority_ref`, `constraints`, `valid_until`. `valid_until` is required: an RFC 3339 UTC millisecond timestamp for `permit` and `narrow`, exactly `null` for `deny`. Draft -03 specifies the member; the prior code accepted outputs without it.

2. `fix(receipt-core): enforce normalize-before-hash in decision_ref construction`. The builder normalizes the decision output at runtime before hashing, so an unnormalized or malformed output cannot reach the digest through the construction path. `computeDecisionComponentRefV1` is documented as the internal primitive that expects already normalized input.

Python and Go additionally carry `feat(receipt-core): port receipt-core v1 module` as the first commit: receipt-core previously existed only in the TypeScript repository, and the fixes land on top of the port. In Go the builder takes the typed `CoreDecisionOutputV1` struct, which turns the old opaque-value bypass into a compile error.

## Cross-language evidence

Five decision outputs through the builder in TypeScript, Python, and Go: 5/5 component digests match and 5/5 full `decision_ref` values match, including an NFC-decomposed constraint and a supplementary-plane (U+1F600) constraint. Five malformed outputs rejected in all three; the unknown-extra-member case is unrepresentable in Go and fails at compile time. One known-answer test per language pinned the previous digest shape and is repinned here: the pinned `decision_ref` moves from `2157809a…` to `e474f27b…`, identical across the three languages, and the new component digest reproduces from stock JSON and SHA-256 libraries with no repository code.

Suites at these heads: TypeScript 4351 passed, 0 failed; Python 762 passed; Go all packages ok. All exit 0.

## Boundary, stated plainly

This PR does not claim conformance. Three gates remain open and are tracked as follow-up work: the receipt-level relation that `valid_until` must be later than the receipt's `issued_at` (the receipt carries `decision_ref` as a digest, so neither validator currently sees both operands; the enforcement point is a design decision in progress), dispatch-level enforcement, and strict raw duplicate-member parsing. receipt-core remains unexported from the public API in all three repositories. Merged means the construction path is specified and tested, not that the semantic core is fully conformant.

Sibling PRs: https://github.com/aeoess/agent-passport-python/pull/4, https://github.com/aeoess/agent-passport-go/pull/5
