### PR TITLE
ci(release): read the npm pack result from a file, not the environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,9 +196,17 @@ jobs:
           PACKAGE_VERSION: ${{ needs.authorize.outputs.version }}
         run: |
           set -euo pipefail
-          pack_json=$(npm pack --ignore-scripts --json)
-          tarball=$(PACK_JSON="$pack_json" node --input-type=module -e "
-            const value = JSON.parse(process.env.PACK_JSON);
+          # The structured result lists every packed file (about 228 KB for
+          # this package), which exceeds Linux's 128 KiB single-argument limit
+          # when passed through the environment; the runner then fails with
+          # "Argument list too long" (E2BIG, exit 126). Write it to a file and
+          # read the file through the same-open-handle helper instead.
+          pack_json_path="$RUNNER_TEMP/npm-pack-result.json"
+          npm pack --ignore-scripts --json > "$pack_json_path"
+          tarball=$(PACK_JSON_PATH="$pack_json_path" node --input-type=module -e "
+            import { readOpenedRegularFile } from './.github/scripts/opened-regular-file.mjs';
+            const text = await readOpenedRegularFile(process.env.PACK_JSON_PATH, 'npm pack result is not a regular file', { encoding: 'utf8' });
+            const value = JSON.parse(text);
             if (!Array.isArray(value) || value.length !== 1 || typeof value[0]?.filename !== 'string') {
               throw new Error('npm pack did not return exactly one structured result');
             }


### PR DESCRIPTION
The structured `npm pack --json` result for this package is about 228 KB, which
exceeds Linux's 128 KiB single-argument limit when passed through an environment
variable. The v5.0.1 release run (33690069810) failed in the package job at that
handoff with "Argument list too long" (exit 126) after authorize, test and build
had passed; probe, attest, publish and release were skipped, so nothing was
published and no GitHub Release exists. Write the result to $RUNNER_TEMP and read
it through readOpenedRegularFile, the same-open-handle helper the release scripts
already use. Introduced in #133 (4156f91); the 5.0.0 workflow had no such step.
Verified locally with the fixed shape; actionlint clean.

