### PR TITLE
Capture the gateway policy-eval benchmark so its numbers can be published

### DIFF
--- a/benchmarks/gateway/2026-08-20/METHODOLOGY.md
+++ b/benchmarks/gateway/2026-08-20/METHODOLOGY.md
@@ -1,0 +1,65 @@
+# Gateway policy evaluation, 2026-08-20
+
+## What this measures
+
+The full gateway authorization path in TypeScript: signature verification, scope check,
+reputation, hybrid logical clock, and every enforcement constraint, end to end in one
+process. `tests/benchmark-gateway.ts`, 500 iterations per scenario after 10 warmup calls.
+
+This is NOT the L0 verifier hot path. That lives in `benchmarks/prototype-1/results/` and
+is measured in nanoseconds across three canonical environments. Two different layers, two
+different numbers, and conflating them would overstate both.
+
+## Environment
+
+Apple M3, 8 cores, macOS 26.5, Node v24.11.1, SDK 4.4.0 at commit
+`1f79817504a394d5e6cedb546451357c188a2236`. Full record in `env_capture.json`.
+
+DEVELOPER MACHINE, NOT CANONICAL. The three canonical environments are defined in spec
+sections 13.1 (bare metal Linux), 13.2 (AWS c7i.2xlarge) and 13.3 (Apple Silicon
+reference) and each has its own captured environment. This run is none of them. Every
+public claim derived from this file names the machine, per the CLAIMS.md rule that a
+performance claim pins to the measured cpu_model.
+
+## Results
+
+Three consecutive runs, same machine, same commit.
+
+| scenario | p50 | p95 | p99 |
+|---|---|---|---|
+| minimal, signature and scope only | 0.13 to 0.14 ms | 0.15 to 0.17 ms | 0.19 to 0.23 ms |
+| standard, plus reputation and HLC | 0.13 to 0.14 ms | 0.15 to 0.16 ms | 0.19 to 0.23 ms |
+| full enforcement | 0.132 to 0.140 ms | 0.15 ms | 0.156 to 0.161 ms |
+| burst, 100 sequential | 0.139 ms | 0.15 ms | 0.16 ms |
+| denied path | 0.075 ms | 0.086 ms | 0.11 ms |
+
+Burst throughput: 7,147, 7,275 and 7,167 ops per second.
+
+## What gets published, and the rule
+
+Published values take the CONSERVATIVE end of the observed range: the slowest p50 and the
+lowest throughput across the three runs, never the best sample.
+
+    policy evaluation p50    0.14 ms
+    burst throughput         7,100 ops/sec, single process, Apple M3
+
+Two properties worth stating because they are the interesting part. Full enforcement costs
+essentially nothing over signature and scope alone, so the constraint stack is not where
+the time goes. And the denied path is roughly twice as fast as the allow path, which is
+the evaluation order working as designed: the cheapest checks run first, so a refusal
+exits early.
+
+## What this supersedes
+
+`403 ops/sec`, which sat in `.well-known/mcp.json` and `llms-full.txt` for months with no
+environment record and no reproduction path. The same harness on the same code path now
+reports roughly eighteen times that. The old figure was not wrong so much as unowned, and
+it understated the system badly.
+
+## Reproducing
+
+    cd ~/agent-passport-system
+    NODE_ENV=development npx tsx tests/benchmark-gateway.ts
+
+Anyone can run it. If the number moves, this directory gets a new dated sibling rather
+than an edit, so the history stays readable.

--- a/benchmarks/gateway/2026-08-20/env_capture.json
+++ b/benchmarks/gateway/2026-08-20/env_capture.json
@@ -1,0 +1,16 @@
+{
+  "environment_tag": "mac-apple-silicon-dev",
+  "canonical": false,
+  "spec_section": null,
+  "note": "Developer machine, NOT one of the three canonical environments in spec sections 13.1, 13.2 and 13.3. Any claim derived from this file must name the machine.",
+  "cpu_model": "Apple M3",
+  "cpu_cores": "8",
+  "ram_bytes": "17179869184",
+  "os": "Darwin 25.5.0",
+  "os_product_version": "26.5",
+  "node_version": "v24.11.1",
+  "npm_version": "11.6.2",
+  "sdk_commit": "1f79817504a394d5e6cedb546451357c188a2236",
+  "sdk_version": "4.4.0",
+  "captured_at": "2026-08-20T20:05:44.366100Z"
+}

