### PR TITLE
Name the JCS oracle at 4.0.0 and record what the major changed

### DIFF
--- a/.github/workflows/cross-impl-jcs.yml
+++ b/.github/workflows/cross-impl-jcs.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   byte-match:
-    name: SDK ↔ canonicalize@3.0.0 ↔ rfc8785@0.1.4
+    name: SDK ↔ canonicalize@4.0.0 ↔ rfc8785@0.1.4
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -53,7 +53,7 @@ jobs:
         # --require-hashes enforces the committed wheel/sdist SHA-256 hashes.
         run: pip install --require-hashes --no-deps -r .github/requirements/cross-impl-jcs.txt
 
-      - name: TS test, SDK canonicalizeJCS vs canonicalize@3.0.0 (erdtman)
+      - name: TS test, SDK canonicalizeJCS vs canonicalize@4.0.0 (erdtman)
         run: npm run test:cross-impl
 
       - name: Python test, rfc8785@0.1.4 vs pinned manifest
@@ -100,7 +100,7 @@ jobs:
         # all three agree by transitivity. This step prints the summary
         # line so the conformance signal is visible at a glance in CI logs.
         run: |
-          echo "TS test:  SDK canonicalizeJCS ≡ canonicalize@3.0.0 (erdtman, RFC 8785 author)"
+          echo "TS test:  SDK canonicalizeJCS ≡ canonicalize@4.0.0 (erdtman, RFC 8785 author)"
           echo "Py test:  rfc8785@0.1.4 ≡ pinned manifest"
-          echo "Pinned:   manifest pinned to canonicalize@3.0.0 + rfc8785@0.1.4 byte-match"
-          echo "Therefore SDK ≡ canonicalize@3.0.0 ≡ rfc8785@0.1.4 byte-for-byte."
+          echo "Pinned:   manifest pinned to canonicalize@4.0.0 + rfc8785@0.1.4 byte-match"
+          echo "Therefore SDK ≡ canonicalize@4.0.0 ≡ rfc8785@0.1.4 byte-for-byte."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-passport-system",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-passport-system",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "libsodium-wrappers": "^0.8.4",
@@ -60,6 +60,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1358,6 +1359,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",

--- a/tests/cross-impl/gen-vectors.py
+++ b/tests/cross-impl/gen-vectors.py
@@ -3,7 +3,7 @@
 """Generate pinned expected canonical bytes + SHA-256 from rfc8785@0.1.4.
 
 This produces a JSON manifest that the SDK's cross-impl test asserts against
-in BOTH TypeScript and Python. The Node-side reference (canonicalize@3.0.0)
+in BOTH TypeScript and Python. The Node-side reference (canonicalize@4.0.0)
 must produce byte-identical output; the SDK's strict-JCS impl
 (canonicalHashJCS in TS, canonicalize_jcs in Python) must too.
 """

--- a/tests/cross-impl/jcs-equivalence.test.ts
+++ b/tests/cross-impl/jcs-equivalence.test.ts
@@ -11,10 +11,19 @@
 //   2. SHA-256(canonicalizeJCS(input))      — what computeActionRef and
 //      computeAttributionActionRef hash through — matches the pinned
 //      SHA-256.
-//   3. canonicalize@3.0.0(input)            — erdtman's reference impl
+//   3. canonicalize@4.0.0(input)            — erdtman's reference impl
 //      (one of the RFC 8785 authors) — matches the pinned canonical
 //      bytes byte-for-byte.
-//   4. SHA-256(canonicalize@3.0.0(input))   — matches the pinned SHA-256.
+//   4. SHA-256(canonicalize@4.0.0(input))   — matches the pinned SHA-256.
+//
+// Oracle pin moved 3.0.0 -> 4.0.0 on 2026-08-20. Verified before taking it:
+// all 12 pinned vectors are byte-identical under both versions and both match
+// the pinned bytes. An 18-case adversarial probe found exactly one behavioural
+// difference: 3.0.0 emitted a lone UTF-16 surrogate silently as \ud800, and
+// 4.0.0 rejects it. canonicalizeJCS already rejected lone surrogates with a
+// `lone_surrogate` reason, so that divergence existed under 3.0.0 and was
+// untested in both directions. 4.0.0 closes it. The pin stays exact, never a
+// caret: an oracle that can move under you is not an oracle.
 //
 // If any vector fails, either the SDK has drifted from strict RFC 8785,
 // or the external reference has drifted, or the pinned vectors are stale.
@@ -24,7 +33,7 @@
 //
 // CI runs both this test and a parallel Python step that exercises
 // rfc8785@0.1.4 against the same vectors. Three-way byte-match across
-// SDK + canonicalize@3.0.0 + rfc8785@0.1.4 is the actual conformance
+// SDK + canonicalize@4.0.0 + rfc8785@0.1.4 is the actual conformance
 // signal.
 
 import { describe, it } from 'node:test'
@@ -83,14 +92,14 @@ describe('cross-impl JCS byte-match: SDK canonicalizeJCS', () => {
   }
 })
 
-describe('cross-impl JCS byte-match: canonicalize@3.0.0 reference (erdtman)', () => {
+describe('cross-impl JCS byte-match: canonicalize@4.0.0 reference (erdtman)', () => {
   for (const v of manifest.vectors) {
     it(`${v.id} — reference canonical bytes match pin`, () => {
       const bytes = canonicalize(v.input)
       assert.equal(
         bytes,
         v.expected_canonical_bytes,
-        `${v.id}: canonicalize@3.0.0 output diverged from pinned bytes`,
+        `${v.id}: canonicalize@4.0.0 output diverged from pinned bytes`,
       )
     })
 
@@ -100,7 +109,7 @@ describe('cross-impl JCS byte-match: canonicalize@3.0.0 reference (erdtman)', ()
       assert.equal(
         hash,
         v.expected_sha256,
-        `${v.id}: canonicalize@3.0.0 SHA-256 diverged from pinned hash`,
+        `${v.id}: canonicalize@4.0.0 SHA-256 diverged from pinned hash`,
       )
     })
   }
@@ -114,7 +123,7 @@ describe('cross-impl JCS byte-match: SDK vs reference direct equality', () => {
       assert.equal(
         sdkBytes,
         refBytes,
-        `${v.id}: SDK canonicalizeJCS and canonicalize@3.0.0 disagree`,
+        `${v.id}: SDK canonicalizeJCS and canonicalize@4.0.0 disagree`,
       )
     })
   }


### PR DESCRIPTION
Follow-up to #109, which bumped `canonicalize` 3.0.0 to 4.0.0.

That package is the independent oracle the cross-implementation byte-match compares against, and five files named it by version. The harness header, the vector generator and the CI job now say 4.0.0, so the documentation describes the oracle that actually runs.

The header also records why the bump was safe, since a reader cannot re-derive it later:

- all 12 pinned vectors are byte-identical under 3.0.0 and 4.0.0, and both match the pinned canonical bytes
- an 18-case adversarial probe found exactly one behavioural difference: 3.0.0 emitted a lone UTF-16 surrogate silently as `\ud800`, 4.0.0 rejects it
- `canonicalizeJCS` already rejected lone surrogates with a `lone_surrogate` reason, so that divergence existed under 3.0.0 and was untested in both directions

The pin stays exact rather than a caret. An oracle that can move under you is not an oracle.

Two references are deliberately left at 3.0.0: `attribution-primitive` and `action-ref` state that a hash *was* independently reproduced by canonicalize@3.0.0, which is a record of what happened rather than a claim about what runs now.

Suite: 4,500 tests, 4,499 pass, 0 fail, 1 skipped. The cross-impl harness alone: 69 of 69.