### PR TITLE
chore(deps): group codeql-action bumps and pin @types/node to the supported floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,22 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # Type definitions track the lowest supported runtime (engines: node >=18,
+      # CI runs 20), not the newest Node release. Major bumps here would put the
+      # type floor above the runtime floor we publish and test. See PR #90.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      # init and analyze live in the same workflow and must resolve to the same
+      # version; CodeQL fails with "Loaded a configuration file for version X,
+      # but running version Y" when they split across separate PRs. See #97/#100.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
Two dependabot behaviours produced avoidable failures this week.

`codeql-action/init` and `codeql-action/analyze` live in the same workflow and must resolve to the same version. Dependabot opened them as separate PRs (#100, #97), so each one alone left the pair split and CodeQL failed with `Loaded a configuration file for version '4.37.6', but running version '4.37.3'`. Grouping the pattern keeps them in one PR.

`@types/node` majors track the newest Node release, but the type floor should track the lowest runtime this package supports: `engines` declares `node >=18` and CI runs 20. #90 would have put the types five majors above the tested runtime, letting code typecheck against APIs absent at run time. Majors are ignored; the 20.x line still receives minor and patch updates.

YAML validated: parses, both ecosystems intact, group and ignore blocks read back correctly.