--- a/benchmarks/gateway/2026-08-20/results.json
+++ b/benchmarks/gateway/2026-08-20/results.json
@@ -1,0 +1,106 @@
+{
+  "benchmark": "gateway policy evaluation, full enforcement path",
+  "harness": "tests/benchmark-gateway.ts",
+  "iterations_per_scenario": 500,
+  "warmup": 10,
+  "concurrency": "single process, sequential",
+  "runs": [
+    {
+      "run": 1,
+      "minimal": {
+        "p50_ms": 0.135,
+        "p95_ms": 0.152,
+        "p99_ms": 0.17
+      },
+      "standard": {
+        "p50_ms": 0.139,
+        "p95_ms": 0.143,
+        "p99_ms": 0.16
+      },
+      "full_enforcement": {
+        "p50_ms": 0.132,
+        "p95_ms": 0.143,
+        "p99_ms": 0.161
+      },
+      "burst": {
+        "p50_ms": 0.139,
+        "p95_ms": 0.141,
+        "p99_ms": 0.152
+      },
+      "denied": {
+        "p50_ms": 0.08,
+        "p95_ms": 0.081,
+        "p99_ms": 0.087
+      },
+      "burst_throughput_ops_sec": 7167
+    },
+    {
+      "run": 2,
+      "minimal": {
+        "p50_ms": 0.141,
+        "p95_ms": 0.157,
+        "p99_ms": 0.172
+      },
+      "standard": {
+        "p50_ms": 0.132,
+        "p95_ms": 0.142,
+        "p99_ms": 0.16
+      },
+      "full_enforcement": {
+        "p50_ms": 0.14,
+        "p95_ms": 0.142,
+        "p99_ms": 0.156
+      },
+      "burst": {
+        "p50_ms": 0.139,
+        "p95_ms": 0.142,
+        "p99_ms": 0.154
+      },
+      "denied": {
+        "p50_ms": 0.08,
+        "p95_ms": 0.082,
+        "p99_ms": 0.087
+      },
+      "burst_throughput_ops_sec": 7275
+    },
+    {
+      "run": 3,
+      "minimal": {
+        "p50_ms": 0.142,
+        "p95_ms": 0.157,
+        "p99_ms": 0.175
+      },
+      "standard": {
+        "p50_ms": 0.139,
+        "p95_ms": 0.144,
+        "p99_ms": 0.159
+      },
+      "full_enforcement": {
+        "p50_ms": 0.14,
+        "p95_ms": 0.143,
+        "p99_ms": 0.156
+      },
+      "burst": {
+        "p50_ms": 0.139,
+        "p95_ms": 0.146,
+        "p99_ms": 0.152
+      },
+      "denied": {
+        "p50_ms": 0.08,
+        "p95_ms": 0.082,
+        "p99_ms": 0.086
+      },
+      "burst_throughput_ops_sec": 7147
+    }
+  ],
+  "headline": {
+    "policy_eval_p50_ms": 0.14,
+    "burst_throughput_ops_sec": 7147,
+    "rule": "Published values take the CONSERVATIVE end of the observed range: the slowest p50 and the lowest throughput across three runs, never the best sample."
+  },
+  "supersedes": {
+    "claim": "403 ops/sec",
+    "note": "Published for months in .well-known/mcp.json and llms-full.txt with no environment record. The harness that produced it now reports an order of magnitude more on the same code path."
+  },
+  "generated_at": "2026-08-20T20:06:09.335662Z"
+}


### PR DESCRIPTION
The site carried `403 ops/sec` and `under 2ms` from a March run with no environment record and no reproduction path.

The harness still exists and still runs. Three runs today, same machine, same commit:

| scenario | p50 | p99 |
|---|---|---|
| full enforcement | 0.132 to 0.140 ms | 0.156 to 0.161 ms |
| denied path | 0.080 ms | 0.086 to 0.087 ms |

Burst throughput: 7,147, 7,275 and 7,167 ops per second. The published figure understated throughput by roughly eighteen times, and the `under 2ms` bound held by a factor of fifteen.

Deleting the stale number was the easy half and it left the site saying less than the truth. This captures it instead. `env_capture.json` records cpu_model, cores, RAM, OS, Node, SDK version and commit, matching the shape `prototype-1` uses. `results.json` holds all three runs. `METHODOLOGY.md` states what is measured, what it explicitly is not, and the publishing rule: the slowest p50 and the lowest throughput of the three runs, never the best sample.

Marked NOT canonical. This is a developer machine rather than one of the three environments in spec sections 13.1, 13.2 and 13.3, so every derived claim names the machine, per the CLAIMS.md rule that a performance claim pins to the measured cpu_model.

Two properties worth noting: full enforcement costs essentially nothing over signature and scope alone, and the denied path is about twice as fast as the allow path, which is the cheapest-checks-first evaluation order working as designed.