### PR TITLE
Description states what the package is, not what the numbers are

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-passport-system",
   "version": "4.4.0",
-  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Verifier hot path p50 = 420ns bare-metal Linux EPYC 7313P (\u00a713.1 canonical environment per spec), 347ns AWS c7i.2xlarge, 292ns Mac M3. Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). 4,500 tests.",
+  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). Benchmarks and suite counts live in the README, which ships with this package.",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Removes the three benchmark figures and the test count from the npm description.

A package description is immutable between releases, so any mutable fact placed there is wrong the moment the number moves and can only be corrected by shipping a version. This package has already lived that: the description carried `4,361 tests` through three releases of drift before being corrected this morning.

Two sibling packages were worse. The MCP description said it tracks SDK v3.3.0 while depending on 4.4.0, and PyPI claimed parity with npm v3.3.0. Both named a version two majors behind, and both were republished today carrying it.

The numbers move to the README, which ships inside the tarball, renders on the npm page, and is already a propagation target with working patterns. Generating the description instead was considered and rejected: it would make the wrong thing accurate more often without removing the failure class.

A guard now fails any release that puts a count, version or benchmark back into published metadata, wired into the weekly self-check as category G3 and negative-tested in both directions.