### PR TITLE
fix(action-ref): strict duplicate-member parsing for serialized action_ref input

### DIFF
--- a/src/v2/action-reference/v2.ts
+++ b/src/v2/action-reference/v2.ts
@@ -3,6 +3,7 @@
 
 import { createHash } from 'node:crypto'
 import { canonicalizeJCS } from '../../core/canonical-jcs.js'
+import { parseStrictIJson } from '../receipt-core/jcs.js'
 import {
   assertExactKeys,
   assertHex,
@@ -83,4 +84,37 @@ export function validateActionReferenceInputV2(candidate: unknown): asserts cand
   }
   assertUtcMilliseconds(String(candidate.issued_at), 'issued_at')
   assertHex(String(candidate.nonce), 32, 'nonce')
+}
+
+/** Serialized-input entry path for an action reference document.
+ *
+ *  WHY THIS EXISTS, and why validation could never have covered it. Rejecting a
+ *  duplicate object member is a property of PARSING, not of validation. By the
+ *  time raw JSON has become a JavaScript object the second `agent_id` has already
+ *  overwritten the first and the evidence is gone, so no check added to
+ *  computeActionRefV2 or validateActionReferenceInputV2, both of which receive an
+ *  already-parsed value, can ever satisfy the duplicate-member requirement. The
+ *  only place the fact still exists is the byte stream.
+ *
+ *  So this entry point takes the raw document and parses it with the strict
+ *  parser that already lives in receipt-core, which rejects a duplicate member
+ *  name after JSON string decoding, meaning "a" and "\u0061" collide as the same
+ *  name. The result is then handed to the EXISTING validator unchanged: nothing
+ *  here weakens or bypasses validateActionReferenceInputV2, it runs in full.
+ */
+export function parseActionReferenceInputV2(raw: string): ActionReferenceInputV2 {
+  const parsed: unknown = parseStrictIJson(raw)
+  validateActionReferenceInputV2(parsed)
+  return parsed
+}
+
+/** Compute an action_ref straight from the serialized document.
+ *
+ *  The composed form of parseActionReferenceInputV2 and computeActionRefV2, for
+ *  callers holding wire bytes rather than a constructed input. Identical digest
+ *  to the parsed path for any document that parses, because it IS the parsed
+ *  path once the bytes have been read.
+ */
+export function computeActionRefV2FromJson(raw: string): string {
+  return computeActionRefV2(parseActionReferenceInputV2(raw))
 }

--- a/tests/action-reference-v2.test.ts
+++ b/tests/action-reference-v2.test.ts
@@ -5,8 +5,10 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   computeActionRefV2,
+  computeActionRefV2FromJson,
   computePayloadRefV1,
   createActionReferenceInputV2,
