### PR TITLE
release: 5.0.2 metadata; record the v5.0.1 attempt as failed and unpublished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@
 
 - Failed release attempt, never published. The tag `v5.0.1` was pushed on
   2026-09-02 at `0bc21579` and the release workflow run `33690069810` passed
-  authorize, test and build, then failed in the package job before any
-  artifact left the runner: the structured `npm pack --json` result was
-  passed through an environment variable and exceeded Linux's single-argument
-  limit ("Argument list too long", exit 126). Probe, attest, publish and
-  release were skipped. No GitHub Release and no npm version `5.0.1` exist.
+  authorize, test and build, then failed in the package job while parsing the
+  structured `npm pack --json` result: it was passed through an environment
+  variable and exceeded Linux's single-argument limit ("Argument list too
+  long", exit 126). The failure occurred before the immutable package handoff,
+  probe, attestation, npm publication, or GitHub Release; those downstream
+  jobs were skipped. No GitHub Release and no npm version `5.0.1` exist.
   The tag stays where it is as the record of that attempt; the workflow fix is
   #139 and the recovery version is `5.0.2`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.0.1 (unreleased)
+## 5.0.2 (unreleased)
 
 ### Release process
 
@@ -11,6 +11,17 @@
   same security remediation as `5.0.0`, whose registry entry cannot be amended
   with missing npm provenance.
 
+## 5.0.1 (not published)
+
+- Failed release attempt, never published. The tag `v5.0.1` was pushed on
+  2026-09-02 at `0bc21579` and the release workflow run `33690069810` passed
+  authorize, test and build, then failed in the package job before any
+  artifact left the runner: the structured `npm pack --json` result was
+  passed through an environment variable and exceeded Linux's single-argument
+  limit ("Argument list too long", exit 126). Probe, attest, publish and
+  release were skipped. No GitHub Release and no npm version `5.0.1` exist.
+  The tag stays where it is as the record of that attempt; the workflow fix is
+  #139 and the recovery version is `5.0.2`.
 
 ## 5.0.0 (2026-08-29)
 
@@ -140,7 +151,7 @@ Per AGENTS.md this bump is PROPOSED, not decided. A human owns the version.
   is graded malformed and denied with a reason, and no reader tests `.length`
   on a caller-supplied value again. This sentence originally said "neither
   guard", enumerating the two guards it was written for; there was a third
-  READER, `verifySocialContract`, and it was missed. See the 5.0.1 entry. A bare key string is refused
+  READER, `verifySocialContract`, and it was missed. See the entry above in this release. A bare key string is refused
   too, since it has a numeric length and the membership test downstream was
   substring matching. Pre-existing, and older than the gate consolidation;
   what the consolidation changed is that the repair is one function rather

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -161,7 +161,7 @@ Porting notes:
   value before handing it over. In 5.0.0 this held at `verifyPassport`,
   `checkPassportTrustPosture`, the five adapter gates and the relying-party
   middleware, but NOT at `verifySocialContract`, which was a third reader of
-  the option and was missed; 5.0.1 closes it. If you read
+  the option and was missed; the 5.0.0 release closes it. If you read
   `TrustVerification.overall` — deprecated, and the field this affected — a
   malformed anchor list used to leave it `true`.
 - **The same posture is now required at the five adapter gates.** If you call

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,8 +76,11 @@ was published on 2026-09-01 with the registry shasum
 without npm provenance. It contains the security remediation released as
 `5.0.0`; the exception concerns release provenance, not the fixed code. A
 GitHub repository artifact attestation over matching tarball bytes is separate
-evidence and cannot add npm provenance to an already published npm version. If
-published through the corrected Trusted Publishing workflow, `5.0.1` is
+evidence and cannot add npm provenance to an already published npm version. A
+first attempt at that patch release, tagged `v5.0.1` on 2026-09-02, failed in
+the release workflow before npm publication or GitHub Release creation (a
+release-workflow transport defect, fixed in #139); no `5.0.1` version exists on
+npm. If published through the corrected Trusted Publishing workflow, `5.0.2` is
 intended to be the first post-remediation patch release that restores the
 normal npm provenance property. Version-specific registry metadata is
 available from:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-passport-system",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-passport-system",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "libsodium-wrappers": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-passport-system",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, earned reputation, wallet binding, attribution, signed receipts.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Release metadata only, no SDK source change. package.json and the two lockfile
version fields move to 5.0.2. CHANGELOG gains a 5.0.2 (unreleased) entry with the
same scope the 5.0.1 entry described, and a 5.0.1 (not published) entry recording
the failed attempt: tag v5.0.1 at 0bc21579, run 33690069810, authorize/test/build
passed, the package job failed while parsing the structured `npm pack --json`
result ("Argument list too long", exit 126, fixed in #139), before the immutable
package handoff, probe, attestation, npm publication, or GitHub Release; those
downstream jobs were skipped. No GitHub Release and no npm 5.0.1. SECURITY.md's provenance paragraph now names 5.0.2 as
the intended first provenance-bearing post-remediation patch and states the
v5.0.1 outcome in one sentence. Two stale forward references that pointed at
5.0.1 as the version closing the verifySocialContract gap now point at 5.0.0,
where that fix shipped (CHANGELOG line 143, MIGRATION.md line 164). The tag
v5.0.1 is not touched.

