### PR TITLE
release: 5.0.3 metadata; record the v5.0.2 attempt as failed and unpublished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.0.2 (unreleased)
+## 5.0.3 (unreleased)
 
 ### Release process
 
@@ -10,6 +10,18 @@
   create registry provenance for the new immutable version. It carries the
   same security remediation as `5.0.0`, whose registry entry cannot be amended
   with missing npm provenance.
+
+## 5.0.2 (not published)
+
+- Failed release attempt, never published. The tag `v5.0.2` was pushed on
+  2026-09-02 at `37db6b47` and the release workflow run `33692642859` passed
+  authorize, test, build, package, probe and attest, then failed in the
+  release job at `gh release create`: the command ran at the workspace root
+  while the sources were checked out under `release-source/`, so `gh`
+  attempted repository inference outside a git checkout and failed. Publish
+  was skipped. No GitHub Release and no npm version `5.0.2` exist. The tag
+  stays where it is as the record of that attempt; the workflow fix is #141
+  and the recovery version is `5.0.3`.
 
 ## 5.0.1 (not published)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,7 +80,10 @@ evidence and cannot add npm provenance to an already published npm version. A
 first attempt at that patch release, tagged `v5.0.1` on 2026-09-02, failed in
 the release workflow before npm publication or GitHub Release creation (a
 release-workflow transport defect, fixed in #139); no `5.0.1` version exists on
-npm. If published through the corrected Trusted Publishing workflow, `5.0.2` is
+npm. A second attempt, tagged `v5.0.2` on 2026-09-02, passed packaging and
+attestation and failed at GitHub Release creation (a release-workflow
+repository-binding defect, fixed in #141); no `5.0.2` version exists on npm. If
+published through the corrected Trusted Publishing workflow, `5.0.3` is
 intended to be the first post-remediation patch release that restores the
 normal npm provenance property. Version-specific registry metadata is
 available from:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-passport-system",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-passport-system",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "libsodium-wrappers": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-passport-system",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, earned reputation, wallet binding, attribution, signed receipts.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Release metadata only, no SDK source change. package.json and the two lockfile
version fields move to 5.0.3. CHANGELOG gains a 5.0.3 (unreleased) entry with the
same scope the 5.0.2 entry described, and a 5.0.2 (not published) entry recording
the failed attempt: tag v5.0.2 at 37db6b47, run 33692642859, authorize, test,
build, package, probe and attest passed, release failed at `gh release create`
because repository inference was attempted outside a git checkout (fixed in
#141), publish skipped, no GitHub Release and no npm 5.0.2. SECURITY.md's
provenance paragraph now names 5.0.3 as the intended first provenance-bearing
post-remediation patch and states the v5.0.2 outcome in one sentence. The tags
v5.0.1 and v5.0.2 are not touched.

