### PR TITLE
release: 4.5.0, receipt-core and authority-delegation public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-passport-system",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, earned reputation, wallet binding, attribution, signed receipts.",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2032,3 +2032,54 @@ export type {
   HistoricalKeyResolutionRequest,
   HistoricalKeyResolutionResult,
 } from './v2/identity-binding/types.js'
+
+// ── Receipt core (v2): signed decision receipts ──
+// Verification establishes the integrity and semantics represented by a
+// receipt. It does not authorize dispatch, consume receipt_id, enforce
+// single-use, recheck revocation or time at dispatch, or reserve spend.
+// Those obligations belong to the enforcement boundary.
+// For serialized artifacts the safe public route is verifyReceiptV1Serialized,
+// which rejects duplicate members before structured parsing destroys the
+// evidence; the object-taking entrypoints cannot detect duplicates that
+// existed in serialized JSON.
+export {
+  RECEIPT_ID_TAG,
+  RECEIPT_SIG_TAG,
+  isExactUtcMilliseconds,
+  receiptIdPayloadV1,
+  computeReceiptIdV1,
+  receiptSignaturePayloadV1,
+  validateReceiptV1,
+  createReceiptV1,
+  verifyReceiptV1,
+  verifyReceiptV1Serialized,
+} from './v2/receipt-core/receipt.js'
+export type {
+  ReceiptV1,
+  ReceiptSignatureV1,
+  ReceiptSignerV1,
+} from './v2/receipt-core/types.js'
+export type { ReceiptVerificationV1 } from './v2/receipt-core/receipt.js'
+export { verifyReceiptWithDecisionV1 } from './v2/receipt-core/composite.js'
+export type {
+  DecisionEvidenceV1,
+  ReceiptWithDecisionVerificationV1,
+} from './v2/receipt-core/composite.js'
+
+// ── Authority delegation (v2): signed delegation records ──
+export {
+  AUTHORITY_DELEGATION_ID_DOMAIN,
+  AUTHORITY_DELEGATION_SIGNATURE_DOMAIN,
+  authorityDelegationIdInput,
+  computeAuthorityDelegationId,
+  authorityDelegationSignatureInput,
+  signAuthorityDelegation,
+  verifyAuthorityDelegationSignature,
+} from './v2/authority-delegation/canonical.js'
+export { parseAuthorityDelegationJson } from './v2/authority-delegation/parse.js'
+export type {
+  AuthorityDelegationV1,
+  AuthorityDelegationBodyV1,
+  AuthorityFailureCode,
+  RevocationResolution,
+} from './v2/authority-delegation/types.js'


### PR DESCRIPTION
Makes receipt-core and authority-delegation public API and bumps the version to 4.5.0. This is the follow-up promised in the 4.2.0 release notes, shipping after its preconditions landed: strict serialized-input parsing (#125, #127), composite receipt/decision verification with reference binding (#126), and the conformance corpus family testing both cross-document failure classes (suite #36).

The export block carries scope documentation inline: verification does not authorize dispatch, consume receipt_id, enforce single-use, recheck revocation or time at dispatch, or reserve spend; for serialized artifacts the safe public route is verifyReceiptV1Serialized. Full suite and type-check green with the exports in place.
