### PR TITLE
docs(oracle-safety-check): delegation time window -> delegation expiry

### DIFF
--- a/fixtures/oracle-safety-check/README.md
+++ b/fixtures/oracle-safety-check/README.md
@@ -92,7 +92,7 @@ in the conformance suite):
    `roles.evm_attester.address`;
 5. derive the composite-gate reason set from the observable signals (verdict,
    policy deny, evidence digest, inner verification, revocation, delegation
-   time window) and assert it **exactly equals** `expectReasons`;
+   expiry) and assert it **exactly equals** `expectReasons`;
 6. assert `allowed ⇔ (derived reasons empty)`.
    Flipping `oracle_input.verdict`, emptying `revocation`, replacing
    `expectReasons`, or flipping `expected` on any vector FAILS the run.


### PR DESCRIPTION
Line 95 of fixtures/oracle-safety-check/README.md still lists the delegation check reason as delegation time window. The verifier checks delegation expiry via not_after only; not_before is not enforced, and line 19 of the same file already uses leaf expiry (not_after). This aligns the wording with the implemented semantics.

Pointed out in cross-stack review (three rounds, non-blocking). Wording only: one file, +1/-1. No code, no vector bytes, no behavior change.