### PR TITLE
ci(release): bind every GitHub CLI call to the triggering repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,14 @@ concurrency:
 permissions:
   contents: read
 
+# Every gh release call in the probe, release and publish jobs runs from a
+# working directory that is not a git checkout (public-release, release-bundle,
+# immutable-release), so gh cannot infer the repository from git and fails with
+# "not a git repository"; the v5.0.2 release run failed at release creation on
+# exactly that. Name the repository once for the whole workflow.
+env:
+  GH_REPO: ${{ github.repository }}
+
 jobs:
   authorize:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a workflow-level env `GH_REPO: ${{ github.repository }}` so every gh
operation in release.yml targets the repository that triggered the run,
independent of working directory or checkout layout. The v5.0.2 release run
(33692642859) passed authorize, test, build, package, probe and attest; in the
release job the remote-tag recheck and the absent-release classification
succeeded, then `gh release create` failed with "fatal: not a git repository"
because the sources are checked out under release-source/ while the command
runs at the workspace root, so gh tried to discover the repository from .git.
Publish was skipped; no GitHub Release and no npm 5.0.2 exist. Ten gh release
calls across probe, release and publish rely on the same implicit discovery;
binding the repository once removes the class rather than enumerating the
calls. Existing explicit --repo arguments on the attestation commands are
unchanged. No permission is added; GH_TOKEN still determines authorization.
Validated with actionlint and by exercising gh release reads from a directory
with no .git while GH_REPO is set.

