### PR TITLE
Description under the registry ceiling, retired phrasing out, paper list complete

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -52,4 +52,5 @@ Ed25519 ActionReceipt, AuthorityBoundaryReceipt, CustodyReceipt, ContestabilityR
 - Governance in the Medium: https://doi.org/10.5281/zenodo.19582550
 - Cognitive Attestation: https://doi.org/10.5281/zenodo.19646276
 - The Evidence-Safety Gap: https://doi.org/10.5281/zenodo.19914628
+- Plausibly Wrong: https://doi.org/10.5281/zenodo.21208555
 - IETF Internet-Draft: draft-pidlisnyi-aps-01

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-passport-system",
   "version": "4.4.0",
-  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, Bayesian reputation, wallet binding, unified four-axis attribution primitive, per-period attribution settlement, data lifecycle, mutual authentication, Wave 1 accountability primitives (action, authority-boundary, custody, contestability, bundle), evidentiary type safety (claim/evidence registry, claim verifier with forbidden-substitution detection, contestation cascade). Benchmarks and suite counts live in the README, which ships with this package.",
+  "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, earned reputation, wallet binding, attribution, signed receipts.",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Three corrections from the claims audit.

**Retired phrasing.** The description carried `Bayesian reputation`, which `project-state.json` `language_replacements` retires in favour of `earned reputation`. It survived a rewrite done earlier the same day with the canonical file open, because that rewrite was checking numbers and versions rather than wording. The guard now covers retired phrasing too.

**The registry ceiling, which is a new finding.** npm publishes only the first 255 characters of a description. Verified against the registry API rather than the CLI: published 4.3.0, 4.3.1 and 4.4.0 are each exactly 255 characters, and 4.4.0 ends mid-sentence at `292ns Mac M3.`. So the 635-character local string was a different artifact from the text users actually read, and roughly 60 percent of it, including the test count, was never published at all. The description is now 246 characters and the two agree. The guard enforces the ceiling.

**Paper list.** `llms.txt` was missing `zenodo.21208555`. The count had an owner in `papers[]`; the list did not, so nothing delivered new entries to consuming files. Four files across four repos were short. `project-state.json` now also records `third_party_citations` and the membership rule, because the UBC preprint cited in `llms-full.txt` is ours to cite and not ours to count.