### PR TITLE
6.0.1: documentation-only patch so the package page lists every SDK registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.1 (2026-09-04)
+
+Documentation only. The README published with 6.0.0 listed three registries; the package page now lists npm, PyPI, crates.io, Go and the MCP server, and the skills advertise the MCP version npm publishes. No code change.
+
 ## 6.0.0 (2026-09-04)
 
 Security release. The full cross-SDK account, including the affected version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-passport-system",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-passport-system",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "libsodium-wrappers": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-passport-system",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Enforcement and accountability layer for AI agents. Bring your own identity (did:key, did:web, SPIFFE, OAuth, did:aps). Gateway enforcement, monotonic narrowing, cascade revocation, earned reputation, wallet binding, attribution, signed receipts.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Version 6.0.1 with a changelog entry. No code change: the README published with 6.0.0 listed three registries; the package page now lists all five SDK surfaces and the skills advertise the MCP version npm publishes.