### PR TITLE
fix(cli): validate delegate numeric flags as decimal, reject NaN depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.3.1 (2026-08-15)
+
+### Behavior change
+- **The `delegate` numeric flags accept canonical decimal only.** `--limit`, `--depth` and `--hours` were parsed with `Number()`, which accepts every literal form JavaScript accepts. `--limit 0x64` therefore signed a spend cap of one hundred while reading as sixty-four to a human and to every base-10 parser, and the same coercion accepted `1e3`, `+5`, `5.`, `.5` and a value padded with spaces. These flags carry authority, so the accepted grammar is now an optional minus, digits, and an optional fractional part. Hexadecimal, octal and binary literals, exponent form, a leading plus, a bare leading or trailing dot, and surrounding whitespace now exit non-zero and write no delegation. Input that previously produced an artifact now fails, and only non-decimal spellings are affected: `500`, `0`, `0.5` and `007` are unchanged. The documented forms in the usage string were already canonical.
+- **A numeric flag supplied without a value is an error rather than a silent default.** `--depth ""`, `--hours ""` and either flag given as the last argument with nothing after it previously fell through to the default and signed it. `getFlag` returns `undefined` both for an absent flag and for one supplied without a value, so the two cases were indistinguishable. Presence is now tested directly and a valueless flag exits non-zero. Omitting a flag entirely still applies its documented default.
+
+### Fixed
+- **`delegate --depth` no longer signs a delegation with no depth ceiling.** `Number('abc')` is `NaN`, `NaN` passed `maxDepth: opts.maxDepth ?? 1` unchanged because `NaN` is not nullish, and `JSON.stringify` emits `null` for `NaN`. The signed artifact carried `maxDepth: null`. Chain verifiers guard the depth rule on the ceiling being present, so a null removed the delegation depth bound instead of tightening it: a typo widened authority. `maxDepth` has no validation in `createDelegation` the way `spendLimit` does, so the command line was the only gate. `--depth` now requires a non-negative integer and rejects `abc`, `1.5` and `-1`.
+- **`delegate --limit 0` no longer signs a delegation with no spend cap.** The flag was coerced with `Number()` and then passed through a trailing truthiness fallback, and both `0` and `NaN` are falsy, so an explicit zero, a non-numeric value, an empty value and a bare `--limit` all resolved to `undefined`, which means unbounded. An operator asking for a budget of nothing received unbounded authority at exit code 0, and the `Limit:` line in the success output was itself guarded by a truthiness check, so the omission was not printed. `--limit 0` now signs `spendLimit: 0`.
+
 ## 4.3.0 (2026-07-26)
 
 ### Behavior change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,4 +8,4 @@ The same content applies whether you are Claude Code, another coding agent, or a
 
 ---
 
-**Current SDK version: 4.2.0 (stable, npm latest).** This anchor is maintained manually until the propagation pipeline is rewired (the canonical web repo is `aps-web` per SURFACES.md, and its `project-state.json` is the read-only reference). If you see drift here, update this line by hand and report it; do not run any propagation script.
+**Current SDK version: 4.3.1 (staged for release, npm latest is 4.3.0).** This anchor is maintained manually until the propagation pipeline is rewired (the canonical web repo is `aps-web` per SURFACES.md, and its `project-state.json` is the read-only reference). If you see drift here, update this line by hand and report it; do not run any propagation script.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-passport-system",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Verifier hot path p50 = 420ns bare-metal Linux EPYC 7313P (§13.1 canonical environment per spec), 347ns AWS c7i.2xlarge, 292ns Mac M3. Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). 4,361 tests.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -128,6 +128,15 @@ function askYesNo(question: string): Promise<boolean> {
 // ── CLI Router ──
 
 const args = process.argv.slice(2)