+  parseActionReferenceInputV2,
 } from '../src/v2/action-reference/v2.js'
 
 describe('action_ref v2', () => {
@@ -42,5 +44,86 @@ describe('action_ref v2', () => {
       scope_required: ['caf\u00e9:read', 'repo:write'],
     })
     assert.equal(computeActionRefV2(first), computeActionRefV2(second))
+  })
+})
+
+describe('action_ref v2 serialized input, strict duplicate-member parsing', () => {
+  // A well-formed document, written out as the bytes a peer would send.
+  const doc = {
+    profile: 'aps-action-ref-v2',
+    agent_id: 'did:example:agent',
+    action_type: 'mcp:tools/call',
+    target: 'https://mcp.example#tool=checkout',
+    payload_ref: computePayloadRefV1({ cart: ['sku-1'] }),
+    scope_required: ['commerce:write'],
+    issued_at: '2026-07-17T00:00:00.000Z',
+    nonce: '11'.repeat(16),
+  }
+  const clean = JSON.stringify(doc)
+  // JSON.stringify cannot emit a duplicate member, so the duplicate is spliced
+  // in textually. That is the point: the fact only exists in the byte stream.
+  const withDuplicate = clean.replace(
+    '"agent_id":"did:example:agent"',
+    '"agent_id":"did:example:agent","agent_id":"did:example:attacker"',
+  )
+  // Same member name reached through an escape alias rather than a literal
+  // repeat, so this is rejected only if names are compared AFTER decoding.
+  const withEscapedDuplicate = clean.replace(
+    '"agent_id":"did:example:agent"',
+    '"agent_id":"did:example:agent","\\u0061gent_id":"did:example:attacker"',
+  )
+
+  it('the duplicate is genuinely present in the raw bytes', () => {
+    // Guards the fixture itself: if the splice silently failed, the rejection
+    // tests below would pass for the wrong reason.
+    assert.notEqual(withDuplicate, clean)
+    assert.notEqual(withEscapedDuplicate, clean)
+    assert.equal(withDuplicate.match(/"agent_id":/g)?.length, 2)
+    // And a permissive parser really does lose it, which is why validation
+    // downstream of JSON.parse can never see this.
+    assert.equal((JSON.parse(withDuplicate) as { agent_id: string }).agent_id, 'did:example:attacker')
+  })
+
+  it('rejects a duplicated member name at parseActionReferenceInputV2', () => {
+    assert.throws(() => parseActionReferenceInputV2(withDuplicate), /duplicate object member/)
+  })
+
+  it('rejects a duplicated member name at computeActionRefV2FromJson', () => {
+    assert.throws(() => computeActionRefV2FromJson(withDuplicate), /duplicate object member/)
+  })
+
+  it('rejects an escape-aliased duplicate at both entry points', () => {
+    assert.throws(() => parseActionReferenceInputV2(withEscapedDuplicate), /duplicate object member/)
+    assert.throws(() => computeActionRefV2FromJson(withEscapedDuplicate), /duplicate object member/)
+  })
+
+  it('accepts the same document without the duplicate', () => {
+    const parsed = parseActionReferenceInputV2(clean)
+    assert.equal(parsed.agent_id, 'did:example:agent')
+    assert.match(computeActionRefV2FromJson(clean), /^[0-9a-f]{64}$/)
+  })
+
+  it('agrees digest-for-digest with the already-parsed path', () => {
+    // Proves the serialized path is the existing path plus parsing, not a
+    // second implementation that could drift.
+    assert.equal(computeActionRefV2FromJson(clean), computeActionRefV2(parseActionReferenceInputV2(clean)))
+    assert.equal(computeActionRefV2FromJson(clean), computeActionRefV2(createActionReferenceInputV2({
+      agent_id: doc.agent_id,
+      action_type: doc.action_type,
+      target: doc.target,
+      payload_ref: doc.payload_ref,
+      scope_required: doc.scope_required,
+      issued_at: doc.issued_at,
+      nonce: doc.nonce,
+    })))
+  })
+
+  it('does not weaken the existing validation it wraps', () => {
+    const wrongProfile = clean.replace('"aps-action-ref-v2"', '"aps-action-ref-v1"')
+    assert.throws(() => parseActionReferenceInputV2(wrongProfile), /action reference profile/)
+    const badNonce = clean.replace(doc.nonce, 'zz'.repeat(16))
+    assert.throws(() => parseActionReferenceInputV2(badNonce))
+    const extraKey = clean.replace('"profile":', '"unexpected":1,"profile":')
+    assert.throws(() => parseActionReferenceInputV2(extraKey))
   })
 })


### PR DESCRIPTION
Adds a serialized-input entry path for action_ref v2 that parses the wire document through the existing strict I-JSON parser, so duplicate members in raw input are rejected before structured parsing destroys the evidence.

What it adds, and nothing else:

- `parseActionReferenceInputV2(raw)`: parses via `parseStrictIJson`, then runs the existing `validateActionReferenceInputV2` unchanged.
- `computeActionRefV2FromJson(raw)`: composes that with the existing `computeActionRefV2`.

No existing validation is weakened or bypassed; the new path is the old path plus parsing. `src/index.ts` is untouched.

Tests: 4533/4532/0 baseline to 4540/4539/0 after, exit 0, `tsc --noEmit` clean. Seven new tests, including an escape-aliased duplicate that only a decode-then-compare parser catches, with a fixture guard asserting the duplicate is present in the raw bytes and lost by a permissive parser. Verified that the checks fire: substituting `JSON.parse` for the strict parser fails exactly the three duplicate-rejection cases and nothing else.
