### PR TITLE
docs: README and package description carry the 4.3.1 suite counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ APS lets a person or company give an AI agent limited authority to act on its be
 
 [![npm version](https://img.shields.io/npm/v/agent-passport-system)](https://www.npmjs.com/package/agent-passport-system)
 [![license](https://img.shields.io/npm/l/agent-passport-system)](https://github.com/aeoess/agent-passport-system/blob/main/LICENSE)
-[![tests](https://img.shields.io/badge/tests-4361%20passing%20%2F%204361-brightgreen)](https://github.com/aeoess/agent-passport-system)
+[![tests](https://img.shields.io/badge/tests-4377%20passing%20%2F%204378-brightgreen)](https://github.com/aeoess/agent-passport-system)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18749779.svg)](https://doi.org/10.5281/zenodo.18749779)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13536/badge)](https://www.bestpractices.dev/projects/13536)
 [![OpenSSF Baseline](https://www.bestpractices.dev/projects/13536/baseline)](https://www.bestpractices.dev/projects/13536)
@@ -249,7 +249,7 @@ The composition contract specifies how a verifier MUST cross-check per-request s
 
 ## Numbers
 
-4,361 tests. 8 protocol layers. Framework adapters for CrewAI, LangChain, ADK, A2A, MCP, OpenShell, IBAC, Gonka. Gateway evaluation under 2ms. Zero heavy dependencies. Apache-2.0.
+4,378 tests. 8 protocol layers. Framework adapters for CrewAI, LangChain, ADK, A2A, MCP, OpenShell, IBAC, Gonka. Gateway evaluation under 2ms. Zero heavy dependencies. Apache-2.0.
 
 The test count is one number derived from the suite, not three guesses. The badge above, this section, and the `package.json` description all carry the same `4,326`, which is the `tests` total reported by `npm test`. When the suite grows, re-run `npm test`, read the `tests` line, and update all three to match.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-passport-system",
   "version": "4.3.1",
-  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Verifier hot path p50 = 420ns bare-metal Linux EPYC 7313P (§13.1 canonical environment per spec), 347ns AWS c7i.2xlarge, 292ns Mac M3. Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). 4,361 tests.",
+  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Verifier hot path p50 = 420ns bare-metal Linux EPYC 7313P (§13.1 canonical environment per spec), 347ns AWS c7i.2xlarge, 292ns Mac M3. Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). 4,378 tests.",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Badge to 4377 passing / 4378 registered, prose and package.json description to 4,378 tests. Counts from the suite on c75b27e: tests 4378, pass 4377, fail 0, skipped 1. No code change.