### PR TITLE
fix(runtime): clear spec section for aws-other

### DIFF
--- a/packages/aps-sdk-runtime/src/lib.rs
+++ b/packages/aps-sdk-runtime/src/lib.rs
@@ -806,7 +806,7 @@ pub struct EnvSnapshot {
 /// Labels:
 /// - `mac-apple-silicon` (§13.3) on macOS
 /// - `aws-c7i-gp3` (§13.2) on AWS EC2 when IMDSv2 reports c7i.2xlarge
-/// - `aws-other` (§13.2) on any other EC2 instance type
+/// - `aws-other` (no spec section) on any other EC2 instance type
 /// - `bare-metal-linux` (§13.1) on Linux with no hypervisor
 /// - `linux-vm` (no spec section) on Linux with a non-AWS hypervisor
 /// - `unknown` on any other platform
@@ -855,6 +855,29 @@ fn capture_mac() -> EnvSnapshot {
     }
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn classify_aws_instance_type(instance_type: &str) -> (String, String, bool) {
+    if instance_type == "c7i.2xlarge" {
+        ("aws-c7i-gp3".to_string(), "13.2".to_string(), false)
+    } else {
+        ("aws-other".to_string(), String::new(), false)
+    }
+}
+
+#[cfg(test)]
+mod environment_capture_tests {
+    use super::classify_aws_instance_type;
+
+    #[test]
+    fn aws_other_does_not_claim_reference_spec_section() {
+        let (label, spec_section, canonical) = classify_aws_instance_type("t3.micro");
+
+        assert_eq!(label, "aws-other");
+        assert_eq!(spec_section, "");
+        assert!(!canonical);
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn capture_linux() -> EnvSnapshot {
     let sys_vendor = read_trim("/sys/class/dmi/id/sys_vendor");
@@ -862,11 +885,7 @@ fn capture_linux() -> EnvSnapshot {
 
     let (label, spec_section, canonical) = if sys_vendor == "Amazon EC2" {
         let instance_type = imdsv2_instance_type();
-        if instance_type == "c7i.2xlarge" {
-            ("aws-c7i-gp3".to_string(), "13.2".to_string(), false)
-        } else {
-            ("aws-other".to_string(), "13.2".to_string(), false)
-        }
+        classify_aws_instance_type(&instance_type)
     } else if hypervisor.is_empty() || hypervisor == "none" {
         ("bare-metal-linux".to_string(), "13.1".to_string(), true)
     } else {


### PR DESCRIPTION
## Summary

Closes #37.

`captureEnvironment()` now leaves `specSection` empty for EC2 environments classified as `aws-other`. The adjacent label documentation reflects the same contract, while the `aws-c7i-gp3` reference path continues to emit `specSection="13.2"`.

A small pure classifier makes the AWS instance-type decision testable without live EC2 metadata. The regression test uses `t3.micro` and fails against the previous implementation with `left: "13.2", right: ""`.

## What this proves

The SDK no longer associates environments classified as `aws-other` with §13.2 through `specSection`.

## What this does not prove

This change does not validate IMDSv2 behavior on a live EC2 host and does not modify the benchmark reference implementation. It only tests and corrects the classification performed after the instance type has been read.

## Verification

- Regression test demonstrated failing before the fix and passing after it
- `npm run build`
- `npm test` — 4,361 tests, 4,352 passed, 9 skipped, 0 failed
- `cargo test --offline -p aps-sdk-runtime-native` — 7 passed
- `cargo clippy --offline -p aps-sdk-runtime-native --all-targets -- -D warnings`
- `cargo check --offline -p aps-sdk-runtime-native --target x86_64-unknown-linux-musl`

## Checklist

- [x] **Signed-off-by (DCO) — required.** Every commit in this PR is signed off (`git commit -s`).
