### PR TITLE
fix(authority-delegation): falsifiable export tests, drop compareAuthority from the root, probe the packed tarball at release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,30 @@ jobs:
           tarball=$(npm pack | tail -n1)
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
+      - name: Probe the packed tarball's public exports
+        # Installs the exact tarball into a scratch directory and imports it through
+        # the package's exports map, the way a consumer does. Guards the failure class
+        # where a symbol exists in dist but is unreachable from the package root
+        # (ERR_PACKAGE_PATH_NOT_EXPORTED), which no source-level test can see.
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: |
+          set -euo pipefail
+          probe=$(mktemp -d)
+          cp "./$TARBALL" "$probe/"
+          cd "$probe"
+          npm init -y >/dev/null
+          npm install --silent --ignore-scripts "./$TARBALL"
+          node --input-type=module -e "
+            const m = await import('agent-passport-system');
+            const c = await import('agent-passport-system/core');
+            for (const name of ['verifyAuthorityDelegationChain','verifyAuthorityDelegationSignature','parseAuthorityDelegationJson','verifyReceiptV1','computeReceiptIdV1']) {
+              if (typeof m[name] !== 'function') { console.error('root export missing: ' + name); process.exit(1); }
+            }
+            if (typeof c.verifyPassport !== 'function') { console.error('core export missing: verifyPassport'); process.exit(1); }
+            console.log('packed tarball exports probe: ok');
+          "
+
       - name: Publish to npm (Trusted Publishing, OIDC)
         # Publishes the tarball packed above, the same file the attestation
         # step signs, so the provenance subject and the shipped bytes are one

--- a/src/index.ts
+++ b/src/index.ts
@@ -2078,10 +2078,9 @@ export {
 } from './v2/authority-delegation/canonical.js'
 export { parseAuthorityDelegationJson } from './v2/authority-delegation/parse.js'
 // Full root-to-leaf chain validation (structural, cryptographic, temporal, revocation,
-// attenuation via compareAuthority). Verification only: a valid result is admissibility of
+// attenuation). Verification only: a valid result is admissibility of
 // the chain at `options.now`, never authorization to dispatch.
 export { verifyAuthorityDelegationChain } from './v2/authority-delegation/verify.js'
-export { compareAuthority } from './v2/authority-delegation/compare.js'
 export type {
   AuthorityDelegationV1,
   AuthorityDelegationBodyV1,

--- a/tests/authority-chain-public-export.test.ts
+++ b/tests/authority-chain-public-export.test.ts
@@ -2,13 +2,22 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import * as api from '../src/index.js'
 
-test('verifyAuthorityDelegationChain and compareAuthority are public exports', () => {
+test('verifyAuthorityDelegationChain is a public export', () => {
   assert.equal(typeof api.verifyAuthorityDelegationChain, 'function')
-  assert.equal(typeof api.compareAuthority, 'function')
 })
 
-test('verifyAuthorityDelegationChain rejects a non-canonical now before reading the chain', () => {
-  const r = api.verifyAuthorityDelegationChain([], { now: 'not-a-timestamp' } as any)
+test('verifyAuthorityDelegationChain rejects a non-canonical now with NONCANONICAL_VALUE', () => {
+  // A nonempty chain is required: the empty-chain guard runs first and would mask a
+  // deleted timestamp check. `now` is checked before any record is inspected, so [{}]
+  // reaches it.
+  const r = api.verifyAuthorityDelegationChain([{}], { now: 'not-a-timestamp' } as any)
   assert.equal(r.valid, false)
-  assert.equal(r.state === 'valid', false)
+  assert.equal(r.state, 'invalid')
+  assert.equal(r.failures[0]?.code, 'NONCANONICAL_VALUE')
+})
+
+test('verifyAuthorityDelegationChain rejects an empty chain with SCHEMA_INVALID, not NONCANONICAL_VALUE', () => {
+  const r = api.verifyAuthorityDelegationChain([], { now: 'not-a-timestamp' } as any)
+  assert.equal(r.state, 'invalid')
+  assert.equal(r.failures[0]?.code, 'SCHEMA_INVALID')
 })


### PR DESCRIPTION
Follow-up to #130 after hostile review.

- The non-canonical-clock test passed against an empty chain, which the empty-chain guard rejects first; deleting the timestamp check would not have failed it. Now a nonempty chain, asserting `NONCANONICAL_VALUE`, plus a test pinning the guard order.
- `compareAuthority` removed from the root export. The verifier was the ask; no external use case for the comparator exists; 4.6.0 is unreleased, so this is the cheapest moment.
- release.yml: after packing, install the exact tarball into a scratch directory and import it through the exports map, checking five root symbols and one `./core` symbol. Guards `ERR_PACKAGE_PATH_NOT_EXPORTED`, the failure class that started this. Rehearsed locally against a real pack: ok; actionlint clean.

4556 tests, 0 failures.