+
+// Canonical decimal only: an optional minus, digits, and an optional fractional part.
+// This rejects hexadecimal, octal and binary literals, exponent form, a leading plus,
+// surrounding whitespace, and a bare leading or trailing dot. `0x64` reads as
+// sixty-four to a human and to every base-10 parser while Number() evaluates it to one
+// hundred, and these flags carry authority, so an ambiguity that large is not accepted.
+// Declared here, above the command dispatch below, because a `const` is not hoisted and
+// the dispatch calls the command functions during module evaluation.
+const CANONICAL_DECIMAL = /^-?[0-9]+(?:\.[0-9]+)?$/
 const command = args[0]
 
 switch (command) {
@@ -615,30 +624,21 @@ function cmdDelegate(): void {
   const agent = loadAgent()
   const toKey = getFlag('--to')
   const scope = getFlag('--scope')?.split(',')
-  // --limit is authority-bearing, so it resolves to exactly one of three outcomes:
-  // ABSENT (no spend cap), a VALID non-negative finite number, or a TYPED ERROR.
-  // It is never collapsed through a truthiness operator. The previous version coerced
-  // the flag with Number(...) and then discarded every falsy result through a trailing
-  // truthiness fallback, so an explicit zero, a non-numeric value, an empty value and a
-  // bare `--limit` all became undefined and signed a delegation with NO cap at all.
-  // getFlag cannot tell an absent flag from one supplied without a value, so presence
-  // is tested against args directly.
-  let limit: number | undefined
-  if (args.includes('--limit')) {
-    const rawLimit = getFlag('--limit')
-    if (rawLimit === undefined || rawLimit.trim() === '') {
-      console.error('❌ --limit requires a value: a non-negative finite number. Use --limit 0 for a zero spend cap.')
-      process.exit(1)
-    }
-    const parsedLimit = Number(rawLimit)
-    if (!Number.isFinite(parsedLimit) || parsedLimit < 0) {
-      console.error(`❌ --limit must be a non-negative finite number, got "${rawLimit}"`)
-      process.exit(1)
-    }
-    limit = parsedLimit
-  }
-  const hours = Number(getFlag('--hours') || '24')
-  const depth = Number(getFlag('--depth') || '1')
+  const limit = numericFlag('--limit', 'a non-negative number, 0 for a zero spend cap',
+    n => Number.isFinite(n) && n >= 0)
+  // Zero, fractional and negative hours are all accepted: createDelegation documents
+  // them as intended, computing an immediate expiry for 0 and a past expiry for a
+  // negative duration, and it avoids setHours precisely so fractional hours survive.
+  const hoursFlag = numericFlag('--hours', 'a finite number of hours',
+    n => Number.isFinite(n))
+  // maxDepth has NO downstream validation in createDelegation, unlike spendLimit, so
+  // this is the only gate. A non-integer depth is meaningless for a hop count, and a
+  // NaN depth serialized to `"maxDepth": null`, which chain verifiers read as no depth
+  // ceiling at all: a typo REMOVED the limit instead of failing.
+  const depthFlag = numericFlag('--depth', 'a non-negative integer',
+    n => Number.isInteger(n) && n >= 0)
+  const hours = hoursFlag ?? 24
+  const depth = depthFlag ?? 1
 
   if (!toKey || !scope) {
     console.error('Usage: passport delegate --to <publicKey> --scope <scope1,scope2> [--limit 500, 0 for a zero cap] [--hours 24] [--depth 1]')
@@ -1294,4 +1294,32 @@ function getFlag(flag: string): string | undefined {
   const idx = args.indexOf(flag)
   if (idx === -1 || idx + 1 >= args.length) return undefined
   return args[idx + 1]
+}
+
+/**
+ * Read an authority-bearing numeric flag as exactly one of three outcomes: ABSENT
+ * (the caller applies its own default), a VALID number, or a TYPED ERROR that exits
+ * non-zero. It is never collapsed through a truthiness operator and never passes an
+ * unparsed value downstream. `getFlag` cannot distinguish an absent flag from one
+ * supplied without a value, since both yield undefined, so presence is tested against
+ * `args` directly. `valid` carries the caller's domain rule, applied here so the raw
+ * text the operator typed can be quoted back in the error.
+ */
+function numericFlag(flag: string, hint: string, valid: (n: number) => boolean): number | undefined {
+  if (!args.includes(flag)) return undefined
+  const raw = getFlag(flag)
+  if (raw === undefined || raw.trim() === '') {
+    console.error(`❌ ${flag} requires a value: ${hint}`)
+    process.exit(1)
+  }
+  if (!CANONICAL_DECIMAL.test(raw)) {
+    console.error(`❌ ${flag} must be a canonical decimal number (${hint}), got "${raw}"`)
+    process.exit(1)
+  }
+  const parsed = Number(raw)
+  if (!valid(parsed)) {
+    console.error(`❌ ${flag} must be ${hint}, got "${raw}"`)
+    process.exit(1)
+  }
+  return parsed
 }

--- a/tests/cli-delegate-limit.test.ts
+++ b/tests/cli-delegate-limit.test.ts
@@ -48,10 +48,10 @@ function delegateWith(extra: string[]) {
   return { exit: r.status, out: (r.stdout || '') + (r.stderr || ''), artifact }
 }
 
-describe('CLI delegate --limit (D1)', () => {
+describe('CLI delegate numeric flags (--limit, --depth, --hours)', () => {
   before(() => {
-    dir = mkdtempSync(join(tmpdir(), 'aps-cli-limit-'))
-    const j = cli(['join', '--name', 'limit-test', '--mission', 'd1 test', '--owner', 'tima'])
+    dir = mkdtempSync(join(tmpdir(), 'aps-cli-numeric-'))
+    const j = cli(['join', '--name', 'numeric-test', '--mission', 'numeric flag test', '--owner', 'tima'])
     assert.equal(j.status, 0, `join failed: ${(j.stdout || '') + (j.stderr || '')}`)
     toKey = JSON.parse(readFileSync(join(dir, '.passport', 'agent.json'), 'utf8')).publicKey
     assert.ok(toKey, 'agent public key missing')
@@ -117,5 +117,101 @@ describe('CLI delegate --limit (D1)', () => {
     assert.equal(preFix(''), undefined, 'pre-fix: an empty value also became uncapped')
     assert.equal(preFix(undefined), undefined, 'pre-fix: absent and valueless were indistinguishable')
     assert.equal(preFix('500'), 500, 'pre-fix: only truthy numbers survived')
+  })
+
+  // ── --depth ──
+  // maxDepth has NO downstream validation in createDelegation, unlike spendLimit, so
+  // the CLI is the only gate.
+
+  // The decisive new case. `Number('abc')` is NaN, NaN reached createDelegation
+  // unvalidated, and JSON.stringify(NaN) emits null. Chain verifiers guard the depth
+  // rule on the ceiling being present, so a signed `maxDepth: null` REMOVED the depth
+  // bound rather than tightening it. A typo widened authority.
+  it('--depth abc exits non-zero and writes no artifact', () => {
+    const { exit, artifact } = delegateWith(['--depth', 'abc'])
+    assert.notEqual(exit, 0, 'a non-numeric depth must exit non-zero')
+    assert.equal(artifact, null, 'no delegation may be written for a rejected depth')
+  })
+
+  it('a valid --depth is carried through to maxDepth', () => {
+    const { exit, artifact } = delegateWith(['--depth', '5'])
+    assert.equal(exit, 0)
+    assert.ok(artifact, 'a delegation artifact must be written')
+    assert.strictEqual(artifact!.maxDepth, 5)
+  })
+
+  it('--depth 0 is a valid ceiling and is carried through', () => {
+    const { exit, artifact } = delegateWith(['--depth', '0'])
+    assert.equal(exit, 0, 'a zero depth ceiling is meaningful: no sub-delegation')
+    assert.strictEqual(artifact!.maxDepth, 0)
+  })
+
+  it('--depth absent keeps the default ceiling', () => {
+    const { exit, artifact } = delegateWith([])
+    assert.equal(exit, 0)
+    assert.strictEqual(artifact!.maxDepth, 1, 'omitting --depth must keep the documented default')
+  })
+
+  it('--depth never signs a null ceiling for any rejected input', () => {
+    for (const bad of ['abc', '1.5', '-1', '0x10', '1e3']) {
+      const { exit, artifact } = delegateWith(['--depth', bad])
+      assert.notEqual(exit, 0, `--depth ${bad} must exit non-zero`)
+      assert.equal(artifact, null, `--depth ${bad} must write no artifact`)
+    }
+  })
+
+  // ── --hours ──
+
+  it('--hours abc exits non-zero and writes no artifact', () => {
+    const { exit, artifact } = delegateWith(['--hours', 'abc'])
+    assert.notEqual(exit, 0, 'a non-numeric hours value must exit non-zero')
+    assert.equal(artifact, null, 'no delegation may be written for a rejected hours value')
+  })
+
+  it('--hours accepts a fractional value, which createDelegation supports exactly', () => {
+    const { exit, artifact } = delegateWith(['--hours', '0.5'])
+    assert.equal(exit, 0, 'fractional hours are deliberately supported downstream')
+    assert.ok(artifact, 'a delegation artifact must be written')
+    assert.ok(typeof artifact!.expiresAt === 'string' && artifact!.expiresAt.length > 0)
+  })
+
+  // ── decimal grammar, shared by all three flags ──
+  // `0x64` reads as sixty-four to a human and to every base-10 parser while Number()
+  // evaluates it to one hundred. On a spend cap that ambiguity is not acceptable.
+
+  it('--limit 0x64 exits non-zero and writes no artifact', () => {
+    const { exit, artifact } = delegateWith(['--limit', '0x64'])
+    assert.notEqual(exit, 0, 'a hexadecimal literal must be rejected, not read as 100')
+    assert.equal(artifact, null, 'no delegation may be written for a rejected limit')
+  })
+
+  it('non-decimal lexical forms are rejected on --limit', () => {
+    for (const bad of ['0x64', '1e3', '+5', '5.', '.5', ' 5 ']) {
+      const { exit, artifact } = delegateWith(['--limit', bad])
+      assert.notEqual(exit, 0, `--limit ${JSON.stringify(bad)} must exit non-zero`)
+      assert.equal(artifact, null, `--limit ${JSON.stringify(bad)} must write no artifact`)
+    }
+  })
+
+  it('canonical decimal values still work on --limit', () => {
+    for (const [raw, want] of [['0', 0], ['500', 500], ['0.5', 0.5], ['007', 7]] as const) {
+      const { exit, artifact } = delegateWith(['--limit', raw])
+      assert.equal(exit, 0, `--limit ${raw} must succeed`)
+      assert.strictEqual(artifact!.spendLimit, want, `--limit ${raw} must sign ${want}`)
+    }
+  })
+
+  // ── CONTROL for the depth defect ──
+  // If this ever stops holding, the description of the depth defect is wrong.
+  it('CONTROL: NaN depth serializes to a null ceiling', () => {
+    assert.ok(Number.isNaN(Number('abc')), "Number('abc') must be NaN")
+    assert.equal(
+      JSON.stringify({ maxDepth: Number('abc') }), '{"maxDepth":null}',
+      'JSON.stringify emits null for NaN, which is how a typo removed the depth ceiling',
+    )
+    // `??` is nullish, so NaN is NOT replaced by the default. This is why the NaN
+    // survived `maxDepth: opts.maxDepth ?? 1` in createDelegation.
+    const viaNullish = Number('abc') ?? 1
+    assert.ok(Number.isNaN(viaNullish), 'NaN survives ?? because NaN is not nullish')
   })
 })


### PR DESCRIPTION
## Summary

`passport delegate --depth abc` signed a delegation with **no depth ceiling**, and `--limit 0x64` signed a spend cap of one hundred while reading as sixty-four.

`Number('abc')` is `NaN`. `NaN` passed `maxDepth: opts.maxDepth ?? 1` unchanged because `NaN` is not nullish, and `JSON.stringify` emits `null` for `NaN`, so the signed artifact carried `maxDepth: null`. Chain verifiers guard the depth rule on the ceiling being present, so a null **removed** the depth bound rather than tightening it. A typo widened authority.

`maxDepth` has no validation in `createDelegation` the way `spendLimit` does, so the command line was the only gate.

### The rule

Each authority-bearing numeric flag now resolves to exactly one of three outcomes: **absent** (caller applies its documented default), a **valid** value, or a **typed error** that exits non-zero and writes no artifact. Never collapsed through a truthiness operator, never passing an unparsed value downstream. Implemented once in `numericFlag`, accepting canonical decimal only.

### Behavior changes, all previously defective

| input | before | after |
|---|---|---|
| `--depth abc` | signed `maxDepth: null` | exits 1 |
| `--depth -1`, `1.5` | signed as given | exits 1 |
| `--depth 0x10`, `1e3` | signed 16, 1000 | exits 1 |
| `--limit 0x64` | signed 100 | exits 1 |
| valueless flag | silently defaulted | exits 1 |

Preserved and verified: `--limit 0` signs `0`, `--depth 0` signs `0`, `--hours 0` gives immediate expiry, and `500`, `0.5`, `007` and every absent-flag default are unchanged.

`--hours` accepts zero, negative and fractional values deliberately: `createDelegation` documents them as intended, and both produce an already-expired delegation, which is the restrictive direction.

### Tests

Extends `tests/cli-delegate-limit.test.ts` to the whole flag class, asserting on the **signed artifact** rather than an intermediate. 11 new cases. Control: 4 fail against `2aed5d4`, 17 pass after, with `--hours abc` passing in both runs since it was never defective.

Full suite: 4378 tests, 4377 passing, 0 failures. `npm audit --audit-level=high` exits 0.

### Release

Version bumped to 4.3.1 with a CHANGELOG entry covering this and the `--limit` fix from #105. Tag push publishes.

## Checklist

- [x] **Signed-off-by (DCO) — required.** Every commit in this PR is signed off (`git commit -s`) per the [Developer Certificate of Origin](https://developercertificate.org/).